### PR TITLE
Refactor Withdraw Endpoint

### DIFF
--- a/app/views/api_docs/reference/v1.0/_reference.md
+++ b/app/views/api_docs/reference/v1.0/_reference.md
@@ -1220,21 +1220,65 @@ Withdraw a trainee.
 
 #### Request
 
-`POST /api/v1.0/trainees/{trainee_id}/withdraw?reasons[]={reasons}&withdraw_date={withdraw_date}&withdraw_reasons_details={withdraw_reasons_details}&withdraw_reasons_dfe_details={withdraw_reasons_dfe_details}`
-
-There is no request body for this endpoint.
-
-Note that multiple values for the reasons parameter can be provided by repeating the parameter in the query string, e.g. `reasons[]=personal_reasons&reasons[]=got_a_job`
+`POST /api/v1.0/trainees/{trainee_id}/withdraw`
 
 #### Parameters
 
 | **Parameter** | **In**  | **Type** | **Required** | **Description** |
 | ------------- | ------- | -------- | ------------ | --------------- |
 | **trainee_id** | path | string | true | The unique ID of the trainee |
-| **reasons** | query | array of strings | true | The reason(s) for the withdrawal |
-| **withdraw_date** | query | string | true | The date and time of the withdrawal in ISO 8601 format |
-| **withdraw_reasons_details** | query | string | false | Details about why the trainee withdrew |
-| **withdraw_reasons_dfe_details** | query | string | false | What the Department of Education could have done to prevent the trainee withdrawing |
+
+#### Request body
+
+Recommendation details
+
+<div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>reasons</code></dt>
+    <dd class="govuk-summary-list__value">
+        <p class="govuk-body">
+          array of strings, required
+        </p>
+        <p class="govuk-body">
+          The reason(s) for the withdrawal
+        </p>
+    </dd>
+</div>
+
+<div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>withdraw_date</code></dt>
+    <dd class="govuk-summary-list__value">
+        <p class="govuk-body">
+          string, required
+        </p>
+        <p class="govuk-body">
+          The date and time of the withdrawal in ISO 8601 format
+        </p>
+    </dd>
+</div>
+
+<div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>withdraw_reasons_details</code></dt>
+    <dd class="govuk-summary-list__value">
+        <p class="govuk-body">
+          string, optional
+        </p>
+        <p class="govuk-body">
+          Details about why the trainee withdrew
+        </p>
+    </dd>
+</div>
+
+<div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>withdraw_reasons_dfe_details</code></dt>
+    <dd class="govuk-summary-list__value">
+        <p class="govuk-body">
+          string, optional
+        </p>
+        <p class="govuk-body">
+          What the Department of Education could have done to prevent the trainee withdrawing
+        </p>
+    </dd>
+</div>
 
 #### Possible responses
 

--- a/public/openapi/v1.0.yaml
+++ b/public/openapi/v1.0.yaml
@@ -67,7 +67,7 @@ paths:
         required: false
         schema:
           nullable: true
-        example: 'false'
+        example: 'true'
       - name: page
         in: query
         required: false
@@ -85,7 +85,7 @@ paths:
         required: false
         schema:
           type: string
-        example: '2024-03-15T13:15:37.880Z'
+        example: 2023-13-01
       - name: sort_order
         in: query
         required: false
@@ -100,7 +100,7 @@ paths:
         example: invalid_state
       responses:
         '200':
-          description: returns all the trainees
+          description: sorts the results in descending order by default
           content:
             application/json:
               schema:
@@ -448,393 +448,13 @@ paths:
                 - meta
               example:
                 data:
-                - first_names: Socorro
-                  last_name: Pouros
-                  date_of_birth: '1964-10-03'
-                  created_at: '2024-07-05T14:01:20.292Z'
-                  updated_at: '2024-07-05T14:01:20.297Z'
-                  email: Socorro.Pouros@example.com
-                  middle_names: Heidenreich
-                  training_route:
-                  sex: '11'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-12'
-                  outcome_date:
-                  itt_end_date: '2025-07-11'
-                  trn:
-                  submitted_for_trn_at: '2024-07-05T14:01:20.287Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-08-14'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 18
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative: '036'
-                  study_mode:
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id:
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-822
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-12'
-                  course_age_range:
-                  expected_end_date: '2025-07-11'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code:
-                  bursary_level:
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree: '088'
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:20.293Z'
-                    updated_at: '2024-07-05T14:01:20.293Z'
-                    subject: '100090'
-                    institution: '0046'
-                    graduation_year: 2005
-                    grade: '01'
-                    country:
-                    other_grade:
-                    institution_uuid: 4871f34a-2887-e711-80d8-005056ac45bb
-                    uk_degree_uuid: 256a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 7b7f70f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: qiJ4AkjzvF2REp8ArBoPZDMk
-                  state: submitted_for_trn
-                  trainee_id: 4SYQLH9A2zTPkAqsD6KnUve6
-                  application_id:
-                - first_names: Maurita
-                  last_name: Okuneva
-                  date_of_birth: '1986-08-18'
-                  created_at: '2024-07-05T14:01:20.262Z'
-                  updated_at: '2024-07-05T14:01:20.268Z'
-                  email: Maurita.Okuneva@example.com
-                  middle_names: Langosh
-                  training_route:
-                  sex: '96'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-19'
-                  outcome_date:
-                  itt_end_date: '2025-07-20'
-                  trn:
-                  submitted_for_trn_at: '2024-07-05T14:01:20.257Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-08-21'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 18
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative: '036'
-                  study_mode:
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id:
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-820
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-19'
-                  course_age_range:
-                  expected_end_date: '2025-07-20'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code:
-                  bursary_level:
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree: '307'
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:20.264Z'
-                    updated_at: '2024-07-05T14:01:20.264Z'
-                    subject: '100518'
-                    institution: '0276'
-                    graduation_year: 2003
-                    grade: '14'
-                    country:
-                    other_grade:
-                    institution_uuid: 813e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: 03d6b7af-499c-49e3-96cc-e63f9beda6e5
-                    subject_uuid: 1b8270f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                    degree_id: 7VwUCZsJZX3zn8KLvBX5owV6
-                  state: submitted_for_trn
-                  trainee_id: B7ZnSpsmB8M7jBNqssQsRvo1
-                  application_id:
-                - first_names: Jeffry
-                  last_name: Buckridge
-                  date_of_birth: '1959-08-01'
-                  created_at: '2024-07-05T14:01:20.221Z'
-                  updated_at: '2024-07-05T14:01:20.232Z'
-                  email: Jeffry.Buckridge@example.com
-                  middle_names: Kunde
-                  training_route:
-                  sex: '12'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-01'
-                  outcome_date:
-                  itt_end_date: '2024-07-09'
-                  trn: '6504567'
-                  submitted_for_trn_at: '2024-07-05T14:01:20.225Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-08-03'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 16
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative:
-                  study_mode: '01'
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id: '6504925000263'
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-817
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-01'
-                  course_age_range: '13912'
-                  expected_end_date: '2024-07-09'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code: '2'
-                  bursary_level: C
-                  previous_last_name: Beatty
-                  itt_aim: '202'
-                  course_study_mode: '01'
-                  course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: C
-                  ni_number: QQ 12 34 56 C
-                  additional_training_initiative: '026'
-                  itt_qualification_aim: '031'
-                  hesa_disabilities: {}
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree: '097'
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:20.233Z'
-                    updated_at: '2024-07-05T14:01:20.233Z'
-                    subject: '101166'
-                    institution: '0232'
-                    graduation_year: 1994
-                    grade: '12'
-                    country:
-                    other_grade:
-                    institution_uuid: 0e3e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: 376a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: b78570f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                    degree_id: eySojJnzKp26LRgnuYF74moM
-                  state: trn_received
-                  trainee_id: M69Ea14SQzRDYxpuPLQjvd9d
-                  application_id:
-                - first_names: Rene
-                  last_name: Stoltenberg
-                  date_of_birth: '1984-12-17'
-                  created_at: '2024-07-05T14:01:20.168Z'
-                  updated_at: '2024-07-05T14:01:20.179Z'
-                  email: Rene.Stoltenberg@example.com
-                  middle_names: Bartell
-                  training_route:
-                  sex: '11'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-25'
-                  outcome_date:
-                  itt_end_date: '2025-07-01'
-                  trn: '1505498'
-                  submitted_for_trn_at: '2024-07-05T14:01:20.172Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-09-06'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 16
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative:
-                  study_mode: '01'
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id: '8042087712775'
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-814
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-25'
-                  course_age_range: '13912'
-                  expected_end_date: '2025-07-01'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code: '7'
-                  bursary_level: C
-                  previous_last_name: Armstrong
-                  itt_aim: '201'
-                  course_study_mode: '01'
-                  course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: C
-                  ni_number: QQ 12 34 56 C
-                  additional_training_initiative: '026'
-                  itt_qualification_aim: '031'
-                  hesa_disabilities: {}
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree: '302'
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:20.180Z'
-                    updated_at: '2024-07-05T14:01:20.180Z'
-                    subject: '100190'
-                    institution: '0160'
-                    graduation_year: 2000
-                    grade:
-                    country:
-                    other_grade:
-                    institution_uuid: 4f5b7f3b-7042-e811-80ff-3863bb3640b8
-                    uk_degree_uuid: 5f6a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 138070f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: 1jVwMAtvtzVnrgxeza5XTAHh
-                  state: trn_received
-                  trainee_id: Dcyp7Axw1ZwTjvPnjKUtpoQo
-                  application_id:
-                - first_names: Deanna
-                  last_name: Will
-                  date_of_birth: '1997-04-28'
-                  created_at: '2024-07-05T14:01:20.114Z'
-                  updated_at: '2024-07-05T14:01:20.125Z'
-                  email: Deanna.Will@example.com
-                  middle_names: Fay
+                - first_names: Vannessa
+                  last_name: Pagac
+                  date_of_birth: '1998-03-05'
+                  created_at: '2024-07-08T10:39:42.621Z'
+                  updated_at: '2024-07-08T10:39:42.634Z'
+                  email: Vannessa.Pagac@example.com
+                  middle_names: Morar
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -843,11 +463,211 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2023-08-21'
+                  itt_start_date: '2023-08-09'
                   outcome_date:
-                  itt_end_date: '2025-07-01'
-                  trn: '6437999'
-                  submitted_for_trn_at: '2024-07-05T14:01:20.118Z'
+                  itt_end_date: '2024-07-25'
+                  trn: '4779840'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.626Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-09'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative:
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '5189506301425'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-1004
+                  lead_partner_id:
+                  ukprn: '11251893'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-09'
+                  course_age_range: '13915'
+                  expected_end_date: '2024-07-25'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: D
+                  previous_last_name: Weber
+                  itt_aim: '201'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: D
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '004'
+                  hesa_disabilities: {}
+                  nationality: MX
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '012'
+                    non_uk_degree:
+                    created_at: '2024-07-08T10:39:42.636Z'
+                    updated_at: '2024-07-08T10:39:42.636Z'
+                    subject: '100194'
+                    institution: '0165'
+                    graduation_year: 2005
+                    grade:
+                    country:
+                    other_grade:
+                    institution_uuid: 1b5b7f3b-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: d5695652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 198070f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
+                    degree_id: eBLCie97VLLxRFsiD5MdC7r5
+                  state: trn_received
+                  trainee_id: jAG6ixXs7tuz3eHaKuapd6Xd
+                  application_id:
+                - first_names: Willian
+                  last_name: Reichert
+                  date_of_birth: '1993-02-18'
+                  created_at: '2024-07-08T10:39:42.558Z'
+                  updated_at: '2024-07-08T10:39:42.569Z'
+                  email: Willian.Reichert@example.com
+                  middle_names: Hammes
+                  training_route:
+                  sex: '10'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-22'
+                  outcome_date:
+                  itt_end_date: '2024-07-17'
+                  trn: '9579820'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.562Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-27'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '036'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '9837715232211'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-1001
+                  lead_partner_id:
+                  ukprn: '11251893'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-22'
+                  course_age_range: '13913'
+                  expected_end_date: '2024-07-17'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: D
+                  previous_last_name: Armstrong
+                  itt_aim: '201'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: D
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '004'
+                  hesa_disabilities: {}
+                  nationality: MX
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '003'
+                    non_uk_degree:
+                    created_at: '2024-07-08T10:39:42.570Z'
+                    updated_at: '2024-07-08T10:39:42.570Z'
+                    subject: '101494'
+                    institution: '0252'
+                    graduation_year: 1989
+                    grade: '12'
+                    country:
+                    other_grade:
+                    institution_uuid: 3a3e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 7ba49954-7595-437c-8df0-6a777c97307b
+                    subject_uuid: 938770f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
+                    degree_id: Nd7JfF6uHSvPu3M28e4z6bmK
+                  state: trn_received
+                  trainee_id: oMUsscPSk3Cqs2BzFv5w8GZW
+                  application_id:
+                - first_names: Ethan
+                  last_name: Raynor
+                  date_of_birth: '1985-06-18'
+                  created_at: '2024-07-08T10:39:42.502Z'
+                  updated_at: '2024-07-08T10:39:42.514Z'
+                  email: Ethan.Raynor@example.com
+                  middle_names: Hand
+                  training_route:
+                  sex: '96'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-11'
+                  outcome_date:
+                  itt_end_date: '2025-07-06'
+                  trn: '1211327'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.507Z'
                   withdraw_date:
                   withdraw_reasons_details:
                   defer_date:
@@ -871,7 +691,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '5571954658327'
+                  hesa_id: '4328093673793'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -881,460 +701,60 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-811
+                  provider_trainee_id: 23/24-998
                   lead_partner_id:
-                  ukprn: '71285009'
+                  ukprn: '11251893'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2023-08-21'
-                  course_age_range: '13919'
-                  expected_end_date: '2025-07-01'
+                  course_itt_start_date: '2023-08-11'
+                  course_age_range: '13912'
+                  expected_end_date: '2025-07-06'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
                   fund_code: '2'
-                  bursary_level: '6'
-                  previous_last_name: Shanahan
+                  bursary_level: D
+                  previous_last_name: Wehner
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: '6'
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: D
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
-                  itt_qualification_aim: '008'
+                  itt_qualification_aim: '001'
                   hesa_disabilities: {}
-                  nationality: CK
+                  nationality: MX
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '096'
+                  - uk_degree: '082'
                     non_uk_degree:
-                    created_at: '2024-07-05T14:01:20.126Z'
-                    updated_at: '2024-07-05T14:01:20.126Z'
-                    subject: '100059'
-                    institution: '0237'
-                    graduation_year: 1992
-                    grade: '01'
-                    country:
-                    other_grade:
-                    institution_uuid: 693e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: 356a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 4d7f70f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: Yzx8gPFoxjE2wXfJf3V2N95b
-                  state: trn_received
-                  trainee_id: WeF9VUeSWpRzhyxKUr4wpAXa
-                  application_id:
-                - first_names: Minh
-                  last_name: Prohaska
-                  date_of_birth: '1978-10-04'
-                  created_at: '2024-07-05T14:01:20.059Z'
-                  updated_at: '2024-07-05T14:01:20.070Z'
-                  email: Minh.Prohaska@example.com
-                  middle_names: Rutherford
-                  training_route:
-                  sex: '11'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-22'
-                  outcome_date:
-                  itt_end_date: '2024-07-17'
-                  trn: '1023438'
-                  submitted_for_trn_at: '2024-07-05T14:01:20.063Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-08-28'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 18
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative: '025'
-                  study_mode: '01'
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id: '9885648558845'
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-808
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-22'
-                  course_age_range: '13919'
-                  expected_end_date: '2024-07-17'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code: '2'
-                  bursary_level: '8'
-                  previous_last_name: Beer
-                  itt_aim: '202'
-                  course_study_mode: '01'
-                  course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: '8'
-                  ni_number: QQ 12 34 56 C
-                  additional_training_initiative: '026'
-                  itt_qualification_aim: '020'
-                  hesa_disabilities: {}
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree: '080'
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:20.071Z'
-                    updated_at: '2024-07-05T14:01:20.071Z'
-                    subject: '101086'
-                    institution: '1078'
+                    created_at: '2024-07-08T10:39:42.515Z'
+                    updated_at: '2024-07-08T10:39:42.515Z'
+                    subject: '100856'
+                    institution: '0332'
                     graduation_year: 2007
-                    grade:
+                    grade: '12'
                     country:
                     other_grade:
-                    institution_uuid: 20e5a08c-ee97-e711-80d8-005056ac45bb
-                    uk_degree_uuid: 156a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 438570f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: ive1CVahKrRtNn4onDNsmZr6
+                    institution_uuid: 1a3e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 196a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: '018470f0-5dce-e911-a985-000d3ab79618'
+                    grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
+                    degree_id: LFkkM6vFNV71yuz4YkfLQfpq
                   state: trn_received
-                  trainee_id: Rqzrt7NQ3yd5vPqny3pTY9Un
+                  trainee_id: cD14vzCGtfJJdLSNEbdhpwDH
                   application_id:
-                - first_names: Bessie
-                  last_name: Koss
-                  date_of_birth: '1969-03-21'
-                  created_at: '2024-07-05T14:01:19.995Z'
-                  updated_at: '2024-07-05T14:01:20.006Z'
-                  email: Bessie.Koss@example.com
-                  middle_names: Bosco
-                  training_route:
-                  sex: '99'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-06'
-                  outcome_date:
-                  itt_end_date: '2024-07-08'
-                  trn: '9673388'
-                  submitted_for_trn_at: '2024-07-05T14:01:19.998Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-08-06'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 16
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative:
-                  study_mode: '01'
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id: '7510394639476'
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-805
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-06'
-                  course_age_range: '13916'
-                  expected_end_date: '2024-07-08'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code: '7'
-                  bursary_level: B
-                  previous_last_name: Wisozk
-                  itt_aim: '202'
-                  course_study_mode: '01'
-                  course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: B
-                  ni_number: QQ 12 34 56 C
-                  additional_training_initiative: '026'
-                  itt_qualification_aim: '020'
-                  hesa_disabilities: {}
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree:
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:20.007Z'
-                    updated_at: '2024-07-05T14:01:20.007Z'
-                    subject: '101499'
-                    institution: '0041'
-                    graduation_year: 2009
-                    grade: '03'
-                    country:
-                    other_grade:
-                    institution_uuid: 054b9247-7042-e811-80ff-3863bb3640b8
-                    uk_degree_uuid: '0584565a-1c98-4c1d-ae64-c241542c0879'
-                    subject_uuid: 9d8770f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
-                    degree_id: FMuz8Rk8yNzsMcvjq4Ua3SkS
-                  state: trn_received
-                  trainee_id: UN2CPPzc9YGP8DN7mp5YA3st
-                  application_id:
-                - first_names: Jewell
-                  last_name: Kling
-                  date_of_birth: '1970-01-01'
-                  created_at: '2024-07-05T14:01:19.936Z'
-                  updated_at: '2024-07-05T14:01:19.948Z'
-                  email: Jewell.Kling@example.com
-                  middle_names: O'Hara
-                  training_route:
-                  sex: '99'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-07'
-                  outcome_date:
-                  itt_end_date: '2024-07-01'
-                  trn: '4794364'
-                  submitted_for_trn_at: '2024-07-05T14:01:19.940Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-08-08'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 18
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative:
-                  study_mode: '01'
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id: '9948317790562'
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-802
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-07'
-                  course_age_range: '13911'
-                  expected_end_date: '2024-07-01'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code: '2'
-                  bursary_level: '4'
-                  previous_last_name: Aufderhar
-                  itt_aim: '202'
-                  course_study_mode: '01'
-                  course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: '4'
-                  ni_number: QQ 12 34 56 C
-                  additional_training_initiative: '026'
-                  itt_qualification_aim: '007'
-                  hesa_disabilities: {}
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree: '054'
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:19.949Z'
-                    updated_at: '2024-07-05T14:01:19.949Z'
-                    subject: '100526'
-                    institution: '0018'
-                    graduation_year: 1983
-                    grade: '01'
-                    country:
-                    other_grade:
-                    institution_uuid: 1b369414-75d9-e911-a863-000d3ab0da57
-                    uk_degree_uuid: e1695652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 258270f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: YVEwjyxqCj4kbwQZT83FbikY
-                  state: trn_received
-                  trainee_id: ibNBVvEeWRrgQo4W9k8yEX5a
-                  application_id:
-                - first_names: Dalton
-                  last_name: Schaden
-                  date_of_birth: '1986-01-12'
-                  created_at: '2024-07-05T14:01:19.876Z'
-                  updated_at: '2024-07-05T14:01:19.887Z'
-                  email: Dalton.Schaden@example.com
-                  middle_names: Streich
-                  training_route:
-                  sex: '11'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-13'
-                  outcome_date:
-                  itt_end_date: '2025-07-12'
-                  trn: '7960771'
-                  submitted_for_trn_at: '2024-07-05T14:01:19.880Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-08-27'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 18
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative:
-                  study_mode: '01'
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id: '3313884277621'
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-799
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-13'
-                  course_age_range: '13915'
-                  expected_end_date: '2025-07-12'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code: '7'
-                  bursary_level: E
-                  previous_last_name: Erdman
-                  itt_aim: '201'
-                  course_study_mode: '01'
-                  course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: E
-                  ni_number: QQ 12 34 56 C
-                  additional_training_initiative: '026'
-                  itt_qualification_aim: '032'
-                  hesa_disabilities: {}
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree: '058'
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:19.888Z'
-                    updated_at: '2024-07-05T14:01:19.888Z'
-                    subject: '101215'
-                    institution: '0201'
-                    graduation_year: 2003
-                    grade: '01'
-                    country:
-                    other_grade:
-                    institution_uuid: 18f35f0b-7042-e811-80ff-3863bb3640b8
-                    uk_degree_uuid: e9695652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: ff8570f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: W1XaShpkxgxZXM2UDRwG8T7y
-                  state: trn_received
-                  trainee_id: 1bv4hCywV3BFG98kUPtL9mou
-                  application_id:
-                - first_names: Chantal
+                - first_names: Alonzo
                   last_name: Hayes
-                  date_of_birth: '2000-02-01'
-                  created_at: '2024-07-05T14:01:19.819Z'
-                  updated_at: '2024-07-05T14:01:19.831Z'
-                  email: Chantal.Hayes@example.com
-                  middle_names: Powlowski
+                  date_of_birth: '1984-05-16'
+                  created_at: '2024-07-08T10:39:42.442Z'
+                  updated_at: '2024-07-08T10:39:42.455Z'
+                  email: Alonzo.Hayes@example.com
+                  middle_names: Mayer
                   training_route:
                   sex: '12'
                   diversity_disclosure: diversity_not_disclosed
@@ -1343,119 +763,19 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2023-08-15'
+                  itt_start_date: '2023-08-24'
                   outcome_date:
-                  itt_end_date: '2025-07-01'
-                  trn: '8299836'
-                  submitted_for_trn_at: '2024-07-05T14:01:19.824Z'
+                  itt_end_date: '2024-07-14'
+                  trn: '6039097'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.447Z'
                   withdraw_date:
                   withdraw_reasons_details:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2023-08-18'
+                  trainee_start_date: '2023-09-08'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
-                  course_subject_two:
-                  course_subject_three:
-                  awarded_at:
-                  training_initiative: '025'
-                  study_mode: '01'
-                  ebacc: false
-                  region:
-                  course_education_phase: secondary
-                  course_uuid:
-                  lead_school_not_applicable: false
-                  employing_school_not_applicable: false
-                  submission_ready: true
-                  commencement_status:
-                  discarded_at:
-                  created_from_dttp: false
-                  hesa_id: '4129803593133'
-                  additional_dttp_data:
-                  created_from_hesa: false
-                  hesa_updated_at:
-                  record_source: manual
-                  iqts_country:
-                  hesa_editable: false
-                  withdraw_reasons_dfe_details:
-                  slug_sent_to_dqt_at:
-                  placement_detail:
-                  provider_trainee_id: 23/24-796
-                  lead_partner_id:
-                  ukprn: '71285009'
-                  ethnicity:
-                  course_qualification: QTS
-                  course_title:
-                  course_level: postgrad
-                  course_itt_start_date: '2023-08-15'
-                  course_age_range: '13912'
-                  expected_end_date: '2025-07-01'
-                  employing_school_urn:
-                  lead_partner_urn_ukprn:
-                  lead_school_urn:
-                  fund_code: '2'
-                  bursary_level: '9'
-                  previous_last_name: Wilkinson
-                  itt_aim: '202'
-                  course_study_mode: '01'
-                  course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: '9'
-                  ni_number: QQ 12 34 56 C
-                  additional_training_initiative: '026'
-                  itt_qualification_aim: '021'
-                  hesa_disabilities: {}
-                  nationality: CK
-                  withdraw_reasons: []
-                  placements: []
-                  degrees:
-                  - uk_degree: '218'
-                    non_uk_degree:
-                    created_at: '2024-07-05T14:01:19.832Z'
-                    updated_at: '2024-07-05T14:01:19.832Z'
-                    subject: '101086'
-                    institution: '0335'
-                    graduation_year: 1984
-                    grade: '13'
-                    country:
-                    other_grade:
-                    institution_uuid: 4f3e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: b6d2c5aa-cf99-4831-9bfe-6279349d8ea9
-                    subject_uuid: 438570f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: df874702-2bcc-4aab-adaa-2efdd3a8dec4
-                    degree_id: PCucMDPdai3BSBKiCup48HHf
-                  state: trn_received
-                  trainee_id: 8BT6S7ewq4Eczs46AGTmnY9G
-                  application_id:
-                - first_names: Lindsay
-                  last_name: Gorczany
-                  date_of_birth: '1985-06-26'
-                  created_at: '2024-07-05T14:01:19.761Z'
-                  updated_at: '2024-07-05T14:01:19.772Z'
-                  email: Lindsay.Gorczany@example.com
-                  middle_names: Schinner
-                  training_route:
-                  sex: '11'
-                  diversity_disclosure: diversity_not_disclosed
-                  ethnic_group:
-                  ethnic_background:
-                  additional_ethnic_background:
-                  disability_disclosure:
-                  course_subject_one: '100403'
-                  itt_start_date: '2023-08-15'
-                  outcome_date:
-                  itt_end_date: '2025-07-29'
-                  trn: '9236830'
-                  submitted_for_trn_at: '2024-07-05T14:01:19.765Z'
-                  withdraw_date:
-                  withdraw_reasons_details:
-                  defer_date:
-                  recommended_for_award_at:
-                  trainee_start_date: '2023-08-15'
-                  reinstate_date:
-                  course_min_age: 11
-                  course_max_age: 16
                   course_subject_two:
                   course_subject_three:
                   awarded_at:
@@ -1471,7 +791,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '8966456160140'
+                  hesa_id: '7385685948362'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1481,73 +801,473 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-793
+                  provider_trainee_id: 23/24-995
                   lead_partner_id:
-                  ukprn: '71285009'
+                  ukprn: '11251893'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2023-08-15'
-                  course_age_range: '13919'
-                  expected_end_date: '2025-07-29'
+                  course_itt_start_date: '2023-08-24'
+                  course_age_range: '13913'
+                  expected_end_date: '2024-07-14'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
-                  fund_code: '7'
+                  fund_code: '2'
                   bursary_level: E
-                  previous_last_name: Kuhic
-                  itt_aim: '201'
+                  previous_last_name: Ward
+                  itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
+                  pg_apprenticeship_start_date: '2024-07-08'
                   funding_method: E
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
-                  itt_qualification_aim: '020'
+                  itt_qualification_aim: '002'
                   hesa_disabilities: {}
-                  nationality: CK
+                  nationality: MX
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '057'
+                  - uk_degree: '071'
                     non_uk_degree:
-                    created_at: '2024-07-05T14:01:19.773Z'
-                    updated_at: '2024-07-05T14:01:19.773Z'
-                    subject: '100410'
-                    institution: '0270'
-                    graduation_year: 2003
-                    grade: '01'
+                    created_at: '2024-07-08T10:39:42.456Z'
+                    updated_at: '2024-07-08T10:39:42.456Z'
+                    subject: '100180'
+                    institution: '0073'
+                    graduation_year: 2016
+                    grade: '14'
                     country:
                     other_grade:
-                    institution_uuid: ed3e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: e7695652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 778170f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: 2Q9S3iMr7QfWTxxEqRkAR3L8
+                    institution_uuid: 3071f34a-2887-e711-80d8-005056ac45bb
+                    uk_degree_uuid: 036a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: '058070f0-5dce-e911-a985-000d3ab79618'
+                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
+                    degree_id: nkGi653gpLUoLr7fAe5yaS34
                   state: trn_received
-                  trainee_id: Ksco6S1oWi1ZHAgdLs5LgAny
+                  trainee_id: bnKp1dFiqwA3dm7peKuF5mYA
                   application_id:
-                - first_names: Verda
-                  last_name: Paucek
-                  date_of_birth: '1959-08-21'
-                  created_at: '2024-07-05T14:01:19.697Z'
-                  updated_at: '2024-07-05T14:01:19.710Z'
-                  email: Verda.Paucek@example.com
-                  middle_names: Lind
+                - first_names: Belkis
+                  last_name: Lehner
+                  date_of_birth: '1962-06-02'
+                  created_at: '2024-07-08T10:39:42.385Z'
+                  updated_at: '2024-07-08T10:39:42.396Z'
+                  email: Belkis.Lehner@example.com
+                  middle_names: Reinger
                   training_route:
-                  sex: '96'
+                  sex: '11'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   ethnic_background:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2023-08-19'
+                  itt_start_date: '2023-08-06'
+                  outcome_date:
+                  itt_end_date: '2024-07-13'
+                  trn: '3626401'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.389Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-12'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '009'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '3985991611569'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-992
+                  lead_partner_id:
+                  ukprn: '11251893'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-06'
+                  course_age_range: '13912'
+                  expected_end_date: '2024-07-13'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '2'
+                  bursary_level: '8'
+                  previous_last_name: Effertz
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: '8'
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '031'
+                  hesa_disabilities: {}
+                  nationality: MX
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '007'
+                    non_uk_degree:
+                    created_at: '2024-07-08T10:39:42.397Z'
+                    updated_at: '2024-07-08T10:39:42.397Z'
+                    subject: '100841'
+                    institution: '0013'
+                    graduation_year: 2011
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: 4c71f34a-2887-e711-80d8-005056ac45bb
+                    uk_degree_uuid: 007a0999-87f7-4afc-8ccd-ce1e1d92c9ac
+                    subject_uuid: e58370f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: V9VfnwDdEZRQMBY8NUvkMcWw
+                  state: trn_received
+                  trainee_id: n1dnZ6osr7N477vX8zsGLULG
+                  application_id:
+                - first_names: Micah
+                  last_name: Weber
+                  date_of_birth: '1968-05-25'
+                  created_at: '2024-07-08T10:39:42.327Z'
+                  updated_at: '2024-07-08T10:39:42.339Z'
+                  email: Micah.Weber@example.com
+                  middle_names: Weber
+                  training_route:
+                  sex: '11'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-21'
+                  outcome_date:
+                  itt_end_date: '2024-07-01'
+                  trn: '2848297'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.331Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-21'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '009'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '3716195176430'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-989
+                  lead_partner_id:
+                  ukprn: '11251893'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-21'
+                  course_age_range: '13915'
+                  expected_end_date: '2024-07-01'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: B
+                  previous_last_name: Dach
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: B
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '021'
+                  hesa_disabilities: {}
+                  nationality: MX
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '218'
+                    non_uk_degree:
+                    created_at: '2024-07-08T10:39:42.340Z'
+                    updated_at: '2024-07-08T10:39:42.340Z'
+                    subject: '100843'
+                    institution: '0317'
+                    graduation_year: 1984
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: 1e3f182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: b6d2c5aa-cf99-4831-9bfe-6279349d8ea9
+                    subject_uuid: e98370f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: Fqj8ojn7Co1mwj76zxm22yQs
+                  state: trn_received
+                  trainee_id: iuWCjMLpwgwkUcLKTZWrH7cD
+                  application_id:
+                - first_names: Diamond
+                  last_name: Koch
+                  date_of_birth: '1968-11-25'
+                  created_at: '2024-07-08T10:39:42.269Z'
+                  updated_at: '2024-07-08T10:39:42.281Z'
+                  email: Diamond.Koch@example.com
+                  middle_names: Borer
+                  training_route:
+                  sex: '10'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-14'
                   outcome_date:
                   itt_end_date: '2025-07-26'
-                  trn: '5019807'
-                  submitted_for_trn_at: '2024-07-05T14:01:19.701Z'
+                  trn: '5154158'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.274Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-17'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '036'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '5691444090057'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-986
+                  lead_partner_id:
+                  ukprn: '11251893'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-14'
+                  course_age_range: '13911'
+                  expected_end_date: '2025-07-26'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: C
+                  previous_last_name: Daniel
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: C
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '007'
+                  hesa_disabilities: {}
+                  nationality: MX
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '300'
+                    non_uk_degree:
+                    created_at: '2024-07-08T10:39:42.283Z'
+                    updated_at: '2024-07-08T10:39:42.283Z'
+                    subject:
+                    institution: '0316'
+                    graduation_year: 2005
+                    grade: '14'
+                    country:
+                    other_grade:
+                    institution_uuid: 113f182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 5b6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 96667ef1-0c31-4266-b3ed-6dc2cfaa1c7b
+                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
+                    degree_id: pkfRZc7LGKHuD18d8zVNQnrp
+                  state: trn_received
+                  trainee_id: Jh5eqpYvp2Vss2fh1RhqVeoc
+                  application_id:
+                - first_names: Fletcher
+                  last_name: Cormier
+                  date_of_birth: '1994-10-29'
+                  created_at: '2024-07-08T10:39:42.208Z'
+                  updated_at: '2024-07-08T10:39:42.221Z'
+                  email: Fletcher.Cormier@example.com
+                  middle_names: Durgan
+                  training_route:
+                  sex: '10'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-26'
+                  outcome_date:
+                  itt_end_date: '2025-07-03'
+                  trn: '5179178'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.213Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-09-10'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '009'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '4300676675346'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-983
+                  lead_partner_id:
+                  ukprn: '11251893'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-26'
+                  course_age_range: '13919'
+                  expected_end_date: '2025-07-03'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: D
+                  previous_last_name: Huels
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: D
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '004'
+                  hesa_disabilities: {}
+                  nationality: MX
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '300'
+                    non_uk_degree:
+                    created_at: '2024-07-08T10:39:42.222Z'
+                    updated_at: '2024-07-08T10:39:42.222Z'
+                    subject: '101511'
+                    institution: '0194'
+                    graduation_year: 1988
+                    grade: '02'
+                    country:
+                    other_grade:
+                    institution_uuid: 9b407223-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: 5b6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: b38770f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
+                    degree_id: vgzGu331d1f66CBxqEBsiPqy
+                  state: trn_received
+                  trainee_id: PhYUeE9SFRHrCDzDHTFUQjLB
+                  application_id:
+                - first_names: Thomasena
+                  last_name: Hoeger
+                  date_of_birth: '1999-02-10'
+                  created_at: '2024-07-08T10:39:42.146Z'
+                  updated_at: '2024-07-08T10:39:42.157Z'
+                  email: Thomasena.Hoeger@example.com
+                  middle_names: Parker
+                  training_route:
+                  sex: '99'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-11'
+                  outcome_date:
+                  itt_end_date: '2025-07-29'
+                  trn: '7055325'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.150Z'
                   withdraw_date:
                   withdraw_reasons_details:
                   defer_date:
@@ -1559,6 +1279,106 @@ paths:
                   course_subject_two:
                   course_subject_three:
                   awarded_at:
+                  training_initiative: '036'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '9593343867099'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-980
+                  lead_partner_id:
+                  ukprn: '11251893'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-11'
+                  course_age_range: '13915'
+                  expected_end_date: '2025-07-29'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: '4'
+                  previous_last_name: Torphy
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: '4'
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '031'
+                  hesa_disabilities: {}
+                  nationality: MX
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '203'
+                    non_uk_degree:
+                    created_at: '2024-07-08T10:39:42.158Z'
+                    updated_at: '2024-07-08T10:39:42.158Z'
+                    subject: '100114'
+                    institution: '0333'
+                    graduation_year: 1999
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: 043e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 416a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 9d7f70f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: otQHZuCtbGWzmTR8qeQrJJvY
+                  state: trn_received
+                  trainee_id: dWbJgDQ3qy93pCt7ZosWQHit
+                  application_id:
+                - first_names: Timmy
+                  last_name: Johnson
+                  date_of_birth: '2002-02-12'
+                  created_at: '2024-07-08T10:39:42.086Z'
+                  updated_at: '2024-07-08T10:39:42.098Z'
+                  email: Timmy.Johnson@example.com
+                  middle_names: Luettgen
+                  training_route:
+                  sex: '96'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-16'
+                  outcome_date:
+                  itt_end_date: '2025-07-06'
+                  trn: '2925443'
+                  submitted_for_trn_at: '2024-07-08T10:39:42.090Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-19'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
                   training_initiative: '025'
                   study_mode: '01'
                   ebacc: false
@@ -1571,7 +1391,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '9921649899686'
+                  hesa_id: '6577975351872'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1581,60 +1401,60 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-790
+                  provider_trainee_id: 23/24-977
                   lead_partner_id:
-                  ukprn: '71285009'
+                  ukprn: '11251893'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2023-08-19'
-                  course_age_range: '13911'
-                  expected_end_date: '2025-07-26'
+                  course_itt_start_date: '2023-08-16'
+                  course_age_range: '13909'
+                  expected_end_date: '2025-07-06'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
                   fund_code: '7'
-                  bursary_level: '6'
-                  previous_last_name: Herman
-                  itt_aim: '202'
+                  bursary_level: E
+                  previous_last_name: Pouros
+                  itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: '6'
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: E
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
-                  itt_qualification_aim: '028'
+                  itt_qualification_aim: '021'
                   hesa_disabilities: {}
-                  nationality: CK
+                  nationality: MX
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '203'
+                  - uk_degree: '300'
                     non_uk_degree:
-                    created_at: '2024-07-05T14:01:19.711Z'
-                    updated_at: '2024-07-05T14:01:19.711Z'
-                    subject: '100369'
-                    institution: '0210'
-                    graduation_year: 2016
-                    grade: '14'
+                    created_at: '2024-07-08T10:39:42.099Z'
+                    updated_at: '2024-07-08T10:39:42.099Z'
+                    subject: '100317'
+                    institution: '0419'
+                    graduation_year: 2017
+                    grade: '13'
                     country:
                     other_grade:
-                    institution_uuid: 154b9247-7042-e811-80ff-3863bb3640b8
-                    uk_degree_uuid: 416a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 358170f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                    degree_id: 4XgciB9Lf6nw5jvxcAK5i1zf
+                    institution_uuid: 363e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 5b6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: db8070f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: df874702-2bcc-4aab-adaa-2efdd3a8dec4
+                    degree_id: nQrgYzc5PFYMUV5uuLcYVpo3
                   state: trn_received
-                  trainee_id: qo3kmJw8ARAFpzikbhfFY4fi
+                  trainee_id: dSKd3AhY8ZouCC1o3mUqw7Sq
                   application_id:
                 meta:
                   current_page: 1
                   total_pages: 1
-                  total_count: 12
+                  total_count: 10
                   per_page: 50
         '422':
-          description: returns 422 if academic cycle filter is invalid
+          description: returns 422 if since filter is an invalid date
           content:
             application/json:
               schema:
@@ -1683,7 +1503,7 @@ paths:
         example: v1.0
       responses:
         '201':
-          description: creates the degrees with the correct graduation_year
+          description: sets the correct subjects
           content:
             application/json:
               schema:
@@ -2076,8 +1896,8 @@ paths:
                   first_names: John
                   last_name: Doe
                   date_of_birth: '1990-01-01'
-                  created_at: '2024-07-05T14:01:05.264Z'
-                  updated_at: '2024-07-05T14:01:05.264Z'
+                  created_at: '2024-07-08T10:39:23.269Z'
+                  updated_at: '2024-07-08T10:39:23.269Z'
                   email: john.doe@example.com
                   middle_names:
                   training_route: '11'
@@ -2092,17 +1912,17 @@ paths:
                   outcome_date:
                   itt_end_date: '2023-10-01'
                   trn:
-                  submitted_for_trn_at: '2024-07-05T14:01:05.316Z'
+                  submitted_for_trn_at: '2024-07-08T10:39:23.328Z'
                   withdraw_date:
                   withdraw_reasons_details:
                   defer_date:
                   recommended_for_award_at:
                   trainee_start_date: '2023-01-01'
                   reinstate_date:
-                  course_min_age: 3
+                  course_min_age: 11
                   course_max_age:
-                  course_subject_two:
-                  course_subject_three:
+                  course_subject_two: '101410'
+                  course_subject_three: '100366'
                   awarded_at:
                   training_initiative:
                   study_mode: '63'
@@ -2127,13 +1947,13 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 99157234/2/01
-                  ukprn: '16807767'
+                  ukprn: '42759658'
                   ethnicity: '997'
                   course_qualification: QTS
                   course_title:
                   course_level: undergrad
                   course_itt_start_date: '2023-01-01'
-                  course_age_range: '13909'
+                  course_age_range: '13918'
                   expected_end_date: '2023-10-01'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
@@ -2158,14 +1978,14 @@ paths:
                   - urn: '900020'
                     name: Establishment does not have a URN
                     postcode:
-                    created_at: '2024-07-05T14:01:05.275Z'
-                    updated_at: '2024-07-05T14:01:05.275Z'
-                    placement_id: KASN9hNie299zDnN9sMDj3kc
+                    created_at: '2024-07-08T10:39:23.285Z'
+                    updated_at: '2024-07-08T10:39:23.285Z'
+                    placement_id: ybNo2BghcqLPBBbDpJvWWzSY
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
-                    created_at: '2024-07-05T14:01:05.265Z'
-                    updated_at: '2024-07-05T14:01:05.265Z'
+                    created_at: '2024-07-08T10:39:23.271Z'
+                    updated_at: '2024-07-08T10:39:23.271Z'
                     subject: '100485'
                     institution: '0117'
                     graduation_year: 2003
@@ -2176,9 +1996,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: e78170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: LeN3RMwRm9BwCDv9qHEh1Pdy
+                    degree_id: gNBUEX3XdvvrqmrSSy9NBhrk
                   state: submitted_for_trn
-                  trainee_id: dFykBJmCNgeiwpU1A71qDiBu
+                  trainee_id: EKbzUEhb7Ai6R1ZGzNiZFWXY
                   application_id:
                   disability1: '58'
                   disability2: '57'
@@ -2360,6 +2180,7 @@ paths:
                                 type: integer
                               grade:
                                 type: string
+                                nullable: true
                               country:
                                 nullable: true
                               other_grade:
@@ -2482,13 +2303,13 @@ paths:
               example:
                 errors: This trainee is already in Register
                 data:
-                - first_names: Delilah
-                  last_name: Keebler
-                  date_of_birth: '2006-03-03'
-                  created_at: '2024-07-05T14:01:26.066Z'
-                  updated_at: '2024-07-05T14:01:26.069Z'
-                  email: Delilah.Keebler@example.com
-                  middle_names: Stokes
+                - first_names: Cyrstal
+                  last_name: Ward
+                  date_of_birth: '1965-06-04'
+                  created_at: '2024-07-08T10:38:56.311Z'
+                  updated_at: '2024-07-08T10:38:56.314Z'
+                  email: Cyrstal.Ward@example.com
+                  middle_names: Gislason
                   training_route: '11'
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -2499,17 +2320,17 @@ paths:
                   course_subject_one: '100346'
                   itt_start_date: '2023-08-01'
                   outcome_date:
-                  itt_end_date: '2026-07-29'
+                  itt_end_date: '2026-07-30'
                   trn:
                   submitted_for_trn_at:
                   withdraw_date:
                   withdraw_reasons_details:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2023-08-02'
+                  trainee_start_date: '2023-08-09'
                   reinstate_date:
                   course_min_age: 11
-                  course_max_age: 16
+                  course_max_age: 18
                   course_subject_two:
                   course_subject_three:
                   awarded_at:
@@ -2535,16 +2356,16 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-1027
+                  provider_trainee_id: 23/24-60
                   lead_partner_id:
-                  ukprn: '38804311'
+                  ukprn: '40482727'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: undergrad
                   course_itt_start_date: '2023-08-01'
                   course_age_range:
-                  expected_end_date: '2026-07-29'
+                  expected_end_date: '2026-07-30'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
@@ -2554,23 +2375,23 @@ paths:
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '059'
+                  - uk_degree: '202'
                     non_uk_degree:
-                    created_at: '2024-07-05T14:01:26.068Z'
-                    updated_at: '2024-07-05T14:01:26.068Z'
-                    subject: '101334'
-                    institution: '0016'
-                    graduation_year: 1995
-                    grade: '13'
+                    created_at: '2024-07-08T10:38:56.313Z'
+                    updated_at: '2024-07-08T10:38:56.313Z'
+                    subject: '100379'
+                    institution: '0433'
+                    graduation_year: 1991
+                    grade:
                     country:
                     other_grade:
-                    institution_uuid: d070f34a-2887-e711-80d8-005056ac45bb
-                    uk_degree_uuid: eb695652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 6f8670f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: df874702-2bcc-4aab-adaa-2efdd3a8dec4
-                    degree_id: qyQGP9rJtyHrkDsACXBJXXqD
+                    institution_uuid: e33e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 3f6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 458170f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
+                    degree_id: yK3UFkfLtjgMKhNDDciAZHPD
                   state: draft
-                  trainee_id: K1ReXDfeJYTVLgFuNWK83eVE
+                  trainee_id: kZNCFxztEFgnaKZ27CTGw4tg
                   application_id:
         '422':
           description: return status code 422 with a meaningful error message
@@ -2760,14 +2581,14 @@ paths:
                   subject: '100485'
                   institution: '0117'
                   uk_degree: '083'
-                  graduation_year: '2003-01-01'
+                  graduation_year: '2003'
                 placements_attributes:
                 - name: Placement
                   urn: '900020'
                 itt_aim: 202
                 itt_qualification_aim: '001'
                 course_year: '2012'
-                course_age_range: '13909'
+                course_age_range: '13918'
                 fund_code: '7'
                 funding_method: '4'
                 hesa_id: '0310261553101'
@@ -2777,8 +2598,8 @@ paths:
                 course_subject_two: '101410'
                 course_subject_three: '100366'
                 course_max_age: 11
-                lead_school_urn: '322600'
-                employing_school_urn: ''
+                lead_school_urn: '900020'
+                employing_school_urn: '662222'
                 trn: '567899'
                 ethnic_group: mixed_ethnic_group
                 ethnic_background: Another Mixed background
@@ -3069,15 +2890,15 @@ paths:
                 - trainee_id
                 - application_id
               example:
-                first_names: Nancie
-                last_name: Jenkins
-                date_of_birth: '1961-09-02'
-                created_at: '2024-07-05T14:00:51.489Z'
-                updated_at: '2024-07-05T14:00:51.503Z'
-                email: Nancie.Jenkins@example.com
-                middle_names: Lang
+                first_names: Darrel
+                last_name: Howell
+                date_of_birth: '1977-02-08'
+                created_at: '2024-07-08T10:38:53.645Z'
+                updated_at: '2024-07-08T10:38:53.660Z'
+                email: Darrel.Howell@example.com
+                middle_names: Schmeler
                 training_route:
-                sex: '12'
+                sex: '11'
                 diversity_disclosure: diversity_not_disclosed
                 ethnic_group:
                 ethnic_background:
@@ -3112,7 +2933,7 @@ paths:
                 commencement_status:
                 discarded_at:
                 created_from_dttp: false
-                hesa_id: '1180575718577'
+                hesa_id: '3636086636934'
                 additional_dttp_data:
                 created_from_hesa: false
                 hesa_updated_at:
@@ -3122,30 +2943,30 @@ paths:
                 withdraw_reasons_dfe_details:
                 slug_sent_to_dqt_at:
                 placement_detail:
-                provider_trainee_id: 23/24-190
+                provider_trainee_id: 23/24-7
                 lead_partner_id:
-                ukprn: '53368175'
+                ukprn: '33869210'
                 ethnicity:
                 course_qualification: QTS
                 course_title:
                 course_level: postgrad
                 course_itt_start_date:
-                course_age_range: '13913'
+                course_age_range: '13914'
                 expected_end_date:
                 employing_school_urn:
                 lead_partner_urn_ukprn:
                 lead_school_urn:
-                fund_code: '7'
-                bursary_level: D
-                previous_last_name: Gibson
+                fund_code: '2'
+                bursary_level: '4'
+                previous_last_name: Spencer
                 itt_aim: '201'
                 course_study_mode: '01'
                 course_year: 2024
-                pg_apprenticeship_start_date: '2024-07-05'
-                funding_method: D
+                pg_apprenticeship_start_date: '2024-07-08'
+                funding_method: '4'
                 ni_number: QQ 12 34 56 C
                 additional_training_initiative: '026'
-                itt_qualification_aim: '021'
+                itt_qualification_aim: '001'
                 hesa_disabilities: {}
                 nationality:
                 withdraw_reasons: []
@@ -3195,10 +3016,10 @@ paths:
         required: true
         schema:
           type: string
-        example: hGJunGJSzCyU3SfzXGwobZJg
+        example: W2zA986Pt6AoDy3NLEQHABoR
       responses:
         '200':
-          description: does not update the ethnic attributes
+          description: is expected to eq "139"
           content:
             application/json:
               schema:
@@ -3435,6 +3256,7 @@ paths:
                               nullable: true
                             institution:
                               type: string
+                              nullable: true
                             graduation_year:
                               type: integer
                             grade:
@@ -3570,34 +3392,34 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Jordan
-                  last_name: Franecki
-                  date_of_birth: '1984-09-08'
-                  created_at: '2024-07-05T14:00:48.714Z'
-                  updated_at: '2024-07-05T14:00:48.813Z'
-                  email: Jordan.Franecki@example.com
-                  middle_names: Heathcote
+                  first_names: Alice
+                  last_name: Schneider
+                  date_of_birth: '2000-10-28'
+                  created_at: '2024-07-08T10:39:10.639Z'
+                  updated_at: '2024-07-08T10:39:10.742Z'
+                  email: Wilber.Schneider@example.com
+                  middle_names: Keebler
                   training_route:
-                  sex: '10'
+                  sex: '99'
                   diversity_disclosure: diversity_not_disclosed
-                  ethnic_group: asian_ethnic_group
-                  ethnic_background: Another Asian background
+                  ethnic_group: black_ethnic_group
+                  ethnic_background: Another Black background
                   additional_ethnic_background:
                   disability_disclosure: disabled
                   course_subject_one: '100403'
-                  itt_start_date: '2023-08-18'
+                  itt_start_date: '2023-08-01'
                   outcome_date:
-                  itt_end_date: '2024-07-12'
+                  itt_end_date: '2024-07-06'
                   trn:
                   submitted_for_trn_at:
                   withdraw_date:
                   withdraw_reasons_details:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2023-08-21'
+                  trainee_start_date: '2023-08-12'
                   reinstate_date:
                   course_min_age: 11
-                  course_max_age: 16
+                  course_max_age: 18
                   course_subject_two:
                   course_subject_three:
                   awarded_at:
@@ -3613,7 +3435,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '6068241514448'
+                  hesa_id: '9169458661094'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -3623,27 +3445,27 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-141
+                  provider_trainee_id: 23/24-221
                   lead_partner_id:
-                  ukprn: '35704337'
-                  ethnicity: '119'
+                  ukprn: '93025213'
+                  ethnicity: '139'
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2023-08-18'
-                  course_age_range: '13919'
-                  expected_end_date: '2024-07-12'
+                  course_itt_start_date: '2023-08-01'
+                  course_age_range: '13915'
+                  expected_end_date: '2024-07-06'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
-                  fund_code: '2'
-                  bursary_level: D
-                  previous_last_name: Lebsack
-                  itt_aim: '202'
+                  fund_code: '7'
+                  bursary_level: E
+                  previous_last_name: Huels
+                  itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: D
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: E
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
                   itt_qualification_aim: '031'
@@ -3654,23 +3476,23 @@ paths:
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '093'
+                  - uk_degree: '091'
                     non_uk_degree:
-                    created_at: '2024-07-05T14:00:48.738Z'
-                    updated_at: '2024-07-05T14:00:48.738Z'
-                    subject: '100651'
-                    institution: '0353'
-                    graduation_year: 1999
-                    grade: '05'
+                    created_at: '2024-07-08T10:39:10.664Z'
+                    updated_at: '2024-07-08T10:39:10.664Z'
+                    subject: '101332'
+                    institution: '0081'
+                    graduation_year: 1982
+                    grade: '12'
                     country:
                     other_grade:
-                    institution_uuid: fe3d182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: 2f6a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: bb8270f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
-                    degree_id: 2rVpm5WzjMfn3Kg6CFJjBs91
+                    institution_uuid: 4071f34a-2887-e711-80d8-005056ac45bb
+                    uk_degree_uuid: 2b6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 6b8670f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
+                    degree_id: 93HQPi9NVtdSYng8HKX3huPz
                   state: draft
-                  trainee_id: N1HNGvg76BKES4qrxTiq7iS9
+                  trainee_id: W2zA986Pt6AoDy3NLEQHABoR
                   application_id:
                   disability1: '55'
                   disability2: '57'
@@ -3688,7 +3510,7 @@ paths:
               example:
                 error: Unauthorized
         '404':
-          description: returns status 404 not found
+          description: returns 404
           content:
             application/json:
               schema:
@@ -3711,9 +3533,10 @@ paths:
               example:
                 errors:
                 - error: NotFound
-                  message: Not found
+                  message: Trainee(s) not found
         '422':
-          description: return status code 422 with a meaningful error message
+          description: is expected to contain exactly "Ethnicity is not included in
+            the list"
           content:
             application/json:
               schema:
@@ -3735,6 +3558,8 @@ paths:
                             type: array
                             items:
                               type: string
+                        required:
+                        - itt_end_date
                       nationalisations.nationality:
                         type: array
                         items:
@@ -3756,7 +3581,7 @@ paths:
                 message: 'Validation failed: 1 error prohibited this trainee from
                   being saved'
                 errors:
-                - Sex is not included in the list
+                - Ethnicity is not included in the list
       requestBody:
         content:
           application/json:
@@ -3806,16 +3631,16 @@ paths:
                 first_names: Alice
                 study_mode: '63'
                 disability2: '57'
-                disability1: '58'
+                disability1: '57'
                 lead_school_urn: '900020'
-                employing_school_urn: '491094'
+                employing_school_urn: '941124'
                 nationality: IE
-                course_subject_one: '100511'
+                course_subject_one: '100346'
                 course_subject_two: '101410'
                 course_subject_three: '100366'
                 course_max_age: 11
                 provider_trainee_id: 99157234/2/01
-                ethnicity: '899'
+                ethnicity:
                 trn: '567899'
                 ethnic_group: mixed_ethnic_group
                 ethnic_background: Another Mixed background
@@ -3836,7 +3661,7 @@ paths:
         required: true
         schema:
           type: string
-        example: nHNB3eN6zkJQKPSrYn9hX9zg
+        example: QadPcVx6det6kKawfZgxPpH3
       responses:
         '200':
           description: defers a trainee
@@ -3922,6 +3747,7 @@ paths:
                         nullable: true
                       training_initiative:
                         nullable: true
+                        type: string
                       study_mode:
                         nullable: true
                       ebacc:
@@ -3999,6 +3825,7 @@ paths:
                           properties:
                             uk_degree:
                               type: string
+                              nullable: true
                             non_uk_degree:
                               nullable: true
                             created_at:
@@ -4013,6 +3840,7 @@ paths:
                               type: integer
                             grade:
                               nullable: true
+                              type: string
                             country:
                               nullable: true
                             other_grade:
@@ -4130,15 +3958,15 @@ paths:
               example:
                 data:
                   commencement_status:
-                  defer_date: '2024-07-05'
-                  trainee_start_date: '2023-08-28'
-                  first_names: Cruz
-                  middle_names: Sanford
-                  last_name: Conroy
-                  email: Cruz.Conroy@example.com
+                  defer_date: '2024-07-08'
+                  trainee_start_date: '2023-08-08'
+                  first_names: Terisa
+                  middle_names: Jaskolski
+                  last_name: Bergnaum
+                  email: Terisa.Bergnaum@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '4544083'
+                  trn: '3246305'
                   withdraw_reasons_details:
                   withdraw_reasons_dfe_details:
                   region:
@@ -4147,18 +3975,18 @@ paths:
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '1986-09-26'
-                  created_at: '2024-07-05T14:01:26.296Z'
-                  updated_at: '2024-07-05T14:01:26.354Z'
+                  date_of_birth: '1962-05-28'
+                  created_at: '2024-07-08T10:38:54.775Z'
+                  updated_at: '2024-07-08T10:38:54.833Z'
                   training_route:
-                  sex: '99'
+                  sex: '12'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2023-08-27'
+                  itt_start_date: '2023-08-05'
                   outcome_date:
-                  itt_end_date: '2024-07-17'
-                  submitted_for_trn_at: '2024-07-05T14:01:26.283Z'
+                  itt_end_date: '2025-07-23'
+                  submitted_for_trn_at: '2024-07-08T10:38:54.769Z'
                   withdraw_date:
                   recommended_for_award_at:
                   reinstate_date:
@@ -4182,42 +4010,42 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-1034
+                  provider_trainee_id: 23/24-30
                   lead_partner_id:
-                  ukprn: '77934060'
+                  ukprn: '62606367'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2023-08-27'
+                  course_itt_start_date: '2023-08-05'
                   course_age_range:
-                  expected_end_date: '2024-07-17'
+                  expected_end_date: '2025-07-23'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
                   fund_code:
                   bursary_level:
-                  nationality: TR
+                  nationality: JM
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '209'
+                  - uk_degree:
                     non_uk_degree:
-                    created_at: '2024-07-05T14:01:26.298Z'
-                    updated_at: '2024-07-05T14:01:26.298Z'
-                    subject: '100172'
-                    institution: '0270'
-                    graduation_year: 2021
+                    created_at: '2024-07-08T10:38:54.777Z'
+                    updated_at: '2024-07-08T10:38:54.777Z'
+                    subject: '100989'
+                    institution: '0031'
+                    graduation_year: 1995
                     grade:
                     country:
                     other_grade:
-                    institution_uuid: ed3e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: 4d6a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: fb7f70f0-5dce-e911-a985-000d3ab79618
+                    institution_uuid: f270f34a-2887-e711-80d8-005056ac45bb
+                    uk_degree_uuid: fdafdcd7-5f21-4363-b7d5-c1f44a852af1
+                    subject_uuid: bb8470f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: GuwCzgjCAeX5vb4eR3F1rc3K
+                    degree_id: JGJiTqLtjTDdsnyF5FqTg4B3
                   state: deferred
-                  trainee_id: nHNB3eN6zkJQKPSrYn9hX9zg
+                  trainee_id: QadPcVx6det6kKawfZgxPpH3
                   application_id:
         '404':
           description: returns 404
@@ -4286,7 +4114,7 @@ paths:
               - data
             example:
               data:
-                defer_date: '2024-07-05'
+                defer_date: '2024-07-08'
   "/api/{api_version}/trainees/{trainee_slug}/degrees":
     get:
       summary: index
@@ -4304,7 +4132,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 4dhmf8CgmUJq22jfvihRLqaj
+        example: tBr3dbP3vrchsQ1cFS7p5spK
       responses:
         '200':
           description: returns status 200 with a valid JSON response
@@ -4328,12 +4156,14 @@ paths:
                           type: string
                         subject:
                           type: string
+                          nullable: true
                         institution:
                           type: string
                         graduation_year:
                           type: integer
                         grade:
                           type: string
+                          nullable: true
                         country:
                           nullable: true
                         other_grade:
@@ -4384,7 +4214,7 @@ paths:
         required: true
         schema:
           type: string
-        example: JEfz82UUkjdHCi6XWY5pFBXc
+        example: 6eXXeeRb7RNQGmwhn1gsfmkY
       responses:
         '201':
           description: creates a new degree and returns a 201 (created) status
@@ -4448,8 +4278,8 @@ paths:
                 data:
                   uk_degree: '083'
                   non_uk_degree:
-                  created_at: '2024-07-05T14:00:51.710Z'
-                  updated_at: '2024-07-05T14:00:51.710Z'
+                  created_at: '2024-07-08T10:39:43.021Z'
+                  updated_at: '2024-07-08T10:39:43.021Z'
                   subject: '100425'
                   institution: '0117'
                   graduation_year: 2015
@@ -4460,7 +4290,7 @@ paths:
                   uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                  degree_id: ui4NyU7YuWPCbZCcjESywSmx
+                  degree_id: K1F7ihcwNvKNTASVnBye1LtY
         '404':
           description: does not create a new degree and returns a 404 status (not_found)
             status
@@ -4601,13 +4431,13 @@ paths:
         required: true
         schema:
           type: string
-        example: uUqFgwN6BkMxNPD6URz2gBUM
+        example: 5kSWTqN4KAsBvU5vZeT2ZovA
       - name: trainee_slug
         in: path
         required: true
         schema:
           type: string
-        example: xhJBgdbrEwnnQvqp4TvKF1he
+        example: YjxUaGGfRRiUbdEXYrVwaFHG
       requestBody:
         content:
           application/json:
@@ -4859,13 +4689,13 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Rosendo
-                  last_name: Gerhold
-                  date_of_birth: '1969-05-31'
-                  created_at: '2024-07-05T14:01:25.173Z'
-                  updated_at: '2024-07-05T14:01:25.225Z'
-                  email: Rosendo.Gerhold@example.com
-                  middle_names: Batz
+                  first_names: Max
+                  last_name: Halvorson
+                  date_of_birth: '2004-01-16'
+                  created_at: '2024-07-08T10:39:44.362Z'
+                  updated_at: '2024-07-08T10:39:44.415Z'
+                  email: Max.Halvorson@example.com
+                  middle_names: Stiedemann
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -4912,9 +4742,9 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-1013
+                  provider_trainee_id: 23/24-1045
                   lead_partner_id:
-                  ukprn: '39205863'
+                  ukprn: '75397808'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
@@ -4932,7 +4762,7 @@ paths:
                   placements: []
                   degrees: []
                   state: draft
-                  trainee_id: Eda26pfZ24HwgpanZ68jLvrN
+                  trainee_id: YjxUaGGfRRiUbdEXYrVwaFHG
                   application_id:
         '404':
           description: does not delete the degree and returns a 404 status (not_found)
@@ -4975,13 +4805,13 @@ paths:
         required: true
         schema:
           type: string
-        example: non-existant
+        example: dtqhZkqT4VX3LHjbuBtkrVCH
       - name: trainee_slug
         in: path
         required: true
         schema:
           type: string
-        example: 1GMdCgdZVD9cELfGsWZU5FDq
+        example: pYNkZL2rLj7wHtK5uUnmBP4f
       responses:
         '200':
           description: returns status 200 with a valid JSON response
@@ -4995,6 +4825,7 @@ paths:
                     properties:
                       uk_degree:
                         type: string
+                        nullable: true
                       non_uk_degree:
                         nullable: true
                       created_at:
@@ -5009,6 +4840,7 @@ paths:
                         type: integer
                       grade:
                         type: string
+                        nullable: true
                       country:
                         nullable: true
                       other_grade:
@@ -5043,21 +4875,21 @@ paths:
                 - data
               example:
                 data:
-                  uk_degree: '201'
+                  uk_degree: '052'
                   non_uk_degree:
-                  created_at: '2024-07-05T14:00:53.349Z'
-                  updated_at: '2024-07-05T14:00:53.349Z'
-                  subject: '100138'
-                  institution: '0220'
-                  graduation_year: 2013
-                  grade: '01'
+                  created_at: '2024-07-08T10:38:56.469Z'
+                  updated_at: '2024-07-08T10:38:56.469Z'
+                  subject: '100959'
+                  institution: '0026'
+                  graduation_year: 1965
+                  grade: '12'
                   country:
                   other_grade:
-                  institution_uuid: 5d3e182c-1425-ec11-b6e6-000d3adf095a
-                  uk_degree_uuid: 3d6a5652-c197-e711-80d8-005056ac45bb
-                  subject_uuid: c57f70f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                  degree_id: QKGSNdqK1ceVRCQokryYoiZ9
+                  institution_uuid: fc70f34a-2887-e711-80d8-005056ac45bb
+                  uk_degree_uuid: dd695652-c197-e711-80d8-005056ac45bb
+                  subject_uuid: 978470f0-5dce-e911-a985-000d3ab79618
+                  grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
+                  degree_id: dtqhZkqT4VX3LHjbuBtkrVCH
         '404':
           description: returns status 404 with a valid JSON response
           content:
@@ -5099,13 +4931,13 @@ paths:
         required: true
         schema:
           type: string
-        example: D15uSt7E4SzPYH1viGUEzT27
+        example: vuf7fJVP4WPpQi747dbDRw6K
       - name: trainee_slug
         in: path
         required: true
         schema:
           type: string
-        example: o3gac6Jq1yFzSp2wK1GiT1cd
+        example: 5G261JtNnhFjeyDFwJc64nPr
       requestBody:
         content:
           application/json:
@@ -5202,19 +5034,19 @@ paths:
                 data:
                   uk_degree: '051'
                   non_uk_degree:
-                  created_at: '2024-07-05T14:01:25.604Z'
-                  updated_at: '2024-07-05T14:01:25.649Z'
+                  created_at: '2024-07-08T10:39:43.894Z'
+                  updated_at: '2024-07-08T10:39:43.938Z'
                   subject: '100105'
                   institution: '0030'
                   graduation_year: 1978
                   grade: '05'
                   country:
                   other_grade:
-                  institution_uuid: 2d3e182c-1425-ec11-b6e6-000d3adf095a
-                  uk_degree_uuid: 1f6a5652-c197-e711-80d8-005056ac45bb
+                  institution_uuid: 5b3e182c-1425-ec11-b6e6-000d3adf095a
+                  uk_degree_uuid: b6d2c5aa-cf99-4831-9bfe-6279349d8ea9
                   subject_uuid: 917f70f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                  degree_id: 3BCf6naCPvLPjUtfRNLTWVuj
+                  grade_uuid: df874702-2bcc-4aab-adaa-2efdd3a8dec4
+                  degree_id: VEcZcPr9Wk7g7nm7ej9wqbTu
         '404':
           description: does not update the degree and returns a 404 status (not_found)
           content:
@@ -5285,7 +5117,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 4cQPyZwcq7MAyrZSiX7B2ECU
+        example: AvTMY6UfpeP4HN8Ug4VDujoC
       responses:
         '200':
           description: returns status 200 with a valid JSON response
@@ -5321,19 +5153,7 @@ paths:
                 required:
                 - data
               example:
-                data:
-                - urn: '383175'
-                  name: Brighthurst Secondary College
-                  postcode: C9S 1JP
-                  created_at: '2024-07-05T14:00:52.097Z'
-                  updated_at: '2024-07-05T14:00:52.097Z'
-                  placement_id: ZrhkFrQK2YLekX8mr7PZPEgp
-                - urn: '966311'
-                  name: Mallowpond High
-                  postcode: YM7W 1NB
-                  created_at: '2024-07-05T14:00:52.102Z'
-                  updated_at: '2024-07-05T14:00:52.102Z'
-                  placement_id: 9t4LGcQM3MQFeJktJd4Wf57d
+                data: []
     post:
       summary: create
       tags:
@@ -5350,7 +5170,7 @@ paths:
         required: true
         schema:
           type: string
-        example: tmztAHzUsEXJGYA4ZLfRHYmi
+        example: Xt2cKUNf8bGdnft6QtDC6pEb
       requestBody:
         content:
           application/json:
@@ -5389,7 +5209,7 @@ paths:
                 name:
                 postcode:
                 urn:
-                school_id: 117
+                school_id: 105
       responses:
         '201':
           description: updates the progress attribute on the trainee
@@ -5424,12 +5244,12 @@ paths:
                 - data
               example:
                 data:
-                  urn: '729091'
-                  name: Bluemeadow High
-                  postcode: WX0 2QX
-                  created_at: '2024-07-05T14:01:26.829Z'
-                  updated_at: '2024-07-05T14:01:26.829Z'
-                  placement_id: RxvYN3JGtgXHbuNWqDLYw2ia
+                  urn: '309644'
+                  name: Bluemeadow High School
+                  postcode: O6 9EN
+                  created_at: '2024-07-08T10:39:24.470Z'
+                  updated_at: '2024-07-08T10:39:24.470Z'
+                  placement_id: VKyBy1Ls7B47R5tsuirqvR4H
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -5501,16 +5321,16 @@ paths:
         required: true
         schema:
           type: string
-        example: vDbUAV3FFqTk8m2UYJPQX5yx
+        example: non-existant
       - name: trainee_slug
         in: path
         required: true
         schema:
           type: string
-        example: hJKBa3WHutaLnxq1oYnbufd8
+        example: non-existant
       responses:
         '200':
-          description: removes the specified placement
+          description: returns status 200 with a valid JSON response
           content:
             application/json:
               schema:
@@ -5804,15 +5624,15 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Reginald
-                  last_name: Anderson
-                  date_of_birth: '1994-08-31'
-                  created_at: '2024-07-05T14:01:24.996Z'
-                  updated_at: '2024-07-05T14:01:25.042Z'
-                  email: Reginald.Anderson@example.com
-                  middle_names: Erdman
+                  first_names: Louis
+                  last_name: Greenfelder
+                  date_of_birth: '2006-06-23'
+                  created_at: '2024-07-08T10:39:23.752Z'
+                  updated_at: '2024-07-08T10:39:23.769Z'
+                  email: Louis.Greenfelder@example.com
+                  middle_names: Rice
                   training_route:
-                  sex: '12'
+                  sex: '96'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   ethnic_background:
@@ -5847,7 +5667,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '5406354081593'
+                  hesa_id: '7695052399964'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -5857,43 +5677,43 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail: has_placement_detail
-                  provider_trainee_id: 23/24-1009
+                  provider_trainee_id: 23/24-228
                   lead_partner_id:
-                  ukprn: '96732450'
+                  ukprn: '89166442'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
                   course_itt_start_date:
-                  course_age_range: '13912'
+                  course_age_range: '13909'
                   expected_end_date:
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
-                  fund_code: '2'
-                  bursary_level: B
-                  previous_last_name: Grant
-                  itt_aim: '202'
+                  fund_code: '7'
+                  bursary_level: '6'
+                  previous_last_name: O'Keefe
+                  itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: B
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: '6'
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
-                  itt_qualification_aim: '032'
+                  itt_qualification_aim: '007'
                   hesa_disabilities: {}
                   nationality:
                   withdraw_reasons: []
                   placements:
-                  - urn: '878582'
-                    name: Lakeacre Secondary College
-                    postcode: WH8P 6EQ
-                    created_at: '2024-07-05T14:01:25.068Z'
-                    updated_at: '2024-07-05T14:01:25.068Z'
-                    placement_id: GBZQfj1EZaTXhVu9jg9q7UkQ
+                  - urn: '456759'
+                    name: Marblewald Secondary College
+                    postcode: YE4X 1ND
+                    created_at: '2024-07-08T10:39:23.773Z'
+                    updated_at: '2024-07-08T10:39:23.773Z'
+                    placement_id: Tj3Pw4FpWzwYXkEPxe8cprqr
                   degrees: []
                   state: draft
-                  trainee_id: hJKBa3WHutaLnxq1oYnbufd8
+                  trainee_id: AwwboxKXazHnRZDD94KSLL5q
                   application_id:
         '404':
           description: returns status 404 with a valid JSON response
@@ -5949,7 +5769,7 @@ paths:
         required: true
         schema:
           type: string
-        example: ro94Z94ndfkc88HPZYiqri2k
+        example: ykr6FGBFmzrNdzmvAeBxxjWt
       responses:
         '200':
           description: returns status 200 with a valid JSON response
@@ -5984,12 +5804,12 @@ paths:
                 - data
               example:
                 data:
-                  urn: '230891'
-                  name: Lakeacre High
-                  postcode: KE1M 4BB
-                  created_at: '2024-07-05T14:00:51.931Z'
-                  updated_at: '2024-07-05T14:00:51.931Z'
-                  placement_id: k6cPJFkgytcxuY69ESMwwFo8
+                  urn: '893393'
+                  name: Bluemeadow Secondary College
+                  postcode: ZR8 0AB
+                  created_at: '2024-07-08T10:39:23.925Z'
+                  updated_at: '2024-07-08T10:39:23.925Z'
+                  placement_id: 382ZSBbCpxf3NkeqFTW67QbD
         '404':
           description: returns status 404 with a valid JSON response
           content:
@@ -6031,13 +5851,13 @@ paths:
         required: true
         schema:
           type: string
-        example: BKBVpWtXaRMSYNJpxsms7SCc
+        example: oh3HnsRFtzC33f7HzhFALFTL
       - name: trainee_slug
         in: path
         required: true
         schema:
           type: string
-        example: YK8LXwmMjDcxF95Tk7RoDGAD
+        example: VyAwx2W1Av4PxqwRDbovjkYw
       requestBody:
         content:
           application/json:
@@ -6068,14 +5888,14 @@ paths:
               - data
             example:
               data:
-                address: 1455 Eliz Forest
-                name: Eastern Marvin Academy
-                postcode: GU1 1AA
-                urn: '709181'
+                address: 849 Crist Crest
+                name: Southern Kub Academy
+                postcode: TR9B 7JB
+                urn: '331763'
                 school_id:
       responses:
         '200':
-          description: partial update of an existing placement returns 200 (ok) status
+          description: creates a new placement and returns a 200 (ok) status
           content:
             application/json:
               schema:
@@ -6107,12 +5927,12 @@ paths:
                 - data
               example:
                 data:
-                  urn: '304657'
-                  name: Icelyn High School
-                  postcode: Y8U 6FA
-                  created_at: '2024-07-05T14:00:49.860Z'
-                  updated_at: '2024-07-05T14:00:49.900Z'
-                  placement_id: 2g5tyhodhQ48Q4QTjudS58Hv
+                  urn: '331763'
+                  name: Southern Kub Academy
+                  postcode: TR9B 7JB
+                  created_at: '2024-07-08T10:39:43.311Z'
+                  updated_at: '2024-07-08T10:39:43.372Z'
+                  placement_id: jZg4syqpqgnQcM4JXvJefboE
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -6184,7 +6004,7 @@ paths:
         required: true
         schema:
           type: string
-        example: QTFAXgCv6NNeMpuGStcKiHLY
+        example: rsyZqD8TCF9UG7SyyjJxqUx4
       responses:
         '202':
           description: recommends the trainee for a qts award
@@ -6266,6 +6086,7 @@ paths:
                         nullable: true
                       training_initiative:
                         type: string
+                        nullable: true
                       study_mode:
                         nullable: true
                       ebacc:
@@ -6347,6 +6168,7 @@ paths:
                           properties:
                             uk_degree:
                               type: string
+                              nullable: true
                             non_uk_degree:
                               nullable: true
                             created_at:
@@ -6361,6 +6183,7 @@ paths:
                               type: integer
                             grade:
                               type: string
+                              nullable: true
                             country:
                               nullable: true
                             other_grade:
@@ -6477,14 +6300,14 @@ paths:
                 - data
               example:
                 data:
-                  recommended_for_award_at: '2024-07-05T14:00:52Z'
-                  first_names: Trinidad
-                  middle_names: Rath
-                  last_name: Rath
-                  email: Trinidad.Rath@example.com
+                  recommended_for_award_at: '2024-07-08T10:38:56Z'
+                  first_names: Carmelo
+                  middle_names: Schuppe
+                  last_name: Frami
+                  email: Carmelo.Frami@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '2411953'
+                  trn: '5684863'
                   withdraw_reasons_details:
                   withdraw_reasons_dfe_details:
                   region:
@@ -6492,26 +6315,26 @@ paths:
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
-                  date_of_birth: '1995-03-09'
-                  created_at: '2024-07-05T14:00:52.736Z'
-                  updated_at: '2024-07-05T14:00:52.736Z'
+                  date_of_birth: '1998-06-07'
+                  created_at: '2024-07-08T10:38:56.148Z'
+                  updated_at: '2024-07-08T10:38:56.148Z'
                   training_route:
-                  sex: '96'
+                  sex: '11'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2023-08-08'
-                  outcome_date: '2024-07-05'
-                  itt_end_date: '2024-07-08'
-                  submitted_for_trn_at: '2024-07-05T14:00:52.736Z'
+                  itt_start_date: '2023-08-23'
+                  outcome_date: '2024-07-08'
+                  itt_end_date: '2024-07-01'
+                  submitted_for_trn_at: '2024-07-08T10:38:56.148Z'
                   withdraw_date:
                   defer_date:
-                  trainee_start_date: '2023-08-22'
+                  trainee_start_date: '2023-09-03'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
                   awarded_at:
-                  training_initiative: '026'
+                  training_initiative: '025'
                   study_mode:
                   ebacc: false
                   course_education_phase: secondary
@@ -6530,42 +6353,42 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-217
+                  provider_trainee_id: 23/24-58
                   lead_partner_id:
-                  ukprn: '72433722'
+                  ukprn: '13094273'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2023-08-08'
+                  course_itt_start_date: '2023-08-23'
                   course_age_range:
-                  expected_end_date: '2024-07-08'
+                  expected_end_date: '2024-07-01'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
                   fund_code:
                   bursary_level:
-                  nationality: JO
+                  nationality: CU
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '305'
+                  - uk_degree: '204'
                     non_uk_degree:
-                    created_at: '2024-07-05T14:00:52.736Z'
-                    updated_at: '2024-07-05T14:00:52.736Z'
-                    subject: '100632'
-                    institution: '0050'
-                    graduation_year: 2006
-                    grade: '01'
+                    created_at: '2024-07-08T10:38:56.148Z'
+                    updated_at: '2024-07-08T10:38:56.148Z'
+                    subject: '101078'
+                    institution: '0359'
+                    graduation_year: 1990
+                    grade: '12'
                     country:
                     other_grade:
-                    institution_uuid: b1c53e05-7042-e811-80ff-3863bb3640b8
-                    uk_degree_uuid: 656a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: a18270f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: WLpjxh3vCuGvSWKrC7YSsZdv
+                    institution_uuid: f43e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 436a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 358570f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
+                    degree_id: ekZsrhZQP3GGFarzyrEXeYir
                   state: recommended_for_award
-                  trainee_id: QTFAXgCv6NNeMpuGStcKiHLY
+                  trainee_id: rsyZqD8TCF9UG7SyyjJxqUx4
                   application_id:
         '404':
           description: returns 404
@@ -6634,7 +6457,7 @@ paths:
               - data
             example:
               data:
-                qts_standards_met_date: '2024-07-05'
+                qts_standards_met_date: '2024-07-08'
   "/api/{api_version}/trainees/{trainee_slug}/withdraw":
     post:
       summary: create
@@ -6652,7 +6475,7 @@ paths:
         required: true
         schema:
           type: string
-        example: dyetNWMCUwNMG3RrsaYA28oP
+        example: 7TrH5iWoFspkRKmZhasakJGy
       requestBody:
         content:
           application/json:
@@ -6677,15 +6500,16 @@ paths:
             example:
               reasons:
               - unknown
-              withdraw_date: 2024-07-05 14:01:06 UTC
-              withdraw_reasons_details: When I was a cop, this was my beat. I’m the
-                Black Dog and when I bite I don’t let go. I have no regrets about
-                her, but I’ll settle this score on my own turf.
-              withdraw_reasons_dfe_details: I'm going up to my room now, where I may
-                die.
+              withdraw_date: 2024-07-08 10:38:56 UTC
+              withdraw_reasons_details: The past is the past and the future is the
+                future. A man is a man and a woman is a woman. The present is the
+                present. I am who I am and you are who you are. That's all there is
+                to it. Does it really matter? Or do we just think it does?
+              withdraw_reasons_dfe_details: I finally get a bouquet and it's a goodbye
+                present. That's depressing.
       responses:
         '200':
-          description: change the trainee
+          description: returns status 200 with a valid JSON response
           content:
             application/json:
               schema:
@@ -6872,6 +6696,7 @@ paths:
                           properties:
                             uk_degree:
                               type: string
+                              nullable: true
                             non_uk_degree:
                               nullable: true
                             created_at:
@@ -6880,8 +6705,10 @@ paths:
                               type: string
                             subject:
                               type: string
+                              nullable: true
                             institution:
                               type: string
+                              nullable: true
                             graduation_year:
                               type: integer
                             grade:
@@ -7063,43 +6890,45 @@ paths:
               example:
                 data:
                   commencement_status:
-                  withdraw_date: '2024-07-05T14:01:06.000Z'
-                  withdraw_reasons_details: When I was a cop, this was my beat. I’m
-                    the Black Dog and when I bite I don’t let go. I have no regrets
-                    about her, but I’ll settle this score on my own turf.
-                  withdraw_reasons_dfe_details: I'm going up to my room now, where
-                    I may die.
-                  updated_at: '2024-07-05T14:01:06.294Z'
-                  first_names: Mitchell
-                  middle_names: Hilll
-                  last_name: McClure
-                  email: Mitchell.McClure@example.com
+                  withdraw_date: '2024-07-08T10:38:56.000Z'
+                  withdraw_reasons_details: The past is the past and the future is
+                    the future. A man is a man and a woman is a woman. The present
+                    is the present. I am who I am and you are who you are. That's
+                    all there is to it. Does it really matter? Or do we just think
+                    it does?
+                  withdraw_reasons_dfe_details: I finally get a bouquet and it's a
+                    goodbye present. That's depressing.
+                  updated_at: '2024-07-08T10:38:56.688Z'
+                  first_names: Von
+                  middle_names: Spencer
+                  last_name: Ratke
+                  email: Von.Ratke@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '3195976'
+                  trn: '8511518'
                   region:
-                  hesa_id: '2075563986795'
+                  hesa_id: '8042487765244'
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '1995-04-15'
-                  created_at: '2024-07-05T14:01:06.281Z'
+                  date_of_birth: '1981-06-04'
+                  created_at: '2024-07-08T10:38:56.677Z'
                   training_route:
-                  sex: '10'
+                  sex: '12'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
                   itt_start_date: '2023-08-27'
                   outcome_date:
-                  itt_end_date: '2025-07-20'
-                  submitted_for_trn_at: '2024-07-05T14:01:06.285Z'
+                  itt_end_date: '2024-07-08'
+                  submitted_for_trn_at: '2024-07-08T10:38:56.681Z'
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2023-08-30'
+                  trainee_start_date: '2023-09-05'
                   reinstate_date:
                   course_min_age: 11
-                  course_max_age: 18
+                  course_max_age: 16
                   awarded_at:
                   training_initiative:
                   study_mode: '01'
@@ -7118,56 +6947,56 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-232
+                  provider_trainee_id: 23/24-69
                   lead_partner_id:
-                  ukprn: '12849068'
+                  ukprn: '59178626'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
                   course_itt_start_date: '2023-08-27'
-                  course_age_range: '13917'
-                  expected_end_date: '2025-07-20'
+                  course_age_range: '13911'
+                  expected_end_date: '2024-07-08'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
                   fund_code: '2'
-                  bursary_level: B
-                  previous_last_name: Cremin
+                  bursary_level: '8'
+                  previous_last_name: Grimes
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
-                  pg_apprenticeship_start_date: '2024-07-05'
-                  funding_method: B
+                  pg_apprenticeship_start_date: '2024-07-08'
+                  funding_method: '8'
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
-                  itt_qualification_aim: '003'
+                  itt_qualification_aim: '020'
                   hesa_disabilities: {}
-                  nationality: AE
+                  nationality: MM
                   withdraw_reasons:
                   - unknown
                   placements: []
                   degrees:
-                  - uk_degree: '302'
+                  - uk_degree: '210'
                     non_uk_degree:
-                    created_at: '2024-07-05T14:01:06.295Z'
-                    updated_at: '2024-07-05T14:01:06.295Z'
-                    subject: '101202'
-                    institution: '0049'
-                    graduation_year: 1982
-                    grade: '14'
+                    created_at: '2024-07-08T10:38:56.689Z'
+                    updated_at: '2024-07-08T10:38:56.689Z'
+                    subject: '100588'
+                    institution: '0083'
+                    graduation_year: 1981
+                    grade: '03'
                     country:
                     other_grade:
-                    institution_uuid: dfdb7129-7042-e811-80ff-3863bb3640b8
-                    uk_degree_uuid: 5f6a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: ed8570f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                    degree_id: 8w8YbMBNP3f3df1BbYqxinBM
+                    institution_uuid: 7eda4db6-a141-e811-80ff-3863bb351d40
+                    uk_degree_uuid: 4f6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 638270f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
+                    degree_id: EYcgJriGVZh65bUremGq573w
                   state: withdrawn
-                  trainee_id: UhRq6M56D1JbiXXrrtX4LpEj
+                  trainee_id: 7TrH5iWoFspkRKmZhasakJGy
                   application_id:
-                  id: 190
-                  dttp_id: 4c58db6b-b7aa-42e6-836c-5ee5fcf14a19
+                  id: 30
+                  dttp_id: df7b696c-f28a-4439-9aea-e5614325c301
                   progress:
                     personal_details: true
                     contact_details: true
@@ -7181,9 +7010,9 @@ paths:
                     schools: true
                     funding: true
                     iqts_country: false
-                  provider_id: 208
+                  provider_id: 36
                   placement_assignment_dttp_id:
-                  slug: cbfB7yAAGHxKJB32XPjQDaoa
+                  slug: wbr3AfxjeN6NT6qQvMp2wi2J
                   dttp_update_sha:
                   dormancy_dttp_id:
                   lead_school_id:

--- a/public/openapi/v1.0.yaml
+++ b/public/openapi/v1.0.yaml
@@ -8,16 +8,16 @@ paths:
     get:
       summary: show
       tags:
-        - Api::Info
+      - Api::Info
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
       responses:
-        "200":
+        '200':
           description: shows the requested version
           content:
             application/json:
@@ -34,11 +34,11 @@ paths:
                       latest:
                         type: string
                     required:
-                      - requested
-                      - latest
+                    - requested
+                    - latest
                 required:
-                  - status
-                  - version
+                - status
+                - version
               example:
                 status: ok
                 version:
@@ -48,59 +48,59 @@ paths:
     get:
       summary: index
       tags:
-        - Api::Trainee
+      - Api::Trainee
       parameters:
-        - name: academic_cycle
-          in: query
-          required: false
-          schema:
-            type: string
-          example: not-a-number
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: has_trn
-          in: query
-          required: false
-          schema:
-            type: string
-          example: "false"
-        - name: page
-          in: query
-          required: false
-          schema:
-            type: integer
-          example: 1
-        - name: per_page
-          in: query
-          required: false
-          schema:
-            type: integer
-          example: 5
-        - name: since
-          in: query
-          required: false
-          schema:
-            type: string
-          example: "2024-03-15T13:15:37.880Z"
-        - name: sort_order
-          in: query
-          required: false
-          schema:
-            type: string
-          example: asc
-        - name: status
-          in: query
-          required: false
-          schema:
-            type: string
-          example: deferred
+      - name: academic_cycle
+        in: query
+        required: false
+        schema:
+          type: string
+        example: not-a-number
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: has_trn
+        in: query
+        required: false
+        schema:
+          nullable: true
+        example: 'false'
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+        example: 1
+      - name: per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+        example: 5
+      - name: since
+        in: query
+        required: false
+        schema:
+          type: string
+        example: '2024-03-15T13:15:37.880Z'
+      - name: sort_order
+        in: query
+        required: false
+        schema:
+          type: string
+        example: asc
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+        example: invalid_state
       responses:
-        "200":
-          description: returns trainees updated after the specified date
+        '200':
+          description: returns all the trainees
           content:
             application/json:
               schema:
@@ -324,106 +324,109 @@ paths:
                               degree_id:
                                 type: string
                             required:
-                              - uk_degree
-                              - non_uk_degree
-                              - created_at
-                              - updated_at
-                              - subject
-                              - institution
-                              - graduation_year
-                              - grade
-                              - country
-                              - other_grade
-                              - institution_uuid
-                              - uk_degree_uuid
-                              - subject_uuid
-                              - grade_uuid
-                              - degree_id
+                            - uk_degree
+                            - non_uk_degree
+                            - created_at
+                            - updated_at
+                            - subject
+                            - institution
+                            - graduation_year
+                            - grade
+                            - country
+                            - other_grade
+                            - institution_uuid
+                            - uk_degree_uuid
+                            - subject_uuid
+                            - grade_uuid
+                            - degree_id
                         state:
                           type: string
                         trainee_id:
                           type: string
                         application_id:
                           type: integer
+                          nullable: true
                         pg_apprenticeship_start_date:
                           type: string
                         withdraw_reasons:
                           type: array
                           items: {}
+                        lead_partner_id:
+                          nullable: true
                       required:
-                        - first_names
-                        - last_name
-                        - date_of_birth
-                        - created_at
-                        - updated_at
-                        - email
-                        - middle_names
-                        - training_route
-                        - sex
-                        - diversity_disclosure
-                        - ethnic_group
-                        - ethnic_background
-                        - additional_ethnic_background
-                        - disability_disclosure
-                        - course_subject_one
-                        - itt_start_date
-                        - outcome_date
-                        - itt_end_date
-                        - trn
-                        - submitted_for_trn_at
-                        - withdraw_date
-                        - withdraw_reasons_details
-                        - defer_date
-                        - recommended_for_award_at
-                        - trainee_start_date
-                        - reinstate_date
-                        - course_min_age
-                        - course_max_age
-                        - course_subject_two
-                        - course_subject_three
-                        - awarded_at
-                        - training_initiative
-                        - study_mode
-                        - ebacc
-                        - region
-                        - course_education_phase
-                        - course_uuid
-                        - lead_school_not_applicable
-                        - employing_school_not_applicable
-                        - submission_ready
-                        - commencement_status
-                        - discarded_at
-                        - created_from_dttp
-                        - hesa_id
-                        - additional_dttp_data
-                        - created_from_hesa
-                        - hesa_updated_at
-                        - record_source
-                        - iqts_country
-                        - hesa_editable
-                        - withdraw_reasons_dfe_details
-                        - slug_sent_to_dqt_at
-                        - placement_detail
-                        - provider_trainee_id
-                        - ukprn
-                        - ethnicity
-                        - course_qualification
-                        - course_title
-                        - course_level
-                        - course_itt_start_date
-                        - course_age_range
-                        - expected_end_date
-                        - employing_school_urn
-                        - lead_partner_urn_ukprn
-                        - lead_school_urn
-                        - fund_code
-                        - bursary_level
-                        - nationality
-                        - placements
-                        - degrees
-                        - state
-                        - trainee_id
-                        - application_id
+                      - first_names
+                      - last_name
+                      - date_of_birth
+                      - created_at
+                      - updated_at
+                      - email
+                      - middle_names
+                      - training_route
+                      - sex
+                      - diversity_disclosure
+                      - ethnic_group
+                      - ethnic_background
+                      - additional_ethnic_background
+                      - disability_disclosure
+                      - course_subject_one
+                      - itt_start_date
+                      - outcome_date
+                      - itt_end_date
+                      - trn
+                      - submitted_for_trn_at
+                      - withdraw_date
+                      - withdraw_reasons_details
+                      - defer_date
+                      - recommended_for_award_at
+                      - trainee_start_date
+                      - reinstate_date
+                      - course_min_age
+                      - course_max_age
+                      - course_subject_two
+                      - course_subject_three
+                      - awarded_at
+                      - training_initiative
+                      - study_mode
+                      - ebacc
+                      - region
+                      - course_education_phase
+                      - course_uuid
+                      - lead_school_not_applicable
+                      - employing_school_not_applicable
+                      - submission_ready
+                      - commencement_status
+                      - discarded_at
+                      - created_from_dttp
+                      - hesa_id
+                      - additional_dttp_data
+                      - created_from_hesa
+                      - hesa_updated_at
+                      - record_source
+                      - iqts_country
+                      - hesa_editable
+                      - withdraw_reasons_dfe_details
+                      - slug_sent_to_dqt_at
+                      - placement_detail
+                      - provider_trainee_id
+                      - ukprn
+                      - ethnicity
+                      - course_qualification
+                      - course_title
+                      - course_level
+                      - course_itt_start_date
+                      - course_age_range
+                      - expected_end_date
+                      - employing_school_urn
+                      - lead_partner_urn_ukprn
+                      - lead_school_urn
+                      - fund_code
+                      - bursary_level
+                      - nationality
+                      - placements
+                      - degrees
+                      - state
+                      - trainee_id
+                      - application_id
                   meta:
                     type: object
                     properties:
@@ -436,814 +439,1202 @@ paths:
                       per_page:
                         type: integer
                     required:
-                      - current_page
-                      - total_pages
-                      - total_count
-                      - per_page
+                    - current_page
+                    - total_pages
+                    - total_count
+                    - per_page
                 required:
-                  - data
-                  - meta
+                - data
+                - meta
               example:
                 data:
-                  - first_names: Sabra
-                    last_name: Johnson
-                    date_of_birth: "2000-09-21"
-                    created_at: "2024-06-19T12:13:15.684Z"
-                    updated_at: "2024-06-19T12:13:15.693Z"
-                    email: Sabra.Johnson@example.com
-                    middle_names: Dach
-                    training_route:
-                    sex: "11"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100403"
-                    itt_start_date: "2023-08-12"
-                    outcome_date:
-                    itt_end_date: "2024-07-14"
-                    trn: "2759846"
-                    submitted_for_trn_at: "2024-06-19T12:13:15.687Z"
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-08-16"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 18
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative: "026"
-                    study_mode: "01"
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: true
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id: "9619283759475"
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-1009
-                    ukprn: "58505074"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: postgrad
-                    course_itt_start_date: "2023-08-12"
-                    course_age_range: "13914"
-                    expected_end_date: "2024-07-14"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code: "2"
-                    bursary_level: "6"
-                    previous_last_name: Cruickshank
-                    itt_aim: "202"
-                    course_study_mode: "01"
-                    course_year: 2024
-                    pg_apprenticeship_start_date: "2024-06-19"
-                    funding_method: "6"
-                    ni_number: QQ 12 34 56 C
-                    additional_training_initiative: "026"
-                    itt_qualification_aim: "032"
-                    hesa_disabilities: {}
-                    nationality: KW
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree: "076"
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:13:15.694Z"
-                        updated_at: "2024-06-19T12:13:15.694Z"
-                        subject: "100887"
-                        institution: "0420"
-                        graduation_year: 2015
-                        grade: "03"
-                        country:
-                        other_grade:
-                        institution_uuid: 343e182c-1425-ec11-b6e6-000d3adf095a
-                        uk_degree_uuid: 0d6a5652-c197-e711-80d8-005056ac45bb
-                        subject_uuid: 2d8470f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
-                        degree_id: A2KeWNwyyrSZHRJF1Vq9E1ZQ
-                    state: trn_received
-                    trainee_id: Ao9ksdiSntx4bRrJYwSMuydZ
-                    application_id: 123456
-                  - first_names: Joel
-                    last_name: Kohler
-                    date_of_birth: "1975-07-05"
-                    created_at: "2024-06-19T12:13:15.642Z"
-                    updated_at: "2024-06-19T12:13:15.651Z"
-                    email: Joel.Kohler@example.com
-                    middle_names: Brakus
-                    training_route:
-                    sex: "12"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100403"
-                    itt_start_date: "2023-08-06"
-                    outcome_date:
-                    itt_end_date: "2024-07-08"
-                    trn: "6603807"
-                    submitted_for_trn_at: "2024-06-19T12:13:15.645Z"
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-08-12"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 18
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative:
-                    study_mode: "01"
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: true
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id: "3827256288911"
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-1006
-                    ukprn: "58505074"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: postgrad
-                    course_itt_start_date: "2023-08-06"
-                    course_age_range: "13916"
-                    expected_end_date: "2024-07-08"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code: "2"
-                    bursary_level: "6"
-                    previous_last_name: Koelpin
-                    itt_aim: "202"
-                    course_study_mode: "01"
-                    course_year: 2024
-                    pg_apprenticeship_start_date: "2024-06-19"
-                    funding_method: "6"
-                    ni_number: QQ 12 34 56 C
-                    additional_training_initiative: "026"
-                    itt_qualification_aim: "020"
-                    hesa_disabilities: {}
-                    nationality: KW
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree: "083"
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:13:15.652Z"
-                        updated_at: "2024-06-19T12:13:15.652Z"
-                        subject: "100418"
-                        institution: "0204"
-                        graduation_year: 2016
-                        grade: "02"
-                        country:
-                        other_grade:
-                        institution_uuid: 2671f34a-2887-e711-80d8-005056ac45bb
-                        uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
-                        subject_uuid: 838170f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                        degree_id: 4dshtbbXe68oMNRts4WDR2cM
-                    state: trn_received
-                    trainee_id: xEn8hSApdnKrN9mwvYzdVpHZ
-                    application_id: 123456
-                  - first_names: Santos
-                    last_name: Nikolaus
-                    date_of_birth: "1991-06-21"
-                    created_at: "2024-06-19T12:13:15.602Z"
-                    updated_at: "2024-06-19T12:13:15.610Z"
-                    email: Santos.Nikolaus@example.com
-                    middle_names: Kunze
-                    training_route:
-                    sex: "10"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100403"
-                    itt_start_date: "2023-08-02"
-                    outcome_date:
-                    itt_end_date: "2024-07-27"
-                    trn: "9201832"
-                    submitted_for_trn_at: "2024-06-19T12:13:15.604Z"
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-08-16"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 16
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative:
-                    study_mode: "01"
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: true
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id: "3235342811624"
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-1003
-                    ukprn: "58505074"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: postgrad
-                    course_itt_start_date: "2023-08-02"
-                    course_age_range: "13913"
-                    expected_end_date: "2024-07-27"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code: "7"
-                    bursary_level: B
-                    previous_last_name: Christiansen
-                    itt_aim: "202"
-                    course_study_mode: "01"
-                    course_year: 2024
-                    pg_apprenticeship_start_date: "2024-06-19"
-                    funding_method: B
-                    ni_number: QQ 12 34 56 C
-                    additional_training_initiative: "026"
-                    itt_qualification_aim: "008"
-                    hesa_disabilities: {}
-                    nationality: KW
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree: "065"
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:13:15.611Z"
-                        updated_at: "2024-06-19T12:13:15.611Z"
-                        subject: "100748"
-                        institution: "0089"
-                        graduation_year: 2011
-                        grade: "02"
-                        country:
-                        other_grade:
-                        institution_uuid: 07f35f0b-7042-e811-80ff-3863bb3640b8
-                        uk_degree_uuid: f7695652-c197-e711-80d8-005056ac45bb
-                        subject_uuid: 498370f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                        degree_id: DXnhGgiQCJZ5XLiKyhdYBNME
-                    state: trn_received
-                    trainee_id: jgUhjP1mwzwNSbZGjry491Y5
-                    application_id: 123456
-                  - first_names: Jeffry
-                    last_name: Hilpert
-                    date_of_birth: "1998-06-07"
-                    created_at: "2024-06-19T12:13:15.561Z"
-                    updated_at: "2024-06-19T12:13:15.569Z"
-                    email: Jeffry.Hilpert@example.com
-                    middle_names: Brekke
-                    training_route:
-                    sex: "11"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100403"
-                    itt_start_date: "2023-08-27"
-                    outcome_date:
-                    itt_end_date: "2025-07-26"
-                    trn: "7005493"
-                    submitted_for_trn_at: "2024-06-19T12:13:15.564Z"
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-09-11"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 18
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative:
-                    study_mode: "01"
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: true
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id: "5919905750685"
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-1000
-                    ukprn: "58505074"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: postgrad
-                    course_itt_start_date: "2023-08-27"
-                    course_age_range: "13912"
-                    expected_end_date: "2025-07-26"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code: "7"
-                    bursary_level: "7"
-                    previous_last_name: Lockman
-                    itt_aim: "202"
-                    course_study_mode: "01"
-                    course_year: 2024
-                    pg_apprenticeship_start_date: "2024-06-19"
-                    funding_method: "7"
-                    ni_number: QQ 12 34 56 C
-                    additional_training_initiative: "026"
-                    itt_qualification_aim: "002"
-                    hesa_disabilities: {}
-                    nationality: KW
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree:
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:13:15.570Z"
-                        updated_at: "2024-06-19T12:13:15.570Z"
-                        subject: "100454"
-                        institution: "0430"
-                        graduation_year: 2021
-                        grade: "13"
-                        country:
-                        other_grade:
-                        institution_uuid: eb3e182c-1425-ec11-b6e6-000d3adf095a
-                        uk_degree_uuid: fdafdcd7-5f21-4363-b7d5-c1f44a852af1
-                        subject_uuid: bb8170f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: df874702-2bcc-4aab-adaa-2efdd3a8dec4
-                        degree_id: NmQ8XUrR7pvgBZUfGmnvTj5R
-                    state: trn_received
-                    trainee_id: XMnVazraBgHFv63jt4FeD8i5
-                    application_id: 123456
-                  - first_names: Etha
-                    last_name: Morar
-                    date_of_birth: "1982-10-11"
-                    created_at: "2024-06-19T12:13:15.525Z"
-                    updated_at: "2024-06-19T12:13:15.532Z"
-                    email: Etha.Morar@example.com
-                    middle_names: Greenholt
-                    training_route:
-                    sex: "12"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100403"
-                    itt_start_date: "2023-08-27"
-                    outcome_date:
-                    itt_end_date: "2025-07-16"
-                    trn: "5655180"
-                    submitted_for_trn_at: "2024-06-19T12:13:15.527Z"
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-08-28"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 16
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative: "009"
-                    study_mode: "01"
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: true
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id: "1083974357910"
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-997
-                    ukprn: "58505074"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: postgrad
-                    course_itt_start_date: "2023-08-27"
-                    course_age_range: "13913"
-                    expected_end_date: "2025-07-16"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code: "7"
-                    bursary_level: E
-                    previous_last_name: Paucek
-                    itt_aim: "201"
-                    course_study_mode: "01"
-                    course_year: 2024
-                    pg_apprenticeship_start_date: "2024-06-19"
-                    funding_method: E
-                    ni_number: QQ 12 34 56 C
-                    additional_training_initiative: "026"
-                    itt_qualification_aim: "003"
-                    hesa_disabilities: {}
-                    nationality: KW
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree: "068"
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:13:15.533Z"
-                        updated_at: "2024-06-19T12:13:15.533Z"
-                        subject: "100251"
-                        institution: "0271"
-                        graduation_year: 1985
-                        grade: "05"
-                        country:
-                        other_grade:
-                        institution_uuid: e93e182c-1425-ec11-b6e6-000d3adf095a
-                        uk_degree_uuid: fd695652-c197-e711-80d8-005056ac45bb
-                        subject_uuid: 6d8070f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
-                        degree_id: HzWXDZfHy9DyVTRWTAirPkBT
-                    state: trn_received
-                    trainee_id: XeGMD8KWqy8URNxTWpWgstnB
-                    application_id: 123456
-                  - first_names: Helen
-                    last_name: Orn
-                    date_of_birth: "2006-05-07"
-                    created_at: "2024-06-19T12:13:15.484Z"
-                    updated_at: "2024-06-19T12:13:15.493Z"
-                    email: Helen.Orn@example.com
-                    middle_names: Kirlin
-                    training_route:
-                    sex: "96"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100403"
-                    itt_start_date: "2023-08-22"
-                    outcome_date:
-                    itt_end_date: "2025-07-07"
-                    trn: "1730122"
-                    submitted_for_trn_at: "2024-06-19T12:13:15.487Z"
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-08-29"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 18
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative: "025"
-                    study_mode: "01"
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: true
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id: "3411815991343"
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-994
-                    ukprn: "58505074"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: postgrad
-                    course_itt_start_date: "2023-08-22"
-                    course_age_range: "13912"
-                    expected_end_date: "2025-07-07"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code: "2"
-                    bursary_level: "9"
-                    previous_last_name: Emmerich
-                    itt_aim: "201"
-                    course_study_mode: "01"
-                    course_year: 2024
-                    pg_apprenticeship_start_date: "2024-06-19"
-                    funding_method: "9"
-                    ni_number: QQ 12 34 56 C
-                    additional_training_initiative: "026"
-                    itt_qualification_aim: "007"
-                    hesa_disabilities: {}
-                    nationality: KW
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree: "086"
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:13:15.494Z"
-                        updated_at: "2024-06-19T12:13:15.494Z"
-                        subject: "101440"
-                        institution: "0131"
-                        graduation_year: 1991
-                        grade: "12"
-                        country:
-                        other_grade:
-                        institution_uuid: d270f34a-2887-e711-80d8-005056ac45bb
-                        uk_degree_uuid: 216a5652-c197-e711-80d8-005056ac45bb
-                        subject_uuid: 2b8770f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                        degree_id: 1AZHNyhUus5M8MzZrswTiNob
-                    state: trn_received
-                    trainee_id: 4PrezGaRVEe7EFGks37L6g1j
-                    application_id: 123456
-                  - first_names: Neal
-                    last_name: Collier
-                    date_of_birth: "1972-07-25"
-                    created_at: "2024-06-19T12:13:15.441Z"
-                    updated_at: "2024-06-19T12:13:15.450Z"
-                    email: Neal.Collier@example.com
-                    middle_names: Effertz
-                    training_route:
-                    sex: "99"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100403"
-                    itt_start_date: "2023-08-18"
-                    outcome_date:
-                    itt_end_date: "2024-07-08"
-                    trn: "4320628"
-                    submitted_for_trn_at: "2024-06-19T12:13:15.444Z"
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-08-21"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 16
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative: "009"
-                    study_mode: "01"
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: true
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id: "8752479240451"
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-991
-                    ukprn: "58505074"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: postgrad
-                    course_itt_start_date: "2023-08-18"
-                    course_age_range: "13919"
-                    expected_end_date: "2024-07-08"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code: "7"
-                    bursary_level: C
-                    previous_last_name: Hagenes
-                    itt_aim: "202"
-                    course_study_mode: "01"
-                    course_year: 2024
-                    pg_apprenticeship_start_date: "2024-06-19"
-                    funding_method: C
-                    ni_number: QQ 12 34 56 C
-                    additional_training_initiative: "026"
-                    itt_qualification_aim: "031"
-                    hesa_disabilities: {}
-                    nationality: KW
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree: "083"
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:13:15.451Z"
-                        updated_at: "2024-06-19T12:13:15.451Z"
-                        subject: "100590"
-                        institution: "0196"
-                        graduation_year: 1970
-                        grade: "03"
-                        country:
-                        other_grade:
-                        institution_uuid: 283f182c-1425-ec11-b6e6-000d3adf095a
-                        uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
-                        subject_uuid: 678270f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
-                        degree_id: AL3GCCPLJf7jgbVJcVJiHhCE
-                    state: trn_received
-                    trainee_id: sufXXzpuLc8BcHDC2E8jxCaW
-                    application_id: 123456
-                  - first_names: Pia
-                    last_name: Smith
-                    date_of_birth: "1977-05-12"
-                    created_at: "2024-06-19T12:13:15.398Z"
-                    updated_at: "2024-06-19T12:13:15.406Z"
-                    email: Pia.Smith@example.com
-                    middle_names: Hintz
-                    training_route:
-                    sex: "11"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100403"
-                    itt_start_date: "2023-08-26"
-                    outcome_date:
-                    itt_end_date: "2024-07-08"
-                    trn: "1782514"
-                    submitted_for_trn_at: "2024-06-19T12:13:15.401Z"
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-08-29"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 16
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative: "009"
-                    study_mode: "01"
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: true
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id: "6843839631350"
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-988
-                    ukprn: "58505074"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: postgrad
-                    course_itt_start_date: "2023-08-26"
-                    course_age_range: "13919"
-                    expected_end_date: "2024-07-08"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code: "7"
-                    bursary_level: D
-                    previous_last_name: Bechtelar
-                    itt_aim: "201"
-                    course_study_mode: "01"
-                    course_year: 2024
-                    pg_apprenticeship_start_date: "2024-06-19"
-                    funding_method: D
-                    ni_number: QQ 12 34 56 C
-                    additional_training_initiative: "026"
-                    itt_qualification_aim: "004"
-                    hesa_disabilities: {}
-                    nationality: KW
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree: "301"
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:13:15.407Z"
-                        updated_at: "2024-06-19T12:13:15.407Z"
-                        subject: "101344"
-                        institution: "0138"
-                        graduation_year: 1986
-                        grade: "02"
-                        country:
-                        other_grade:
-                        institution_uuid: 853e182c-1425-ec11-b6e6-000d3adf095a
-                        uk_degree_uuid: 5d6a5652-c197-e711-80d8-005056ac45bb
-                        subject_uuid: 838670f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                        degree_id: tsTeRmka4eMD7UNX1RqdQcyW
-                    state: trn_received
-                    trainee_id: sZq9wHLfQKdhGWm1hyw7Bx4p
-                    application_id: 123456
+                - first_names: Socorro
+                  last_name: Pouros
+                  date_of_birth: '1964-10-03'
+                  created_at: '2024-07-05T14:01:20.292Z'
+                  updated_at: '2024-07-05T14:01:20.297Z'
+                  email: Socorro.Pouros@example.com
+                  middle_names: Heidenreich
+                  training_route:
+                  sex: '11'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-12'
+                  outcome_date:
+                  itt_end_date: '2025-07-11'
+                  trn:
+                  submitted_for_trn_at: '2024-07-05T14:01:20.287Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-14'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '036'
+                  study_mode:
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id:
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-822
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-12'
+                  course_age_range:
+                  expected_end_date: '2025-07-11'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code:
+                  bursary_level:
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '088'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:20.293Z'
+                    updated_at: '2024-07-05T14:01:20.293Z'
+                    subject: '100090'
+                    institution: '0046'
+                    graduation_year: 2005
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: 4871f34a-2887-e711-80d8-005056ac45bb
+                    uk_degree_uuid: 256a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 7b7f70f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: qiJ4AkjzvF2REp8ArBoPZDMk
+                  state: submitted_for_trn
+                  trainee_id: 4SYQLH9A2zTPkAqsD6KnUve6
+                  application_id:
+                - first_names: Maurita
+                  last_name: Okuneva
+                  date_of_birth: '1986-08-18'
+                  created_at: '2024-07-05T14:01:20.262Z'
+                  updated_at: '2024-07-05T14:01:20.268Z'
+                  email: Maurita.Okuneva@example.com
+                  middle_names: Langosh
+                  training_route:
+                  sex: '96'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-19'
+                  outcome_date:
+                  itt_end_date: '2025-07-20'
+                  trn:
+                  submitted_for_trn_at: '2024-07-05T14:01:20.257Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-21'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '036'
+                  study_mode:
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id:
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-820
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-19'
+                  course_age_range:
+                  expected_end_date: '2025-07-20'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code:
+                  bursary_level:
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '307'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:20.264Z'
+                    updated_at: '2024-07-05T14:01:20.264Z'
+                    subject: '100518'
+                    institution: '0276'
+                    graduation_year: 2003
+                    grade: '14'
+                    country:
+                    other_grade:
+                    institution_uuid: 813e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 03d6b7af-499c-49e3-96cc-e63f9beda6e5
+                    subject_uuid: 1b8270f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
+                    degree_id: 7VwUCZsJZX3zn8KLvBX5owV6
+                  state: submitted_for_trn
+                  trainee_id: B7ZnSpsmB8M7jBNqssQsRvo1
+                  application_id:
+                - first_names: Jeffry
+                  last_name: Buckridge
+                  date_of_birth: '1959-08-01'
+                  created_at: '2024-07-05T14:01:20.221Z'
+                  updated_at: '2024-07-05T14:01:20.232Z'
+                  email: Jeffry.Buckridge@example.com
+                  middle_names: Kunde
+                  training_route:
+                  sex: '12'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-01'
+                  outcome_date:
+                  itt_end_date: '2024-07-09'
+                  trn: '6504567'
+                  submitted_for_trn_at: '2024-07-05T14:01:20.225Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-03'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative:
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '6504925000263'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-817
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-01'
+                  course_age_range: '13912'
+                  expected_end_date: '2024-07-09'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '2'
+                  bursary_level: C
+                  previous_last_name: Beatty
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: C
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '031'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '097'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:20.233Z'
+                    updated_at: '2024-07-05T14:01:20.233Z'
+                    subject: '101166'
+                    institution: '0232'
+                    graduation_year: 1994
+                    grade: '12'
+                    country:
+                    other_grade:
+                    institution_uuid: 0e3e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 376a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: b78570f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
+                    degree_id: eySojJnzKp26LRgnuYF74moM
+                  state: trn_received
+                  trainee_id: M69Ea14SQzRDYxpuPLQjvd9d
+                  application_id:
+                - first_names: Rene
+                  last_name: Stoltenberg
+                  date_of_birth: '1984-12-17'
+                  created_at: '2024-07-05T14:01:20.168Z'
+                  updated_at: '2024-07-05T14:01:20.179Z'
+                  email: Rene.Stoltenberg@example.com
+                  middle_names: Bartell
+                  training_route:
+                  sex: '11'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-25'
+                  outcome_date:
+                  itt_end_date: '2025-07-01'
+                  trn: '1505498'
+                  submitted_for_trn_at: '2024-07-05T14:01:20.172Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-09-06'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative:
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '8042087712775'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-814
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-25'
+                  course_age_range: '13912'
+                  expected_end_date: '2025-07-01'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: C
+                  previous_last_name: Armstrong
+                  itt_aim: '201'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: C
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '031'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '302'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:20.180Z'
+                    updated_at: '2024-07-05T14:01:20.180Z'
+                    subject: '100190'
+                    institution: '0160'
+                    graduation_year: 2000
+                    grade:
+                    country:
+                    other_grade:
+                    institution_uuid: 4f5b7f3b-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: 5f6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 138070f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
+                    degree_id: 1jVwMAtvtzVnrgxeza5XTAHh
+                  state: trn_received
+                  trainee_id: Dcyp7Axw1ZwTjvPnjKUtpoQo
+                  application_id:
+                - first_names: Deanna
+                  last_name: Will
+                  date_of_birth: '1997-04-28'
+                  created_at: '2024-07-05T14:01:20.114Z'
+                  updated_at: '2024-07-05T14:01:20.125Z'
+                  email: Deanna.Will@example.com
+                  middle_names: Fay
+                  training_route:
+                  sex: '99'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-21'
+                  outcome_date:
+                  itt_end_date: '2025-07-01'
+                  trn: '6437999'
+                  submitted_for_trn_at: '2024-07-05T14:01:20.118Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-21'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '026'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '5571954658327'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-811
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-21'
+                  course_age_range: '13919'
+                  expected_end_date: '2025-07-01'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '2'
+                  bursary_level: '6'
+                  previous_last_name: Shanahan
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: '6'
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '008'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '096'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:20.126Z'
+                    updated_at: '2024-07-05T14:01:20.126Z'
+                    subject: '100059'
+                    institution: '0237'
+                    graduation_year: 1992
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: 693e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 356a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 4d7f70f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: Yzx8gPFoxjE2wXfJf3V2N95b
+                  state: trn_received
+                  trainee_id: WeF9VUeSWpRzhyxKUr4wpAXa
+                  application_id:
+                - first_names: Minh
+                  last_name: Prohaska
+                  date_of_birth: '1978-10-04'
+                  created_at: '2024-07-05T14:01:20.059Z'
+                  updated_at: '2024-07-05T14:01:20.070Z'
+                  email: Minh.Prohaska@example.com
+                  middle_names: Rutherford
+                  training_route:
+                  sex: '11'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-22'
+                  outcome_date:
+                  itt_end_date: '2024-07-17'
+                  trn: '1023438'
+                  submitted_for_trn_at: '2024-07-05T14:01:20.063Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-28'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '025'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '9885648558845'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-808
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-22'
+                  course_age_range: '13919'
+                  expected_end_date: '2024-07-17'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '2'
+                  bursary_level: '8'
+                  previous_last_name: Beer
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: '8'
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '020'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '080'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:20.071Z'
+                    updated_at: '2024-07-05T14:01:20.071Z'
+                    subject: '101086'
+                    institution: '1078'
+                    graduation_year: 2007
+                    grade:
+                    country:
+                    other_grade:
+                    institution_uuid: 20e5a08c-ee97-e711-80d8-005056ac45bb
+                    uk_degree_uuid: 156a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 438570f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
+                    degree_id: ive1CVahKrRtNn4onDNsmZr6
+                  state: trn_received
+                  trainee_id: Rqzrt7NQ3yd5vPqny3pTY9Un
+                  application_id:
+                - first_names: Bessie
+                  last_name: Koss
+                  date_of_birth: '1969-03-21'
+                  created_at: '2024-07-05T14:01:19.995Z'
+                  updated_at: '2024-07-05T14:01:20.006Z'
+                  email: Bessie.Koss@example.com
+                  middle_names: Bosco
+                  training_route:
+                  sex: '99'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-06'
+                  outcome_date:
+                  itt_end_date: '2024-07-08'
+                  trn: '9673388'
+                  submitted_for_trn_at: '2024-07-05T14:01:19.998Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-06'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative:
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '7510394639476'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-805
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-06'
+                  course_age_range: '13916'
+                  expected_end_date: '2024-07-08'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: B
+                  previous_last_name: Wisozk
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: B
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '020'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree:
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:20.007Z'
+                    updated_at: '2024-07-05T14:01:20.007Z'
+                    subject: '101499'
+                    institution: '0041'
+                    graduation_year: 2009
+                    grade: '03'
+                    country:
+                    other_grade:
+                    institution_uuid: 054b9247-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: '0584565a-1c98-4c1d-ae64-c241542c0879'
+                    subject_uuid: 9d8770f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
+                    degree_id: FMuz8Rk8yNzsMcvjq4Ua3SkS
+                  state: trn_received
+                  trainee_id: UN2CPPzc9YGP8DN7mp5YA3st
+                  application_id:
+                - first_names: Jewell
+                  last_name: Kling
+                  date_of_birth: '1970-01-01'
+                  created_at: '2024-07-05T14:01:19.936Z'
+                  updated_at: '2024-07-05T14:01:19.948Z'
+                  email: Jewell.Kling@example.com
+                  middle_names: O'Hara
+                  training_route:
+                  sex: '99'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-07'
+                  outcome_date:
+                  itt_end_date: '2024-07-01'
+                  trn: '4794364'
+                  submitted_for_trn_at: '2024-07-05T14:01:19.940Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-08'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative:
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '9948317790562'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-802
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-07'
+                  course_age_range: '13911'
+                  expected_end_date: '2024-07-01'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '2'
+                  bursary_level: '4'
+                  previous_last_name: Aufderhar
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: '4'
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '007'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '054'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:19.949Z'
+                    updated_at: '2024-07-05T14:01:19.949Z'
+                    subject: '100526'
+                    institution: '0018'
+                    graduation_year: 1983
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: 1b369414-75d9-e911-a863-000d3ab0da57
+                    uk_degree_uuid: e1695652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 258270f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: YVEwjyxqCj4kbwQZT83FbikY
+                  state: trn_received
+                  trainee_id: ibNBVvEeWRrgQo4W9k8yEX5a
+                  application_id:
+                - first_names: Dalton
+                  last_name: Schaden
+                  date_of_birth: '1986-01-12'
+                  created_at: '2024-07-05T14:01:19.876Z'
+                  updated_at: '2024-07-05T14:01:19.887Z'
+                  email: Dalton.Schaden@example.com
+                  middle_names: Streich
+                  training_route:
+                  sex: '11'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-13'
+                  outcome_date:
+                  itt_end_date: '2025-07-12'
+                  trn: '7960771'
+                  submitted_for_trn_at: '2024-07-05T14:01:19.880Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-27'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative:
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '3313884277621'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-799
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-13'
+                  course_age_range: '13915'
+                  expected_end_date: '2025-07-12'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: E
+                  previous_last_name: Erdman
+                  itt_aim: '201'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: E
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '032'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '058'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:19.888Z'
+                    updated_at: '2024-07-05T14:01:19.888Z'
+                    subject: '101215'
+                    institution: '0201'
+                    graduation_year: 2003
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: 18f35f0b-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: e9695652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: ff8570f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: W1XaShpkxgxZXM2UDRwG8T7y
+                  state: trn_received
+                  trainee_id: 1bv4hCywV3BFG98kUPtL9mou
+                  application_id:
+                - first_names: Chantal
+                  last_name: Hayes
+                  date_of_birth: '2000-02-01'
+                  created_at: '2024-07-05T14:01:19.819Z'
+                  updated_at: '2024-07-05T14:01:19.831Z'
+                  email: Chantal.Hayes@example.com
+                  middle_names: Powlowski
+                  training_route:
+                  sex: '12'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-15'
+                  outcome_date:
+                  itt_end_date: '2025-07-01'
+                  trn: '8299836'
+                  submitted_for_trn_at: '2024-07-05T14:01:19.824Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-18'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '025'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '4129803593133'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-796
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-15'
+                  course_age_range: '13912'
+                  expected_end_date: '2025-07-01'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '2'
+                  bursary_level: '9'
+                  previous_last_name: Wilkinson
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: '9'
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '021'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '218'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:19.832Z'
+                    updated_at: '2024-07-05T14:01:19.832Z'
+                    subject: '101086'
+                    institution: '0335'
+                    graduation_year: 1984
+                    grade: '13'
+                    country:
+                    other_grade:
+                    institution_uuid: 4f3e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: b6d2c5aa-cf99-4831-9bfe-6279349d8ea9
+                    subject_uuid: 438570f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: df874702-2bcc-4aab-adaa-2efdd3a8dec4
+                    degree_id: PCucMDPdai3BSBKiCup48HHf
+                  state: trn_received
+                  trainee_id: 8BT6S7ewq4Eczs46AGTmnY9G
+                  application_id:
+                - first_names: Lindsay
+                  last_name: Gorczany
+                  date_of_birth: '1985-06-26'
+                  created_at: '2024-07-05T14:01:19.761Z'
+                  updated_at: '2024-07-05T14:01:19.772Z'
+                  email: Lindsay.Gorczany@example.com
+                  middle_names: Schinner
+                  training_route:
+                  sex: '11'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-15'
+                  outcome_date:
+                  itt_end_date: '2025-07-29'
+                  trn: '9236830'
+                  submitted_for_trn_at: '2024-07-05T14:01:19.765Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-15'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative:
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '8966456160140'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-793
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-15'
+                  course_age_range: '13919'
+                  expected_end_date: '2025-07-29'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: E
+                  previous_last_name: Kuhic
+                  itt_aim: '201'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: E
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '020'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '057'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:19.773Z'
+                    updated_at: '2024-07-05T14:01:19.773Z'
+                    subject: '100410'
+                    institution: '0270'
+                    graduation_year: 2003
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: ed3e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: e7695652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 778170f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: 2Q9S3iMr7QfWTxxEqRkAR3L8
+                  state: trn_received
+                  trainee_id: Ksco6S1oWi1ZHAgdLs5LgAny
+                  application_id:
+                - first_names: Verda
+                  last_name: Paucek
+                  date_of_birth: '1959-08-21'
+                  created_at: '2024-07-05T14:01:19.697Z'
+                  updated_at: '2024-07-05T14:01:19.710Z'
+                  email: Verda.Paucek@example.com
+                  middle_names: Lind
+                  training_route:
+                  sex: '96'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-19'
+                  outcome_date:
+                  itt_end_date: '2025-07-26'
+                  trn: '5019807'
+                  submitted_for_trn_at: '2024-07-05T14:01:19.701Z'
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-25'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative: '025'
+                  study_mode: '01'
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id: '9921649899686'
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-790
+                  lead_partner_id:
+                  ukprn: '71285009'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-19'
+                  course_age_range: '13911'
+                  expected_end_date: '2025-07-26'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code: '7'
+                  bursary_level: '6'
+                  previous_last_name: Herman
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: '6'
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '028'
+                  hesa_disabilities: {}
+                  nationality: CK
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '203'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:19.711Z'
+                    updated_at: '2024-07-05T14:01:19.711Z'
+                    subject: '100369'
+                    institution: '0210'
+                    graduation_year: 2016
+                    grade: '14'
+                    country:
+                    other_grade:
+                    institution_uuid: 154b9247-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: 416a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 358170f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
+                    degree_id: 4XgciB9Lf6nw5jvxcAK5i1zf
+                  state: trn_received
+                  trainee_id: qo3kmJw8ARAFpzikbhfFY4fi
+                  application_id:
                 meta:
                   current_page: 1
                   total_pages: 1
-                  total_count: 8
+                  total_count: 12
                   per_page: 50
-        "422":
-          description: returns 422 if since filter is an invalid date
+        '422':
+          description: returns 422 if academic cycle filter is invalid
           content:
             application/json:
               schema:
@@ -1267,33 +1658,32 @@ paths:
                         items:
                           type: string
                 required:
-                  - message
-                  - errors
+                - message
+                - errors
               example:
-                message:
-                  "Validation failed: 1 error prohibited this request being
-                  run"
+                message: 'Validation failed: 1 error prohibited this request being
+                  run'
                 errors:
                   academic_cycle:
-                    - not-a-number is not a valid academic cycle year
+                  - not-a-number is not a valid academic cycle year
                   since:
-                    - 2023-13-01 is not a valid date
+                  - 2023-13-01 is not a valid date
                   status:
-                    - invalid_state is not a valid status
+                  - invalid_state is not a valid status
     post:
       summary: create
       tags:
-        - Api::Trainee
+      - Api::Trainee
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
       responses:
-        "201":
-          description: sets the ethnic attributes based on ethnicity
+        '201':
+          description: creates the degrees with the correct graduation_year
           content:
             application/json:
               schema:
@@ -1493,12 +1883,12 @@ paths:
                             placement_id:
                               type: string
                           required:
-                            - urn
-                            - name
-                            - postcode
-                            - created_at
-                            - updated_at
-                            - placement_id
+                          - urn
+                          - name
+                          - postcode
+                          - created_at
+                          - updated_at
+                          - placement_id
                       degrees:
                         type: array
                         items:
@@ -1535,116 +1925,121 @@ paths:
                             degree_id:
                               type: string
                           required:
-                            - uk_degree
-                            - non_uk_degree
-                            - created_at
-                            - updated_at
-                            - subject
-                            - institution
-                            - graduation_year
-                            - grade
-                            - country
-                            - other_grade
-                            - institution_uuid
-                            - uk_degree_uuid
-                            - subject_uuid
-                            - grade_uuid
-                            - degree_id
+                          - uk_degree
+                          - non_uk_degree
+                          - created_at
+                          - updated_at
+                          - subject
+                          - institution
+                          - graduation_year
+                          - grade
+                          - country
+                          - other_grade
+                          - institution_uuid
+                          - uk_degree_uuid
+                          - subject_uuid
+                          - grade_uuid
+                          - degree_id
                       state:
                         type: string
                       trainee_id:
                         type: string
                       application_id:
                         type: integer
+                        nullable: true
                       disability1:
                         type: string
                       disability2:
                         type: string
+                      lead_partner_id:
+                        nullable: true
                     required:
-                      - first_names
-                      - last_name
-                      - date_of_birth
-                      - created_at
-                      - updated_at
-                      - email
-                      - middle_names
-                      - training_route
-                      - sex
-                      - diversity_disclosure
-                      - ethnic_group
-                      - ethnic_background
-                      - additional_ethnic_background
-                      - disability_disclosure
-                      - course_subject_one
-                      - itt_start_date
-                      - outcome_date
-                      - itt_end_date
-                      - trn
-                      - submitted_for_trn_at
-                      - withdraw_date
-                      - withdraw_reasons_details
-                      - defer_date
-                      - recommended_for_award_at
-                      - trainee_start_date
-                      - reinstate_date
-                      - course_min_age
-                      - course_max_age
-                      - course_subject_two
-                      - course_subject_three
-                      - awarded_at
-                      - training_initiative
-                      - study_mode
-                      - ebacc
-                      - region
-                      - course_education_phase
-                      - course_uuid
-                      - lead_school_not_applicable
-                      - employing_school_not_applicable
-                      - submission_ready
-                      - commencement_status
-                      - discarded_at
-                      - created_from_dttp
-                      - hesa_id
-                      - additional_dttp_data
-                      - created_from_hesa
-                      - hesa_updated_at
-                      - record_source
-                      - iqts_country
-                      - hesa_editable
-                      - withdraw_reasons_dfe_details
-                      - slug_sent_to_dqt_at
-                      - placement_detail
-                      - provider_trainee_id
-                      - ukprn
-                      - ethnicity
-                      - course_qualification
-                      - course_title
-                      - course_level
-                      - course_itt_start_date
-                      - course_age_range
-                      - expected_end_date
-                      - employing_school_urn
-                      - lead_partner_urn_ukprn
-                      - lead_school_urn
-                      - fund_code
-                      - bursary_level
-                      - previous_last_name
-                      - itt_aim
-                      - course_study_mode
-                      - course_year
-                      - pg_apprenticeship_start_date
-                      - funding_method
-                      - ni_number
-                      - additional_training_initiative
-                      - itt_qualification_aim
-                      - hesa_disabilities
-                      - nationality
-                      - withdraw_reasons
-                      - placements
-                      - degrees
-                      - state
-                      - trainee_id
-                      - application_id
+                    - first_names
+                    - last_name
+                    - date_of_birth
+                    - created_at
+                    - updated_at
+                    - email
+                    - middle_names
+                    - training_route
+                    - sex
+                    - diversity_disclosure
+                    - ethnic_group
+                    - ethnic_background
+                    - additional_ethnic_background
+                    - disability_disclosure
+                    - course_subject_one
+                    - itt_start_date
+                    - outcome_date
+                    - itt_end_date
+                    - trn
+                    - submitted_for_trn_at
+                    - withdraw_date
+                    - withdraw_reasons_details
+                    - defer_date
+                    - recommended_for_award_at
+                    - trainee_start_date
+                    - reinstate_date
+                    - course_min_age
+                    - course_max_age
+                    - course_subject_two
+                    - course_subject_three
+                    - awarded_at
+                    - training_initiative
+                    - study_mode
+                    - ebacc
+                    - region
+                    - course_education_phase
+                    - course_uuid
+                    - lead_school_not_applicable
+                    - employing_school_not_applicable
+                    - submission_ready
+                    - commencement_status
+                    - discarded_at
+                    - created_from_dttp
+                    - hesa_id
+                    - additional_dttp_data
+                    - created_from_hesa
+                    - hesa_updated_at
+                    - record_source
+                    - iqts_country
+                    - hesa_editable
+                    - withdraw_reasons_dfe_details
+                    - slug_sent_to_dqt_at
+                    - placement_detail
+                    - provider_trainee_id
+                    - ukprn
+                    - ethnicity
+                    - course_qualification
+                    - course_title
+                    - course_level
+                    - course_itt_start_date
+                    - course_age_range
+                    - expected_end_date
+                    - employing_school_urn
+                    - lead_partner_urn_ukprn
+                    - lead_school_urn
+                    - fund_code
+                    - bursary_level
+                    - previous_last_name
+                    - itt_aim
+                    - course_study_mode
+                    - course_year
+                    - pg_apprenticeship_start_date
+                    - funding_method
+                    - ni_number
+                    - additional_training_initiative
+                    - itt_qualification_aim
+                    - hesa_disabilities
+                    - nationality
+                    - withdraw_reasons
+                    - placements
+                    - degrees
+                    - state
+                    - trainee_id
+                    - application_id
+                required:
+                - data
               example:
                 middle_names:
                 additional_ethnic_background:
@@ -1680,37 +2075,37 @@ paths:
                 data:
                   first_names: John
                   last_name: Doe
-                  date_of_birth: "1990-01-01"
-                  created_at: "2024-06-19T12:13:00.060Z"
-                  updated_at: "2024-06-19T12:13:00.060Z"
+                  date_of_birth: '1990-01-01'
+                  created_at: '2024-07-05T14:01:05.264Z'
+                  updated_at: '2024-07-05T14:01:05.264Z'
                   email: john.doe@example.com
                   middle_names:
-                  training_route: "11"
-                  sex: "10"
+                  training_route: '11'
+                  sex: '96'
                   diversity_disclosure: diversity_disclosed
-                  ethnic_group: other_ethnic_group
-                  ethnic_background: Another ethnic background
+                  ethnic_group: not_provided_ethnic_group
+                  ethnic_background: Not provided
                   additional_ethnic_background:
                   disability_disclosure: disabled
-                  course_subject_one: "100346"
-                  itt_start_date: "2023-01-01"
+                  course_subject_one: '100346'
+                  itt_start_date: '2023-01-01'
                   outcome_date:
-                  itt_end_date: "2023-10-01"
+                  itt_end_date: '2023-10-01'
                   trn:
-                  submitted_for_trn_at: "2024-06-19T12:13:00.103Z"
+                  submitted_for_trn_at: '2024-07-05T14:01:05.316Z'
                   withdraw_date:
                   withdraw_reasons_details:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: "2023-01-01"
+                  trainee_start_date: '2023-01-01'
                   reinstate_date:
-                  course_min_age: 11
+                  course_min_age: 3
                   course_max_age:
                   course_subject_two:
                   course_subject_three:
                   awarded_at:
                   training_initiative:
-                  study_mode: "63"
+                  study_mode: '63'
                   ebacc: false
                   region:
                   course_education_phase: secondary
@@ -1721,7 +2116,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: "0310261553101"
+                  hesa_id: '0310261553101'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1732,64 +2127,64 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 99157234/2/01
-                  ukprn: "17152456"
-                  ethnicity: "899"
+                  ukprn: '16807767'
+                  ethnicity: '997'
                   course_qualification: QTS
                   course_title:
                   course_level: undergrad
-                  course_itt_start_date: "2023-01-01"
-                  course_age_range: "13919"
-                  expected_end_date: "2023-10-01"
+                  course_itt_start_date: '2023-01-01'
+                  course_age_range: '13909'
+                  expected_end_date: '2023-10-01'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
-                  fund_code: "7"
-                  bursary_level: "4"
+                  fund_code: '7'
+                  bursary_level: '4'
                   previous_last_name: Smith
-                  itt_aim: "202"
-                  course_study_mode: "63"
+                  itt_aim: '202'
+                  course_study_mode: '63'
                   course_year: 2012
-                  pg_apprenticeship_start_date: "2024-03-11"
-                  funding_method: "4"
+                  pg_apprenticeship_start_date: '2024-03-11'
+                  funding_method: '4'
                   ni_number:
                   additional_training_initiative:
-                  itt_qualification_aim: "001"
+                  itt_qualification_aim: '001'
                   hesa_disabilities:
-                    disability1: "58"
-                    disability2: "57"
+                    disability1: '58'
+                    disability2: '57'
                   nationality: GB
                   withdraw_reasons: []
                   placements:
-                    - urn: "900020"
-                      name: Establishment does not have a URN
-                      postcode:
-                      created_at: "2024-06-19T12:13:00.068Z"
-                      updated_at: "2024-06-19T12:13:00.068Z"
-                      placement_id: NaqoEqZDwcARRxwKZLe4vAGW
+                  - urn: '900020'
+                    name: Establishment does not have a URN
+                    postcode:
+                    created_at: '2024-07-05T14:01:05.275Z'
+                    updated_at: '2024-07-05T14:01:05.275Z'
+                    placement_id: KASN9hNie299zDnN9sMDj3kc
                   degrees:
-                    - uk_degree: "083"
-                      non_uk_degree:
-                      created_at: "2024-06-19T12:13:00.061Z"
-                      updated_at: "2024-06-19T12:13:00.061Z"
-                      subject: "100485"
-                      institution: "0117"
-                      graduation_year: 2003
-                      grade: "02"
-                      country:
-                      other_grade:
-                      institution_uuid: 1271f34a-2887-e711-80d8-005056ac45bb
-                      uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
-                      subject_uuid: e78170f0-5dce-e911-a985-000d3ab79618
-                      grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                      degree_id: bsJQAVmE6u9xZej9X1s3a7zR
+                  - uk_degree: '083'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:05.265Z'
+                    updated_at: '2024-07-05T14:01:05.265Z'
+                    subject: '100485'
+                    institution: '0117'
+                    graduation_year: 2003
+                    grade: '02'
+                    country:
+                    other_grade:
+                    institution_uuid: 1271f34a-2887-e711-80d8-005056ac45bb
+                    uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: e78170f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
+                    degree_id: LeN3RMwRm9BwCDv9qHEh1Pdy
                   state: submitted_for_trn
-                  trainee_id: pXk1xxHTWeDjnyimW2kbNsY5
-                  application_id: 123456
-                  disability1: "58"
-                  disability2: "57"
-        "409":
-          description:
-            returns status 409 (conflict) with the potential duplicates
+                  trainee_id: dFykBJmCNgeiwpU1A71qDiBu
+                  application_id:
+                  disability1: '58'
+                  disability2: '57'
+                  lead_partner_id:
+        '409':
+          description: returns status 409 (conflict) with the potential duplicates
             and does not create a trainee record
           content:
             application/json:
@@ -1980,200 +2375,204 @@ paths:
                               degree_id:
                                 type: string
                             required:
-                              - uk_degree
-                              - non_uk_degree
-                              - created_at
-                              - updated_at
-                              - subject
-                              - institution
-                              - graduation_year
-                              - grade
-                              - country
-                              - other_grade
-                              - institution_uuid
-                              - uk_degree_uuid
-                              - subject_uuid
-                              - grade_uuid
-                              - degree_id
+                            - uk_degree
+                            - non_uk_degree
+                            - created_at
+                            - updated_at
+                            - subject
+                            - institution
+                            - graduation_year
+                            - grade
+                            - country
+                            - other_grade
+                            - institution_uuid
+                            - uk_degree_uuid
+                            - subject_uuid
+                            - grade_uuid
+                            - degree_id
                         state:
                           type: string
                         trainee_id:
                           type: string
                         application_id:
                           type: integer
+                          nullable: true
                         withdraw_reasons:
                           type: array
                           items: {}
+                        lead_partner_id:
+                          nullable: true
                       required:
-                        - first_names
-                        - last_name
-                        - date_of_birth
-                        - created_at
-                        - updated_at
-                        - email
-                        - middle_names
-                        - training_route
-                        - sex
-                        - diversity_disclosure
-                        - ethnic_group
-                        - ethnic_background
-                        - additional_ethnic_background
-                        - disability_disclosure
-                        - course_subject_one
-                        - itt_start_date
-                        - outcome_date
-                        - itt_end_date
-                        - trn
-                        - submitted_for_trn_at
-                        - withdraw_date
-                        - withdraw_reasons_details
-                        - defer_date
-                        - recommended_for_award_at
-                        - trainee_start_date
-                        - reinstate_date
-                        - course_min_age
-                        - course_max_age
-                        - course_subject_two
-                        - course_subject_three
-                        - awarded_at
-                        - training_initiative
-                        - study_mode
-                        - ebacc
-                        - region
-                        - course_education_phase
-                        - course_uuid
-                        - lead_school_not_applicable
-                        - employing_school_not_applicable
-                        - submission_ready
-                        - commencement_status
-                        - discarded_at
-                        - created_from_dttp
-                        - hesa_id
-                        - additional_dttp_data
-                        - created_from_hesa
-                        - hesa_updated_at
-                        - record_source
-                        - iqts_country
-                        - hesa_editable
-                        - withdraw_reasons_dfe_details
-                        - slug_sent_to_dqt_at
-                        - placement_detail
-                        - provider_trainee_id
-                        - ukprn
-                        - ethnicity
-                        - course_qualification
-                        - course_title
-                        - course_level
-                        - course_itt_start_date
-                        - course_age_range
-                        - expected_end_date
-                        - employing_school_urn
-                        - lead_partner_urn_ukprn
-                        - lead_school_urn
-                        - fund_code
-                        - bursary_level
-                        - nationality
-                        - placements
-                        - degrees
-                        - state
-                        - trainee_id
-                        - application_id
+                      - first_names
+                      - last_name
+                      - date_of_birth
+                      - created_at
+                      - updated_at
+                      - email
+                      - middle_names
+                      - training_route
+                      - sex
+                      - diversity_disclosure
+                      - ethnic_group
+                      - ethnic_background
+                      - additional_ethnic_background
+                      - disability_disclosure
+                      - course_subject_one
+                      - itt_start_date
+                      - outcome_date
+                      - itt_end_date
+                      - trn
+                      - submitted_for_trn_at
+                      - withdraw_date
+                      - withdraw_reasons_details
+                      - defer_date
+                      - recommended_for_award_at
+                      - trainee_start_date
+                      - reinstate_date
+                      - course_min_age
+                      - course_max_age
+                      - course_subject_two
+                      - course_subject_three
+                      - awarded_at
+                      - training_initiative
+                      - study_mode
+                      - ebacc
+                      - region
+                      - course_education_phase
+                      - course_uuid
+                      - lead_school_not_applicable
+                      - employing_school_not_applicable
+                      - submission_ready
+                      - commencement_status
+                      - discarded_at
+                      - created_from_dttp
+                      - hesa_id
+                      - additional_dttp_data
+                      - created_from_hesa
+                      - hesa_updated_at
+                      - record_source
+                      - iqts_country
+                      - hesa_editable
+                      - withdraw_reasons_dfe_details
+                      - slug_sent_to_dqt_at
+                      - placement_detail
+                      - provider_trainee_id
+                      - ukprn
+                      - ethnicity
+                      - course_qualification
+                      - course_title
+                      - course_level
+                      - course_itt_start_date
+                      - course_age_range
+                      - expected_end_date
+                      - employing_school_urn
+                      - lead_partner_urn_ukprn
+                      - lead_school_urn
+                      - fund_code
+                      - bursary_level
+                      - nationality
+                      - placements
+                      - degrees
+                      - state
+                      - trainee_id
+                      - application_id
                 required:
-                  - errors
-                  - data
+                - errors
+                - data
               example:
                 errors: This trainee is already in Register
                 data:
-                  - first_names: Pete
-                    last_name: Bahringer
-                    date_of_birth: "1973-11-05"
-                    created_at: "2024-06-19T12:12:51.030Z"
-                    updated_at: "2024-06-19T12:12:51.033Z"
-                    email: Pete.Bahringer@example.com
-                    middle_names: Dickens
-                    training_route: "11"
-                    sex: "11"
-                    diversity_disclosure: diversity_not_disclosed
-                    ethnic_group:
-                    ethnic_background:
-                    additional_ethnic_background:
-                    disability_disclosure:
-                    course_subject_one: "100346"
-                    itt_start_date: "2023-08-01"
-                    outcome_date:
-                    itt_end_date: "2026-07-08"
-                    trn:
-                    submitted_for_trn_at:
-                    withdraw_date:
-                    withdraw_reasons_details:
-                    defer_date:
-                    recommended_for_award_at:
-                    trainee_start_date: "2023-08-02"
-                    reinstate_date:
-                    course_min_age: 11
-                    course_max_age: 18
-                    course_subject_two:
-                    course_subject_three:
-                    awarded_at:
-                    training_initiative: "036"
-                    study_mode:
-                    ebacc: false
-                    region:
-                    course_education_phase: secondary
-                    course_uuid:
-                    lead_school_not_applicable: false
-                    employing_school_not_applicable: false
-                    submission_ready: false
-                    commencement_status:
-                    discarded_at:
-                    created_from_dttp: false
-                    hesa_id:
-                    additional_dttp_data:
-                    created_from_hesa: false
-                    hesa_updated_at:
-                    record_source: manual
-                    iqts_country:
-                    hesa_editable: false
-                    withdraw_reasons_dfe_details:
-                    slug_sent_to_dqt_at:
-                    placement_detail:
-                    provider_trainee_id: 23/24-187
-                    ukprn: "76460237"
-                    ethnicity:
-                    course_qualification: QTS
-                    course_title:
-                    course_level: undergrad
-                    course_itt_start_date: "2023-08-01"
-                    course_age_range:
-                    expected_end_date: "2026-07-08"
-                    employing_school_urn:
-                    lead_partner_urn_ukprn:
-                    lead_school_urn:
-                    fund_code:
-                    bursary_level:
-                    nationality:
-                    withdraw_reasons: []
-                    placements: []
-                    degrees:
-                      - uk_degree: "306"
-                        non_uk_degree:
-                        created_at: "2024-06-19T12:12:51.032Z"
-                        updated_at: "2024-06-19T12:12:51.032Z"
-                        subject: "100890"
-                        institution: "0422"
-                        graduation_year: 2025
-                        grade: "03"
-                        country:
-                        other_grade:
-                        institution_uuid: 653e182c-1425-ec11-b6e6-000d3adf095a
-                        uk_degree_uuid: 676a5652-c197-e711-80d8-005056ac45bb
-                        subject_uuid: 318470f0-5dce-e911-a985-000d3ab79618
-                        grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
-                        degree_id: ZdwgQjiwhLiRKo8mVQHLrqDB
-                    state: draft
-                    trainee_id: cqKwM5X8AkrtPdtxeFEpXEUR
-                    application_id: 123456
-        "422":
+                - first_names: Delilah
+                  last_name: Keebler
+                  date_of_birth: '2006-03-03'
+                  created_at: '2024-07-05T14:01:26.066Z'
+                  updated_at: '2024-07-05T14:01:26.069Z'
+                  email: Delilah.Keebler@example.com
+                  middle_names: Stokes
+                  training_route: '11'
+                  sex: '11'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  ethnic_background:
+                  additional_ethnic_background:
+                  disability_disclosure:
+                  course_subject_one: '100346'
+                  itt_start_date: '2023-08-01'
+                  outcome_date:
+                  itt_end_date: '2026-07-29'
+                  trn:
+                  submitted_for_trn_at:
+                  withdraw_date:
+                  withdraw_reasons_details:
+                  defer_date:
+                  recommended_for_award_at:
+                  trainee_start_date: '2023-08-02'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 16
+                  course_subject_two:
+                  course_subject_three:
+                  awarded_at:
+                  training_initiative:
+                  study_mode:
+                  ebacc: false
+                  region:
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: false
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  hesa_id:
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  withdraw_reasons_dfe_details:
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-1027
+                  lead_partner_id:
+                  ukprn: '38804311'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: undergrad
+                  course_itt_start_date: '2023-08-01'
+                  course_age_range:
+                  expected_end_date: '2026-07-29'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code:
+                  bursary_level:
+                  nationality:
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '059'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:26.068Z'
+                    updated_at: '2024-07-05T14:01:26.068Z'
+                    subject: '101334'
+                    institution: '0016'
+                    graduation_year: 1995
+                    grade: '13'
+                    country:
+                    other_grade:
+                    institution_uuid: d070f34a-2887-e711-80d8-005056ac45bb
+                    uk_degree_uuid: eb695652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: 6f8670f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: df874702-2bcc-4aab-adaa-2efdd3a8dec4
+                    degree_id: qyQGP9rJtyHrkDsACXBJXXqD
+                  state: draft
+                  trainee_id: K1ReXDfeJYTVLgFuNWK83eVE
+                  application_id:
+        '422':
           description: return status code 422 with a meaningful error message
           content:
             application/json:
@@ -2195,18 +2594,18 @@ paths:
                             items:
                               type: string
                         required:
-                          - date_of_birth
+                        - date_of_birth
                     required:
-                      - personal_details
+                    - personal_details
                 required:
-                  - errors
+                - errors
               example:
-                message:
-                  "Validation failed: 1 error prohibited this trainee from
-                  being saved"
+                message: 'Validation failed: 2 errors prohibited this trainee from
+                  being saved'
                 errors:
-                  - Hesa trainee detail attributes Course age range is not included
-                    in the list
+                - Degrees graduation year Enter a graduation year that is in the past,
+                  for example 2014
+                - Degrees graduation year Enter a valid graduation year
       requestBody:
         content:
           application/json:
@@ -2267,9 +2666,9 @@ paths:
                           subject_one:
                             type: string
                         required:
-                          - grade
-                          - subject
-                          - institution
+                        - grade
+                        - subject
+                        - institution
                     placements_attributes:
                       type: array
                       items:
@@ -2280,7 +2679,7 @@ paths:
                           urn:
                             type: string
                         required:
-                          - urn
+                        - urn
                     itt_aim:
                       type: integer
                     itt_qualification_aim:
@@ -2318,91 +2717,91 @@ paths:
                     ethnic_background:
                       type: string
                   required:
-                    - first_names
-                    - last_name
-                    - date_of_birth
-                    - sex
-                    - email
-                    - nationality
-                    - training_route
-                    - itt_start_date
-                    - itt_end_date
-                    - course_subject_one
-                    - study_mode
-                    - degrees_attributes
-                    - placements_attributes
-                    - itt_aim
-                    - itt_qualification_aim
-                    - course_year
-                    - course_age_range
-                    - fund_code
-                    - funding_method
-                    - hesa_id
+                  - first_names
+                  - last_name
+                  - date_of_birth
+                  - sex
+                  - email
+                  - nationality
+                  - training_route
+                  - itt_start_date
+                  - itt_end_date
+                  - course_subject_one
+                  - study_mode
+                  - degrees_attributes
+                  - placements_attributes
+                  - itt_aim
+                  - itt_qualification_aim
+                  - course_year
+                  - course_age_range
+                  - fund_code
+                  - funding_method
+                  - hesa_id
               required:
-                - data
+              - data
             example:
               data:
                 first_names: John
                 last_name: Doe
                 previous_last_name: Smith
-                date_of_birth: "1990-01-01"
-                sex: "10"
+                date_of_birth: '1990-01-01'
+                sex: '96'
                 email: john.doe@example.com
                 nationality: GB
-                training_route: "11"
-                itt_start_date: "2023-01-01"
-                itt_end_date: "2023-10-01"
-                course_subject_one: "100346"
-                study_mode: "63"
-                disability1: "58"
-                disability2: "57"
+                training_route: '11'
+                itt_start_date: '2023-01-01'
+                itt_end_date: '2023-10-01'
+                course_subject_one: '100346'
+                study_mode: '63'
+                disability1: '58'
+                disability2: '57'
                 degrees_attributes:
-                  - grade: "02"
-                    subject: "100485"
-                    institution: "0117"
-                    uk_degree: "083"
-                    graduation_year: "2003"
+                - grade: '02'
+                  subject: '100485'
+                  institution: '0117'
+                  uk_degree: '083'
+                  graduation_year: '2003-01-01'
                 placements_attributes:
-                  - name: Placement
-                    urn: "900020"
+                - name: Placement
+                  urn: '900020'
                 itt_aim: 202
-                itt_qualification_aim: "001"
-                course_year: "2012"
-                course_age_range: "13919"
-                fund_code: "7"
-                funding_method: "4"
-                hesa_id: "0310261553101"
+                itt_qualification_aim: '001'
+                course_year: '2012'
+                course_age_range: '13909'
+                fund_code: '7'
+                funding_method: '4'
+                hesa_id: '0310261553101'
                 provider_trainee_id: 99157234/2/01
-                pg_apprenticeship_start_date: "2024-03-11"
-                ethnicity: "899"
-                course_subject_two: "101410"
-                course_subject_three: "100366"
+                pg_apprenticeship_start_date: '2024-03-11'
+                ethnicity: '142'
+                course_subject_two: '101410'
+                course_subject_three: '100366'
                 course_max_age: 11
-                lead_school_urn: "630996"
-                employing_school_urn: ""
-                trn: "567899"
+                lead_school_urn: '322600'
+                employing_school_urn: ''
+                trn: '567899'
                 ethnic_group: mixed_ethnic_group
                 ethnic_background: Another Mixed background
-  "/api/{api_version}/trainees/traineee_id}":
+  "/api/{api_version}/trainees/{slug}":
     get:
       summary: show
       tags:
-        - Api::Trainee
+      - Api::Trainee
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          example: nonexistent
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 12345
       responses:
-        "200":
+        '200':
           description: returns the trainee
           content:
             application/json:
@@ -2517,6 +2916,8 @@ paths:
                     nullable: true
                   provider_trainee_id:
                     type: string
+                  lead_partner_id:
+                    nullable: true
                   ukprn:
                     type: string
                   ethnicity:
@@ -2580,102 +2981,103 @@ paths:
                   trainee_id:
                     type: string
                   application_id:
-                    type: integer
+                    nullable: true
                 required:
-                  - first_names
-                  - last_name
-                  - date_of_birth
-                  - created_at
-                  - updated_at
-                  - email
-                  - middle_names
-                  - training_route
-                  - sex
-                  - diversity_disclosure
-                  - ethnic_group
-                  - ethnic_background
-                  - additional_ethnic_background
-                  - disability_disclosure
-                  - course_subject_one
-                  - itt_start_date
-                  - outcome_date
-                  - itt_end_date
-                  - trn
-                  - submitted_for_trn_at
-                  - withdraw_date
-                  - withdraw_reasons_details
-                  - defer_date
-                  - recommended_for_award_at
-                  - trainee_start_date
-                  - reinstate_date
-                  - course_min_age
-                  - course_max_age
-                  - course_subject_two
-                  - course_subject_three
-                  - awarded_at
-                  - training_initiative
-                  - study_mode
-                  - ebacc
-                  - region
-                  - course_education_phase
-                  - course_uuid
-                  - lead_school_not_applicable
-                  - employing_school_not_applicable
-                  - submission_ready
-                  - commencement_status
-                  - discarded_at
-                  - created_from_dttp
-                  - hesa_id
-                  - additional_dttp_data
-                  - created_from_hesa
-                  - hesa_updated_at
-                  - record_source
-                  - iqts_country
-                  - hesa_editable
-                  - withdraw_reasons_dfe_details
-                  - slug_sent_to_dqt_at
-                  - placement_detail
-                  - provider_trainee_id
-                  - ukprn
-                  - ethnicity
-                  - course_qualification
-                  - course_title
-                  - course_level
-                  - course_itt_start_date
-                  - course_age_range
-                  - expected_end_date
-                  - employing_school_urn
-                  - lead_partner_urn_ukprn
-                  - lead_school_urn
-                  - fund_code
-                  - bursary_level
-                  - previous_last_name
-                  - itt_aim
-                  - course_study_mode
-                  - course_year
-                  - pg_apprenticeship_start_date
-                  - funding_method
-                  - ni_number
-                  - additional_training_initiative
-                  - itt_qualification_aim
-                  - hesa_disabilities
-                  - nationality
-                  - withdraw_reasons
-                  - placements
-                  - degrees
-                  - state
-                  - trainee_id
-                  - application_id
+                - first_names
+                - last_name
+                - date_of_birth
+                - created_at
+                - updated_at
+                - email
+                - middle_names
+                - training_route
+                - sex
+                - diversity_disclosure
+                - ethnic_group
+                - ethnic_background
+                - additional_ethnic_background
+                - disability_disclosure
+                - course_subject_one
+                - itt_start_date
+                - outcome_date
+                - itt_end_date
+                - trn
+                - submitted_for_trn_at
+                - withdraw_date
+                - withdraw_reasons_details
+                - defer_date
+                - recommended_for_award_at
+                - trainee_start_date
+                - reinstate_date
+                - course_min_age
+                - course_max_age
+                - course_subject_two
+                - course_subject_three
+                - awarded_at
+                - training_initiative
+                - study_mode
+                - ebacc
+                - region
+                - course_education_phase
+                - course_uuid
+                - lead_school_not_applicable
+                - employing_school_not_applicable
+                - submission_ready
+                - commencement_status
+                - discarded_at
+                - created_from_dttp
+                - hesa_id
+                - additional_dttp_data
+                - created_from_hesa
+                - hesa_updated_at
+                - record_source
+                - iqts_country
+                - hesa_editable
+                - withdraw_reasons_dfe_details
+                - slug_sent_to_dqt_at
+                - placement_detail
+                - provider_trainee_id
+                - lead_partner_id
+                - ukprn
+                - ethnicity
+                - course_qualification
+                - course_title
+                - course_level
+                - course_itt_start_date
+                - course_age_range
+                - expected_end_date
+                - employing_school_urn
+                - lead_partner_urn_ukprn
+                - lead_school_urn
+                - fund_code
+                - bursary_level
+                - previous_last_name
+                - itt_aim
+                - course_study_mode
+                - course_year
+                - pg_apprenticeship_start_date
+                - funding_method
+                - ni_number
+                - additional_training_initiative
+                - itt_qualification_aim
+                - hesa_disabilities
+                - nationality
+                - withdraw_reasons
+                - placements
+                - degrees
+                - state
+                - trainee_id
+                - application_id
               example:
-                first_names: Gwyn
-                last_name: Grant
-                date_of_birth: "1994-10-25"
-                created_at: "2024-06-19T12:13:01.368Z"
-                updated_at: "2024-06-19T12:13:01.379Z"
-                email: Gwyn.Grant@example.com
-                middle_names: Howell
+                first_names: Nancie
+                last_name: Jenkins
+                date_of_birth: '1961-09-02'
+                created_at: '2024-07-05T14:00:51.489Z'
+                updated_at: '2024-07-05T14:00:51.503Z'
+                email: Nancie.Jenkins@example.com
+                middle_names: Lang
                 training_route:
-                sex: "10"
+                sex: '12'
                 diversity_disclosure: diversity_not_disclosed
                 ethnic_group:
                 ethnic_background:
@@ -2699,7 +3101,7 @@ paths:
                 course_subject_three:
                 awarded_at:
                 training_initiative:
-                study_mode: "01"
+                study_mode: '01'
                 ebacc: false
                 region:
                 course_education_phase:
@@ -2710,7 +3112,7 @@ paths:
                 commencement_status:
                 discarded_at:
                 created_from_dttp: false
-                hesa_id: "7694396921207"
+                hesa_id: '1180575718577'
                 additional_dttp_data:
                 created_from_hesa: false
                 hesa_updated_at:
@@ -2720,38 +3122,39 @@ paths:
                 withdraw_reasons_dfe_details:
                 slug_sent_to_dqt_at:
                 placement_detail:
-                provider_trainee_id: 23/24-204
-                ukprn: "56699344"
+                provider_trainee_id: 23/24-190
+                lead_partner_id:
+                ukprn: '53368175'
                 ethnicity:
                 course_qualification: QTS
                 course_title:
                 course_level: postgrad
                 course_itt_start_date:
-                course_age_range: "13916"
+                course_age_range: '13913'
                 expected_end_date:
                 employing_school_urn:
                 lead_partner_urn_ukprn:
                 lead_school_urn:
-                fund_code: "2"
-                bursary_level: "4"
-                previous_last_name: Torp
-                itt_aim: "201"
-                course_study_mode: "01"
+                fund_code: '7'
+                bursary_level: D
+                previous_last_name: Gibson
+                itt_aim: '201'
+                course_study_mode: '01'
                 course_year: 2024
-                pg_apprenticeship_start_date: "2024-06-19"
-                funding_method: "4"
+                pg_apprenticeship_start_date: '2024-07-05'
+                funding_method: D
                 ni_number: QQ 12 34 56 C
-                additional_training_initiative: "026"
-                itt_qualification_aim: "007"
+                additional_training_initiative: '026'
+                itt_qualification_aim: '021'
                 hesa_disabilities: {}
                 nationality:
                 withdraw_reasons: []
                 placements: []
                 degrees: []
                 state: draft
-                trainee_id: "12345"
-                application_id: 123456
-        "404":
+                trainee_id: '12345'
+                application_id:
+        '404':
           description: returns a not found message
           content:
             application/json:
@@ -2768,34 +3171,34 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Trainee(s) not found
+                - error: NotFound
+                  message: Trainee(s) not found
     put:
       summary: update
       tags:
-        - Api::Trainee
+      - Api::Trainee
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          example: CscHUugnbosgW7toKLNbtd6V
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: hGJunGJSzCyU3SfzXGwobZJg
       responses:
-        "200":
-          description: updates the trainee
+        '200':
+          description: does not update the ethnic attributes
           content:
             application/json:
               schema:
@@ -2817,11 +3220,11 @@ paths:
                       email:
                         type: string
                       middle_names:
-                        type: string
                         nullable: true
+                        type: string
                       training_route:
-                        nullable: true
                         type: string
+                        nullable: true
                       sex:
                         type: string
                       diversity_disclosure:
@@ -2848,8 +3251,8 @@ paths:
                       trn:
                         nullable: true
                       submitted_for_trn_at:
-                        nullable: true
                         type: string
+                        nullable: true
                       withdraw_date:
                         nullable: true
                       withdraw_reasons_details:
@@ -2865,8 +3268,8 @@ paths:
                       course_min_age:
                         type: integer
                       course_max_age:
-                        type: integer
                         nullable: true
+                        type: integer
                       course_subject_two:
                         nullable: true
                         type: string
@@ -2920,15 +3323,15 @@ paths:
                       placement_detail:
                         nullable: true
                       provider_trainee_id:
+                        nullable: true
                         type: string
+                      lead_partner_id:
                         nullable: true
                       ukprn:
                         type: string
                       ethnicity:
                         type: string
                         nullable: true
-                      disability1:
-                        type: string
                       course_qualification:
                         type: string
                       course_title:
@@ -2942,21 +3345,21 @@ paths:
                       expected_end_date:
                         type: string
                       employing_school_urn:
-                        type: string
                         nullable: true
+                        type: string
                       lead_partner_urn_ukprn:
-                        type: string
                         nullable: true
+                        type: string
                       lead_school_urn:
-                        type: string
                         nullable: true
+                        type: string
                       fund_code:
                         type: string
                       bursary_level:
                         type: string
                       previous_last_name:
-                        type: string
                         nullable: true
+                        type: string
                       itt_aim:
                         type: string
                       course_study_mode:
@@ -2964,16 +3367,16 @@ paths:
                       course_year:
                         type: integer
                       pg_apprenticeship_start_date:
-                        type: string
                         nullable: true
+                        type: string
                       funding_method:
                         type: string
                       ni_number:
-                        type: string
                         nullable: true
+                        type: string
                       additional_training_initiative:
-                        type: string
                         nullable: true
+                        type: string
                       itt_qualification_aim:
                         type: string
                       hesa_disabilities:
@@ -2984,8 +3387,8 @@ paths:
                           disability2:
                             type: string
                       nationality:
-                        nullable: true
                         type: string
+                        nullable: true
                       withdraw_reasons:
                         type: array
                         items: {}
@@ -3007,20 +3410,20 @@ paths:
                             placement_id:
                               type: string
                           required:
-                            - urn
-                            - name
-                            - postcode
-                            - created_at
-                            - updated_at
-                            - placement_id
+                          - urn
+                          - name
+                          - postcode
+                          - created_at
+                          - updated_at
+                          - placement_id
                       degrees:
                         type: array
                         items:
                           type: object
                           properties:
                             uk_degree:
-                              nullable: true
                               type: string
+                              nullable: true
                             non_uk_degree:
                               nullable: true
                             created_at:
@@ -3029,6 +3432,7 @@ paths:
                               type: string
                             subject:
                               type: string
+                              nullable: true
                             institution:
                               type: string
                             graduation_year:
@@ -3051,151 +3455,154 @@ paths:
                             degree_id:
                               type: string
                           required:
-                            - uk_degree
-                            - non_uk_degree
-                            - created_at
-                            - updated_at
-                            - subject
-                            - institution
-                            - graduation_year
-                            - grade
-                            - country
-                            - other_grade
-                            - institution_uuid
-                            - uk_degree_uuid
-                            - subject_uuid
-                            - grade_uuid
-                            - degree_id
+                          - uk_degree
+                          - non_uk_degree
+                          - created_at
+                          - updated_at
+                          - subject
+                          - institution
+                          - graduation_year
+                          - grade
+                          - country
+                          - other_grade
+                          - institution_uuid
+                          - uk_degree_uuid
+                          - subject_uuid
+                          - grade_uuid
+                          - degree_id
                       state:
                         type: string
                       trainee_id:
                         type: string
                       application_id:
-                        type: integer
+                        nullable: true
+                      disability1:
+                        type: string
                       disability2:
                         type: string
                     required:
-                      - first_names
-                      - last_name
-                      - date_of_birth
-                      - created_at
-                      - updated_at
-                      - email
-                      - middle_names
-                      - training_route
-                      - sex
-                      - diversity_disclosure
-                      - ethnic_group
-                      - ethnic_background
-                      - additional_ethnic_background
-                      - disability_disclosure
-                      - course_subject_one
-                      - itt_start_date
-                      - outcome_date
-                      - itt_end_date
-                      - trn
-                      - submitted_for_trn_at
-                      - withdraw_date
-                      - withdraw_reasons_details
-                      - defer_date
-                      - recommended_for_award_at
-                      - trainee_start_date
-                      - reinstate_date
-                      - course_min_age
-                      - course_max_age
-                      - course_subject_two
-                      - course_subject_three
-                      - awarded_at
-                      - training_initiative
-                      - study_mode
-                      - ebacc
-                      - region
-                      - course_education_phase
-                      - course_uuid
-                      - lead_school_not_applicable
-                      - employing_school_not_applicable
-                      - submission_ready
-                      - commencement_status
-                      - discarded_at
-                      - created_from_dttp
-                      - hesa_id
-                      - additional_dttp_data
-                      - created_from_hesa
-                      - hesa_updated_at
-                      - record_source
-                      - iqts_country
-                      - hesa_editable
-                      - withdraw_reasons_dfe_details
-                      - slug_sent_to_dqt_at
-                      - placement_detail
-                      - provider_trainee_id
-                      - ukprn
-                      - ethnicity
-                      - course_qualification
-                      - course_title
-                      - course_level
-                      - course_itt_start_date
-                      - course_age_range
-                      - expected_end_date
-                      - employing_school_urn
-                      - lead_partner_urn_ukprn
-                      - lead_school_urn
-                      - fund_code
-                      - bursary_level
-                      - previous_last_name
-                      - itt_aim
-                      - course_study_mode
-                      - course_year
-                      - pg_apprenticeship_start_date
-                      - funding_method
-                      - ni_number
-                      - additional_training_initiative
-                      - itt_qualification_aim
-                      - hesa_disabilities
-                      - nationality
-                      - withdraw_reasons
-                      - placements
-                      - degrees
-                      - state
-                      - trainee_id
-                      - application_id
+                    - first_names
+                    - last_name
+                    - date_of_birth
+                    - created_at
+                    - updated_at
+                    - email
+                    - middle_names
+                    - training_route
+                    - sex
+                    - diversity_disclosure
+                    - ethnic_group
+                    - ethnic_background
+                    - additional_ethnic_background
+                    - disability_disclosure
+                    - course_subject_one
+                    - itt_start_date
+                    - outcome_date
+                    - itt_end_date
+                    - trn
+                    - submitted_for_trn_at
+                    - withdraw_date
+                    - withdraw_reasons_details
+                    - defer_date
+                    - recommended_for_award_at
+                    - trainee_start_date
+                    - reinstate_date
+                    - course_min_age
+                    - course_max_age
+                    - course_subject_two
+                    - course_subject_three
+                    - awarded_at
+                    - training_initiative
+                    - study_mode
+                    - ebacc
+                    - region
+                    - course_education_phase
+                    - course_uuid
+                    - lead_school_not_applicable
+                    - employing_school_not_applicable
+                    - submission_ready
+                    - commencement_status
+                    - discarded_at
+                    - created_from_dttp
+                    - hesa_id
+                    - additional_dttp_data
+                    - created_from_hesa
+                    - hesa_updated_at
+                    - record_source
+                    - iqts_country
+                    - hesa_editable
+                    - withdraw_reasons_dfe_details
+                    - slug_sent_to_dqt_at
+                    - placement_detail
+                    - provider_trainee_id
+                    - lead_partner_id
+                    - ukprn
+                    - ethnicity
+                    - course_qualification
+                    - course_title
+                    - course_level
+                    - course_itt_start_date
+                    - course_age_range
+                    - expected_end_date
+                    - employing_school_urn
+                    - lead_partner_urn_ukprn
+                    - lead_school_urn
+                    - fund_code
+                    - bursary_level
+                    - previous_last_name
+                    - itt_aim
+                    - course_study_mode
+                    - course_year
+                    - pg_apprenticeship_start_date
+                    - funding_method
+                    - ni_number
+                    - additional_training_initiative
+                    - itt_qualification_aim
+                    - hesa_disabilities
+                    - nationality
+                    - withdraw_reasons
+                    - placements
+                    - degrees
+                    - state
+                    - trainee_id
+                    - application_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  first_names: Alice
-                  last_name: Doe
-                  date_of_birth: "1990-01-01"
-                  created_at: "2024-06-19T12:12:49.441Z"
-                  updated_at: "2024-06-19T12:12:49.441Z"
-                  email: john.doe@example.com
-                  middle_names:
-                  training_route: "11"
-                  sex: "11"
+                  first_names: Jordan
+                  last_name: Franecki
+                  date_of_birth: '1984-09-08'
+                  created_at: '2024-07-05T14:00:48.714Z'
+                  updated_at: '2024-07-05T14:00:48.813Z'
+                  email: Jordan.Franecki@example.com
+                  middle_names: Heathcote
+                  training_route:
+                  sex: '10'
                   diversity_disclosure: diversity_not_disclosed
-                  ethnic_group: not_provided_ethnic_group
-                  ethnic_background: Not provided
+                  ethnic_group: asian_ethnic_group
+                  ethnic_background: Another Asian background
                   additional_ethnic_background:
-                  disability_disclosure: disability_not_provided
-                  course_subject_one: "100425"
-                  itt_start_date: "2023-08-01"
+                  disability_disclosure: disabled
+                  course_subject_one: '100403'
+                  itt_start_date: '2023-08-18'
                   outcome_date:
-                  itt_end_date: "2025-07-31"
+                  itt_end_date: '2024-07-12'
                   trn:
-                  submitted_for_trn_at: "2024-06-19T12:12:49.467Z"
+                  submitted_for_trn_at:
                   withdraw_date:
                   withdraw_reasons_details:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: "2023-08-01"
+                  trainee_start_date: '2023-08-21'
                   reinstate_date:
-                  course_min_age: 7
-                  course_max_age:
+                  course_min_age: 11
+                  course_max_age: 16
                   course_subject_two:
                   course_subject_three:
                   awarded_at:
                   training_initiative:
-                  study_mode: "63"
+                  study_mode: '01'
                   ebacc: false
                   region:
                   course_education_phase: secondary
@@ -3206,7 +3613,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: "0310261553101"
+                  hesa_id: '6068241514448'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -3216,63 +3623,58 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id:
-                  ukprn: "33770495"
-                  ethnicity: "997"
-                  disability1: "55"
+                  provider_trainee_id: 23/24-141
+                  lead_partner_id:
+                  ukprn: '35704337'
+                  ethnicity: '119'
                   course_qualification: QTS
                   course_title:
-                  course_level: undergrad
-                  course_itt_start_date: "2023-08-01"
-                  course_age_range: "13915"
-                  expected_end_date: "2025-07-31"
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-18'
+                  course_age_range: '13919'
+                  expected_end_date: '2024-07-12'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
-                  fund_code: "7"
-                  bursary_level: "4"
-                  previous_last_name:
-                  itt_aim: "202"
-                  course_study_mode: "63"
-                  course_year: 2012
-                  pg_apprenticeship_start_date:
-                  funding_method: "4"
-                  ni_number:
-                  additional_training_initiative:
-                  itt_qualification_aim: "001"
+                  fund_code: '2'
+                  bursary_level: D
+                  previous_last_name: Lebsack
+                  itt_aim: '202'
+                  course_study_mode: '01'
+                  course_year: 2024
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: D
+                  ni_number: QQ 12 34 56 C
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '031'
                   hesa_disabilities:
-                    disability1: "55"
-                    disability2: "57"
-                  nationality: GB
+                    disability1: '55'
+                    disability2: '57'
+                  nationality:
                   withdraw_reasons: []
-                  placements:
-                    - urn: "900020"
-                      name: Establishment does not have a URN
-                      postcode:
-                      created_at: "2024-06-19T12:12:49.447Z"
-                      updated_at: "2024-06-19T12:12:49.447Z"
-                      placement_id: u9wmhJaQNdN4B3WocEPfgoCX
+                  placements: []
                   degrees:
-                    - uk_degree: "083"
-                      non_uk_degree:
-                      created_at: "2024-06-19T12:12:49.442Z"
-                      updated_at: "2024-06-19T12:12:49.442Z"
-                      subject: "100425"
-                      institution: "0116"
-                      graduation_year: 2003
-                      grade: "02"
-                      country:
-                      other_grade:
-                      institution_uuid: 1071f34a-2887-e711-80d8-005056ac45bb
-                      uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
-                      subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
-                      grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                      degree_id: uQsj1P594q3mZvMMN75b2saX
-                  state: submitted_for_trn
-                  trainee_id: CscHUugnbosgW7toKLNbtd6V
-                  application_id: 123456
-                  disability2: "57"
-        "401":
+                  - uk_degree: '093'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:00:48.738Z'
+                    updated_at: '2024-07-05T14:00:48.738Z'
+                    subject: '100651'
+                    institution: '0353'
+                    graduation_year: 1999
+                    grade: '05'
+                    country:
+                    other_grade:
+                    institution_uuid: fe3d182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 2f6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: bb8270f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
+                    degree_id: 2rVpm5WzjMfn3Kg6CFJjBs91
+                  state: draft
+                  trainee_id: N1HNGvg76BKES4qrxTiq7iS9
+                  application_id:
+                  disability1: '55'
+                  disability2: '57'
+        '401':
           description: returns status 401 unauthorized
           content:
             application/json:
@@ -3282,10 +3684,10 @@ paths:
                   error:
                     type: string
                 required:
-                  - error
+                - error
               example:
                 error: Unauthorized
-        "404":
+        '404':
           description: returns status 404 not found
           content:
             application/json:
@@ -3302,15 +3704,15 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Not found
-        "422":
+                - error: NotFound
+                  message: Not found
+        '422':
           description: return status code 422 with a meaningful error message
           content:
             application/json:
@@ -3321,18 +3723,18 @@ paths:
                     type: string
                   errors:
                     type: array
-                    items:
-                      type: string
                     properties:
                       course_details:
                         type: object
                         properties:
+                          course_subject_one:
+                            type: array
+                            items:
+                              type: string
                           itt_end_date:
                             type: array
                             items:
                               type: string
-                        required:
-                          - itt_end_date
                       nationalisations.nationality:
                         type: array
                         items:
@@ -3345,16 +3747,16 @@ paths:
                             items:
                               type: string
                         required:
-                          - first_names
+                        - first_names
+                    items:
+                      type: string
                 required:
-                  - errors
+                - errors
               example:
-                message:
-                  "Validation failed: 1 error prohibited this trainee from
-                  being saved"
+                message: 'Validation failed: 1 error prohibited this trainee from
+                  being saved'
                 errors:
-                  - Hesa trainee detail attributes Course age range is not included
-                    in the list
+                - Sex is not included in the list
       requestBody:
         content:
           application/json:
@@ -3366,26 +3768,17 @@ paths:
                   properties:
                     first_names:
                       type: string
-                    provider_trainee_id:
+                    study_mode:
                       type: string
-                    trn:
+                    disability2:
                       type: string
-                    ethnicity:
-                      type: string
-                      nullable: true
-                    ethnic_group:
-                      type: string
-                    ethnic_background:
+                    disability1:
                       type: string
                     lead_school_urn:
                       type: string
                     employing_school_urn:
                       type: string
                     nationality:
-                      type: string
-                    disability1:
-                      type: string
-                    disability2:
                       type: string
                     course_subject_one:
                       type: string
@@ -3395,48 +3788,525 @@ paths:
                       type: string
                     course_max_age:
                       type: integer
-                    study_mode:
+                    provider_trainee_id:
+                      type: string
+                    ethnicity:
+                      type: string
+                      nullable: true
+                    trn:
+                      type: string
+                    ethnic_group:
+                      type: string
+                    ethnic_background:
                       type: string
               required:
-                - data
+              - data
             example:
               data:
                 first_names: Alice
+                study_mode: '63'
+                disability2: '57'
+                disability1: '58'
+                lead_school_urn: '900020'
+                employing_school_urn: '491094'
+                nationality: IE
+                course_subject_one: '100511'
+                course_subject_two: '101410'
+                course_subject_three: '100366'
+                course_max_age: 11
                 provider_trainee_id: 99157234/2/01
-                trn: "567899"
-                ethnicity: "142"
+                ethnicity: '899'
+                trn: '567899'
                 ethnic_group: mixed_ethnic_group
                 ethnic_background: Another Mixed background
-                lead_school_urn: "900020"
-                employing_school_urn: ""
-                nationality: IE
-                disability1: "57"
-                disability2: "57"
-                course_subject_one: "100511"
-                course_subject_two: "101410"
-                course_subject_three: "100366"
-                course_max_age: 11
-                study_mode: "63"
-  "/api/{api_version}/trainees/{trainee_id}/degrees":
+  "/api/{api_version}/trainees/{trainee_slug}/defer":
+    post:
+      summary: create
+      tags:
+      - Api::Trainees::Deferral
+      parameters:
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: nHNB3eN6zkJQKPSrYn9hX9zg
+      responses:
+        '200':
+          description: defers a trainee
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      commencement_status:
+                        nullable: true
+                      defer_date:
+                        type: string
+                      trainee_start_date:
+                        type: string
+                      first_names:
+                        type: string
+                      middle_names:
+                        type: string
+                      last_name:
+                        type: string
+                      email:
+                        type: string
+                      ethnic_background:
+                        nullable: true
+                      additional_ethnic_background:
+                        nullable: true
+                      trn:
+                        type: string
+                      withdraw_reasons_details:
+                        nullable: true
+                      withdraw_reasons_dfe_details:
+                        nullable: true
+                      region:
+                        nullable: true
+                      hesa_id:
+                        nullable: true
+                      course_subject_one:
+                        type: string
+                      course_subject_two:
+                        nullable: true
+                      course_subject_three:
+                        nullable: true
+                      record_source:
+                        type: string
+                      date_of_birth:
+                        type: string
+                      created_at:
+                        type: string
+                      updated_at:
+                        type: string
+                      training_route:
+                        nullable: true
+                      sex:
+                        type: string
+                      diversity_disclosure:
+                        type: string
+                      ethnic_group:
+                        nullable: true
+                      disability_disclosure:
+                        nullable: true
+                      itt_start_date:
+                        type: string
+                      outcome_date:
+                        nullable: true
+                      itt_end_date:
+                        type: string
+                      submitted_for_trn_at:
+                        type: string
+                      withdraw_date:
+                        nullable: true
+                      recommended_for_award_at:
+                        nullable: true
+                      reinstate_date:
+                        nullable: true
+                      course_min_age:
+                        type: integer
+                      course_max_age:
+                        type: integer
+                      awarded_at:
+                        nullable: true
+                      training_initiative:
+                        nullable: true
+                      study_mode:
+                        nullable: true
+                      ebacc:
+                        type: boolean
+                      course_education_phase:
+                        type: string
+                      course_uuid:
+                        nullable: true
+                      lead_school_not_applicable:
+                        type: boolean
+                      employing_school_not_applicable:
+                        type: boolean
+                      submission_ready:
+                        type: boolean
+                      discarded_at:
+                        nullable: true
+                      created_from_dttp:
+                        type: boolean
+                      additional_dttp_data:
+                        nullable: true
+                      created_from_hesa:
+                        type: boolean
+                      hesa_updated_at:
+                        nullable: true
+                      iqts_country:
+                        nullable: true
+                      hesa_editable:
+                        type: boolean
+                      slug_sent_to_dqt_at:
+                        nullable: true
+                      placement_detail:
+                        nullable: true
+                      provider_trainee_id:
+                        type: string
+                      lead_partner_id:
+                        nullable: true
+                      ukprn:
+                        type: string
+                      ethnicity:
+                        nullable: true
+                      course_qualification:
+                        type: string
+                      course_title:
+                        nullable: true
+                      course_level:
+                        type: string
+                      course_itt_start_date:
+                        type: string
+                      course_age_range:
+                        nullable: true
+                      expected_end_date:
+                        type: string
+                      employing_school_urn:
+                        nullable: true
+                      lead_partner_urn_ukprn:
+                        nullable: true
+                      lead_school_urn:
+                        nullable: true
+                      fund_code:
+                        nullable: true
+                      bursary_level:
+                        nullable: true
+                      nationality:
+                        type: string
+                      withdraw_reasons:
+                        type: array
+                        items: {}
+                      placements:
+                        type: array
+                        items: {}
+                      degrees:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            uk_degree:
+                              type: string
+                            non_uk_degree:
+                              nullable: true
+                            created_at:
+                              type: string
+                            updated_at:
+                              type: string
+                            subject:
+                              type: string
+                            institution:
+                              type: string
+                            graduation_year:
+                              type: integer
+                            grade:
+                              nullable: true
+                            country:
+                              nullable: true
+                            other_grade:
+                              nullable: true
+                            institution_uuid:
+                              type: string
+                            uk_degree_uuid:
+                              type: string
+                            subject_uuid:
+                              type: string
+                            grade_uuid:
+                              type: string
+                            degree_id:
+                              type: string
+                          required:
+                          - uk_degree
+                          - non_uk_degree
+                          - created_at
+                          - updated_at
+                          - subject
+                          - institution
+                          - graduation_year
+                          - grade
+                          - country
+                          - other_grade
+                          - institution_uuid
+                          - uk_degree_uuid
+                          - subject_uuid
+                          - grade_uuid
+                          - degree_id
+                      state:
+                        type: string
+                      trainee_id:
+                        type: string
+                      application_id:
+                        nullable: true
+                    required:
+                    - commencement_status
+                    - defer_date
+                    - trainee_start_date
+                    - first_names
+                    - middle_names
+                    - last_name
+                    - email
+                    - ethnic_background
+                    - additional_ethnic_background
+                    - trn
+                    - withdraw_reasons_details
+                    - withdraw_reasons_dfe_details
+                    - region
+                    - hesa_id
+                    - course_subject_one
+                    - course_subject_two
+                    - course_subject_three
+                    - record_source
+                    - date_of_birth
+                    - created_at
+                    - updated_at
+                    - training_route
+                    - sex
+                    - diversity_disclosure
+                    - ethnic_group
+                    - disability_disclosure
+                    - itt_start_date
+                    - outcome_date
+                    - itt_end_date
+                    - submitted_for_trn_at
+                    - withdraw_date
+                    - recommended_for_award_at
+                    - reinstate_date
+                    - course_min_age
+                    - course_max_age
+                    - awarded_at
+                    - training_initiative
+                    - study_mode
+                    - ebacc
+                    - course_education_phase
+                    - course_uuid
+                    - lead_school_not_applicable
+                    - employing_school_not_applicable
+                    - submission_ready
+                    - discarded_at
+                    - created_from_dttp
+                    - additional_dttp_data
+                    - created_from_hesa
+                    - hesa_updated_at
+                    - iqts_country
+                    - hesa_editable
+                    - slug_sent_to_dqt_at
+                    - placement_detail
+                    - provider_trainee_id
+                    - lead_partner_id
+                    - ukprn
+                    - ethnicity
+                    - course_qualification
+                    - course_title
+                    - course_level
+                    - course_itt_start_date
+                    - course_age_range
+                    - expected_end_date
+                    - employing_school_urn
+                    - lead_partner_urn_ukprn
+                    - lead_school_urn
+                    - fund_code
+                    - bursary_level
+                    - nationality
+                    - withdraw_reasons
+                    - placements
+                    - degrees
+                    - state
+                    - trainee_id
+                    - application_id
+                required:
+                - data
+              example:
+                data:
+                  commencement_status:
+                  defer_date: '2024-07-05'
+                  trainee_start_date: '2023-08-28'
+                  first_names: Cruz
+                  middle_names: Sanford
+                  last_name: Conroy
+                  email: Cruz.Conroy@example.com
+                  ethnic_background:
+                  additional_ethnic_background:
+                  trn: '4544083'
+                  withdraw_reasons_details:
+                  withdraw_reasons_dfe_details:
+                  region:
+                  hesa_id:
+                  course_subject_one: '100403'
+                  course_subject_two:
+                  course_subject_three:
+                  record_source: manual
+                  date_of_birth: '1986-09-26'
+                  created_at: '2024-07-05T14:01:26.296Z'
+                  updated_at: '2024-07-05T14:01:26.354Z'
+                  training_route:
+                  sex: '99'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  disability_disclosure:
+                  itt_start_date: '2023-08-27'
+                  outcome_date:
+                  itt_end_date: '2024-07-17'
+                  submitted_for_trn_at: '2024-07-05T14:01:26.283Z'
+                  withdraw_date:
+                  recommended_for_award_at:
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  awarded_at:
+                  training_initiative:
+                  study_mode:
+                  ebacc: false
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  discarded_at:
+                  created_from_dttp: false
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  iqts_country:
+                  hesa_editable: false
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-1034
+                  lead_partner_id:
+                  ukprn: '77934060'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-27'
+                  course_age_range:
+                  expected_end_date: '2024-07-17'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code:
+                  bursary_level:
+                  nationality: TR
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '209'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:26.298Z'
+                    updated_at: '2024-07-05T14:01:26.298Z'
+                    subject: '100172'
+                    institution: '0270'
+                    graduation_year: 2021
+                    grade:
+                    country:
+                    other_grade:
+                    institution_uuid: ed3e182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: 4d6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: fb7f70f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
+                    degree_id: GuwCzgjCAeX5vb4eR3F1rc3K
+                  state: deferred
+                  trainee_id: nHNB3eN6zkJQKPSrYn9hX9zg
+                  application_id:
+        '404':
+          description: returns 404
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        error:
+                          type: string
+                        message:
+                          type: string
+                      required:
+                      - error
+                      - message
+                required:
+                - errors
+              example:
+                errors:
+                - error: NotFound
+                  message: Trainee(s) not found
+        '422':
+          description: does not defer the trainee
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        error:
+                          type: string
+                        message:
+                          type: string
+                      required:
+                      - error
+                      - message
+                required:
+                - errors
+              example:
+                errors:
+                - error: UnprocessableEntity
+                  message: Defer date can't be blank
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    defer_date:
+                      type: string
+                  required:
+                  - defer_date
+              required:
+              - data
+            example:
+              data:
+                defer_date: '2024-07-05'
+  "/api/{api_version}/trainees/{trainee_slug}/degrees":
     get:
       summary: index
       tags:
-        - Api::Trainees::Degree
+      - Api::Trainees::Degree
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: JDPoWkCMi4aPPWPiunZ819pc
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: 4dhmf8CgmUJq22jfvihRLqaj
       responses:
-        "200":
+        '200':
           description: returns status 200 with a valid JSON response
           content:
             application/json:
@@ -3479,59 +4349,44 @@ paths:
                         degree_id:
                           type: string
                       required:
-                        - uk_degree
-                        - non_uk_degree
-                        - created_at
-                        - updated_at
-                        - subject
-                        - institution
-                        - graduation_year
-                        - grade
-                        - country
-                        - other_grade
-                        - institution_uuid
-                        - uk_degree_uuid
-                        - subject_uuid
-                        - grade_uuid
-                        - degree_id
+                      - uk_degree
+                      - non_uk_degree
+                      - created_at
+                      - updated_at
+                      - subject
+                      - institution
+                      - graduation_year
+                      - grade
+                      - country
+                      - other_grade
+                      - institution_uuid
+                      - uk_degree_uuid
+                      - subject_uuid
+                      - grade_uuid
+                      - degree_id
                 required:
-                  - data
+                - data
               example:
-                data:
-                  - uk_degree: "080"
-                    non_uk_degree:
-                    created_at: "2024-06-19T12:13:03.418Z"
-                    updated_at: "2024-06-19T12:13:03.418Z"
-                    subject: "100118"
-                    institution: "0230"
-                    graduation_year: 1966
-                    grade: "14"
-                    country:
-                    other_grade:
-                    institution_uuid: b53e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: 156a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: a57f70f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                    degree_id: WQ2eNzuZUhkgBMG51w3JNyZn
+                data: []
     post:
       summary: create
       tags:
-        - Api::Trainees::Degree
+      - Api::Trainees::Degree
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: boAJmpxSJknpTmrgDn6ncT6F
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: JEfz82UUkjdHCi6XWY5pFBXc
       responses:
-        "201":
+        '201':
           description: creates a new degree and returns a 201 (created) status
           content:
             application/json:
@@ -3572,43 +4427,42 @@ paths:
                       degree_id:
                         type: string
                     required:
-                      - uk_degree
-                      - non_uk_degree
-                      - created_at
-                      - updated_at
-                      - subject
-                      - institution
-                      - graduation_year
-                      - grade
-                      - country
-                      - other_grade
-                      - institution_uuid
-                      - uk_degree_uuid
-                      - subject_uuid
-                      - grade_uuid
-                      - degree_id
+                    - uk_degree
+                    - non_uk_degree
+                    - created_at
+                    - updated_at
+                    - subject
+                    - institution
+                    - graduation_year
+                    - grade
+                    - country
+                    - other_grade
+                    - institution_uuid
+                    - uk_degree_uuid
+                    - subject_uuid
+                    - grade_uuid
+                    - degree_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  uk_degree: "083"
+                  uk_degree: '083'
                   non_uk_degree:
-                  created_at: "2024-06-19T12:13:16.002Z"
-                  updated_at: "2024-06-19T12:13:16.002Z"
-                  subject: "100425"
-                  institution: "0117"
+                  created_at: '2024-07-05T14:00:51.710Z'
+                  updated_at: '2024-07-05T14:00:51.710Z'
+                  subject: '100425'
+                  institution: '0117'
                   graduation_year: 2015
-                  grade: "02"
+                  grade: '02'
                   country:
                   other_grade:
                   institution_uuid: 1271f34a-2887-e711-80d8-005056ac45bb
                   uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                  degree_id: 8uCdt88bAQLUNQm8TtN8ucKo
-        "404":
-          description:
-            does not create a new degree and returns a 404 status (not_found)
+                  degree_id: ui4NyU7YuWPCbZCcjESywSmx
+        '404':
+          description: does not create a new degree and returns a 404 status (not_found)
             status
           content:
             application/json:
@@ -3625,15 +4479,15 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Trainee(s) not found
-        "409":
+                - error: NotFound
+                  message: Trainee(s) not found
+        '409':
           description: returns a 409 (conflict) status
           content:
             application/json:
@@ -3650,17 +4504,16 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: Conflict
-                    message: This is a duplicate degree
-        "422":
-          description:
-            does not create a new degree and returns a 422 status (unprocessable_entity)
+                - error: Conflict
+                  message: This is a duplicate degree
+        '422':
+          description: does not create a new degree and returns a 422 status (unprocessable_entity)
             status
           content:
             application/json:
@@ -3677,18 +4530,18 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: UnprocessableEntity
-                    message: Subject can't be blank
-                  - error: UnprocessableEntity
-                    message: Uk degree can't be blank
-                  - error: UnprocessableEntity
-                    message: Grade can't be blank
+                - error: UnprocessableEntity
+                  message: Subject can't be blank
+                - error: UnprocessableEntity
+                  message: Uk degree can't be blank
+                - error: UnprocessableEntity
+                  message: Grade can't be blank
       requestBody:
         content:
           application/json:
@@ -3713,50 +4566,57 @@ paths:
                     locale_code:
                       type: string
                   required:
-                    - grade
-                    - subject
-                    - institution
-                    - uk_degree
-                    - graduation_year
-                    - country
-                    - locale_code
+                  - grade
+                  - subject
+                  - institution
+                  - uk_degree
+                  - graduation_year
+                  - country
+                  - locale_code
               required:
-                - data
+              - data
             example:
               data:
-                grade: "02"
-                subject: "100425"
-                institution: "0117"
-                uk_degree: "083"
-                graduation_year: "2015-01-01"
+                grade: '02'
+                subject: '100425'
+                institution: '0117'
+                uk_degree: '083'
+                graduation_year: '2015-01-01'
                 country: XF
                 locale_code: uk
-  "/api/{api_version}/trainees/{trainee_id}/degrees/{degree_id}":
+  "/api/{api_version}/trainees/{trainee_slug}/degrees/{slug}":
     delete:
       summary: destroy
       tags:
-        - Api::Trainees::Degree
+      - Api::Trainees::Degree
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          example: TYEP5sHEakWamrjxVtoChKhr
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: hTJGtPxdWSTM4DSLdYRokc4x
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: uUqFgwN6BkMxNPD6URz2gBUM
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: xhJBgdbrEwnnQvqp4TvKF1he
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+            example: {}
       responses:
-        "200":
+        '200':
           description: deletes the degree and returns a 200 status (ok)
           content:
             application/json:
@@ -3874,6 +4734,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                      lead_partner_id:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -3916,95 +4778,96 @@ paths:
                       trainee_id:
                         type: string
                       application_id:
-                        type: integer
+                        nullable: true
                     required:
-                      - first_names
-                      - last_name
-                      - date_of_birth
-                      - created_at
-                      - updated_at
-                      - email
-                      - middle_names
-                      - training_route
-                      - sex
-                      - diversity_disclosure
-                      - ethnic_group
-                      - ethnic_background
-                      - additional_ethnic_background
-                      - disability_disclosure
-                      - course_subject_one
-                      - itt_start_date
-                      - outcome_date
-                      - itt_end_date
-                      - trn
-                      - submitted_for_trn_at
-                      - withdraw_date
-                      - withdraw_reasons_details
-                      - defer_date
-                      - recommended_for_award_at
-                      - trainee_start_date
-                      - reinstate_date
-                      - course_min_age
-                      - course_max_age
-                      - course_subject_two
-                      - course_subject_three
-                      - awarded_at
-                      - training_initiative
-                      - study_mode
-                      - ebacc
-                      - region
-                      - course_education_phase
-                      - course_uuid
-                      - lead_school_not_applicable
-                      - employing_school_not_applicable
-                      - submission_ready
-                      - commencement_status
-                      - discarded_at
-                      - created_from_dttp
-                      - hesa_id
-                      - additional_dttp_data
-                      - created_from_hesa
-                      - hesa_updated_at
-                      - record_source
-                      - iqts_country
-                      - hesa_editable
-                      - withdraw_reasons_dfe_details
-                      - slug_sent_to_dqt_at
-                      - placement_detail
-                      - provider_trainee_id
-                      - ukprn
-                      - ethnicity
-                      - course_qualification
-                      - course_title
-                      - course_level
-                      - course_itt_start_date
-                      - course_age_range
-                      - expected_end_date
-                      - employing_school_urn
-                      - lead_partner_urn_ukprn
-                      - lead_school_urn
-                      - fund_code
-                      - bursary_level
-                      - nationality
-                      - withdraw_reasons
-                      - placements
-                      - degrees
-                      - state
-                      - trainee_id
-                      - application_id
+                    - first_names
+                    - last_name
+                    - date_of_birth
+                    - created_at
+                    - updated_at
+                    - email
+                    - middle_names
+                    - training_route
+                    - sex
+                    - diversity_disclosure
+                    - ethnic_group
+                    - ethnic_background
+                    - additional_ethnic_background
+                    - disability_disclosure
+                    - course_subject_one
+                    - itt_start_date
+                    - outcome_date
+                    - itt_end_date
+                    - trn
+                    - submitted_for_trn_at
+                    - withdraw_date
+                    - withdraw_reasons_details
+                    - defer_date
+                    - recommended_for_award_at
+                    - trainee_start_date
+                    - reinstate_date
+                    - course_min_age
+                    - course_max_age
+                    - course_subject_two
+                    - course_subject_three
+                    - awarded_at
+                    - training_initiative
+                    - study_mode
+                    - ebacc
+                    - region
+                    - course_education_phase
+                    - course_uuid
+                    - lead_school_not_applicable
+                    - employing_school_not_applicable
+                    - submission_ready
+                    - commencement_status
+                    - discarded_at
+                    - created_from_dttp
+                    - hesa_id
+                    - additional_dttp_data
+                    - created_from_hesa
+                    - hesa_updated_at
+                    - record_source
+                    - iqts_country
+                    - hesa_editable
+                    - withdraw_reasons_dfe_details
+                    - slug_sent_to_dqt_at
+                    - placement_detail
+                    - provider_trainee_id
+                    - lead_partner_id
+                    - ukprn
+                    - ethnicity
+                    - course_qualification
+                    - course_title
+                    - course_level
+                    - course_itt_start_date
+                    - course_age_range
+                    - expected_end_date
+                    - employing_school_urn
+                    - lead_partner_urn_ukprn
+                    - lead_school_urn
+                    - fund_code
+                    - bursary_level
+                    - nationality
+                    - withdraw_reasons
+                    - placements
+                    - degrees
+                    - state
+                    - trainee_id
+                    - application_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  first_names: Zackary
-                  last_name: Spencer
-                  date_of_birth: "2002-01-18"
-                  created_at: "2024-06-19T12:12:50.452Z"
-                  updated_at: "2024-06-19T12:12:50.489Z"
-                  email: Zackary.Spencer@example.com
-                  middle_names: Daugherty
+                  first_names: Rosendo
+                  last_name: Gerhold
+                  date_of_birth: '1969-05-31'
+                  created_at: '2024-07-05T14:01:25.173Z'
+                  updated_at: '2024-07-05T14:01:25.225Z'
+                  email: Rosendo.Gerhold@example.com
+                  middle_names: Batz
                   training_route:
-                  sex: "11"
+                  sex: '99'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   ethnic_background:
@@ -4049,8 +4912,9 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-176
-                  ukprn: "38837633"
+                  provider_trainee_id: 23/24-1013
+                  lead_partner_id:
+                  ukprn: '39205863'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
@@ -4068,9 +4932,9 @@ paths:
                   placements: []
                   degrees: []
                   state: draft
-                  trainee_id: hTJGtPxdWSTM4DSLdYRokc4x
-                  application_id: 123456
-        "404":
+                  trainee_id: Eda26pfZ24HwgpanZ68jLvrN
+                  application_id:
+        '404':
           description: does not delete the degree and returns a 404 status (not_found)
           content:
             application/json:
@@ -4087,46 +4951,39 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Degree(s) not found
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties: {}
-            example: {}
+                - error: NotFound
+                  message: Trainee(s) not found
     get:
       summary: show
       tags:
-        - Api::Trainees::Degree
+      - Api::Trainees::Degree
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          example: r1ps9LsuD3nUjEazihDcY5Ww
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: 3pesB9Dxz1BVCebTvYADhCuN
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: non-existant
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: 1GMdCgdZVD9cELfGsWZU5FDq
       responses:
-        "200":
+        '200':
           description: returns status 200 with a valid JSON response
           content:
             application/json:
@@ -4167,41 +5024,41 @@ paths:
                       degree_id:
                         type: string
                     required:
-                      - uk_degree
-                      - non_uk_degree
-                      - created_at
-                      - updated_at
-                      - subject
-                      - institution
-                      - graduation_year
-                      - grade
-                      - country
-                      - other_grade
-                      - institution_uuid
-                      - uk_degree_uuid
-                      - subject_uuid
-                      - grade_uuid
-                      - degree_id
+                    - uk_degree
+                    - non_uk_degree
+                    - created_at
+                    - updated_at
+                    - subject
+                    - institution
+                    - graduation_year
+                    - grade
+                    - country
+                    - other_grade
+                    - institution_uuid
+                    - uk_degree_uuid
+                    - subject_uuid
+                    - grade_uuid
+                    - degree_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  uk_degree: "306"
+                  uk_degree: '201'
                   non_uk_degree:
-                  created_at: "2024-06-19T12:13:16.347Z"
-                  updated_at: "2024-06-19T12:13:16.347Z"
-                  subject: "100405"
-                  institution: "0356"
-                  graduation_year: 1979
-                  grade: "14"
+                  created_at: '2024-07-05T14:00:53.349Z'
+                  updated_at: '2024-07-05T14:00:53.349Z'
+                  subject: '100138'
+                  institution: '0220'
+                  graduation_year: 2013
+                  grade: '01'
                   country:
                   other_grade:
-                  institution_uuid: 6f3e182c-1425-ec11-b6e6-000d3adf095a
-                  uk_degree_uuid: 676a5652-c197-e711-80d8-005056ac45bb
-                  subject_uuid: 6f8170f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                  degree_id: r1ps9LsuD3nUjEazihDcY5Ww
-        "404":
+                  institution_uuid: 5d3e182c-1425-ec11-b6e6-000d3adf095a
+                  uk_degree_uuid: 3d6a5652-c197-e711-80d8-005056ac45bb
+                  subject_uuid: c57f70f0-5dce-e911-a985-000d3ab79618
+                  grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                  degree_id: QKGSNdqK1ceVRCQokryYoiZ9
+        '404':
           description: returns status 404 with a valid JSON response
           content:
             application/json:
@@ -4218,39 +5075,72 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Degree(s) not found
+                - error: NotFound
+                  message: Degree(s) not found
     put:
       summary: update
       tags:
-        - Api::Trainees::Degree
+      - Api::Trainees::Degree
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          example: Y2zG2jmFSpEzwRtXLfxm35yh
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: qBA1Q94yzo6XLYRvS9toe3ps
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: D15uSt7E4SzPYH1viGUEzT27
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: o3gac6Jq1yFzSp2wK1GiT1cd
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    grade:
+                      type: string
+                    subject:
+                      type: string
+                    institution:
+                      type: string
+                    uk_degree:
+                      type: string
+                    graduation_year:
+                      type: string
+                    country:
+                      type: string
+                  required:
+                  - subject
+              required:
+              - data
+            example:
+              data:
+                grade: '02'
+                subject: '100105'
+                institution: '0117'
+                uk_degree: '083'
+                graduation_year: '2015-01-01'
+                country: XF
       responses:
-        "200":
+        '200':
           description: updates the degree and returns a 200 status (ok)
           content:
             application/json:
@@ -4291,41 +5181,41 @@ paths:
                       degree_id:
                         type: string
                     required:
-                      - uk_degree
-                      - non_uk_degree
-                      - created_at
-                      - updated_at
-                      - subject
-                      - institution
-                      - graduation_year
-                      - grade
-                      - country
-                      - other_grade
-                      - institution_uuid
-                      - uk_degree_uuid
-                      - subject_uuid
-                      - grade_uuid
-                      - degree_id
+                    - uk_degree
+                    - non_uk_degree
+                    - created_at
+                    - updated_at
+                    - subject
+                    - institution
+                    - graduation_year
+                    - grade
+                    - country
+                    - other_grade
+                    - institution_uuid
+                    - uk_degree_uuid
+                    - subject_uuid
+                    - grade_uuid
+                    - degree_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  uk_degree: "083"
+                  uk_degree: '051'
                   non_uk_degree:
-                  created_at: "2024-06-19T12:13:02.540Z"
-                  updated_at: "2024-06-19T12:13:02.574Z"
-                  subject: "100425"
-                  institution: "0117"
-                  graduation_year: 2015
-                  grade: "02"
+                  created_at: '2024-07-05T14:01:25.604Z'
+                  updated_at: '2024-07-05T14:01:25.649Z'
+                  subject: '100105'
+                  institution: '0030'
+                  graduation_year: 1978
+                  grade: '05'
                   country:
                   other_grade:
-                  institution_uuid: 953e182c-1425-ec11-b6e6-000d3adf095a
-                  uk_degree_uuid: 636a5652-c197-e711-80d8-005056ac45bb
+                  institution_uuid: 2d3e182c-1425-ec11-b6e6-000d3adf095a
+                  uk_degree_uuid: 1f6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 917f70f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                  degree_id: gaYucsVBV1F6bjpEM6h2QgXV
-        "404":
+                  grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
+                  degree_id: 3BCf6naCPvLPjUtfRNLTWVuj
+        '404':
           description: does not update the degree and returns a 404 status (not_found)
           content:
             application/json:
@@ -4342,15 +5232,15 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Trainee(s) not found
-        "422":
+                - error: NotFound
+                  message: Trainee(s) not found
+        '422':
           description: does not update the degree and returns a 422 status (unprocessable_entity)
           content:
             application/json:
@@ -4360,73 +5250,44 @@ paths:
                   errors:
                     type: array
                     items:
-                      type: string
+                      type: object
                       properties:
                         error:
                           type: string
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - "Param is missing or the value is empty: data"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                data:
-                  type: object
-                  properties:
-                    subject:
-                      type: string
-                    grade:
-                      type: string
-                    institution:
-                      type: string
-                    uk_degree:
-                      type: string
-                    graduation_year:
-                      type: string
-                    country:
-                      type: string
-                  required:
-                    - subject
-              required:
-                - data
-            example:
-              data:
-                subject: "100425"
-                grade: "02"
-                institution: "0117"
-                uk_degree: "083"
-                graduation_year: "2015-01-01"
-                country: XF
-  "/api/{api_version}/trainees/{trainee_id}/placements":
+                - error: UnprocessableEntity
+                  message: Graduation year Enter a graduation year that is in the
+                    past, for example 2014
+                - error: UnprocessableEntity
+                  message: Graduation year Enter a valid graduation year
+  "/api/{api_version}/trainees/{trainee_slug}/placements":
     get:
       summary: index
       tags:
-        - Api::Trainees::Placement
+      - Api::Trainees::Placement
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: dr7hEyhfDxQr9ewEuvfUdzUA
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: 4cQPyZwcq7MAyrZSiX7B2ECU
       responses:
-        "200":
+        '200':
           description: returns status 200 with a valid JSON response
           content:
             application/json:
@@ -4451,45 +5312,45 @@ paths:
                         placement_id:
                           type: string
                       required:
-                        - urn
-                        - name
-                        - postcode
-                        - created_at
-                        - updated_at
-                        - placement_id
+                      - urn
+                      - name
+                      - postcode
+                      - created_at
+                      - updated_at
+                      - placement_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  - urn: "924942"
-                    name: Brookville High
-                    postcode: PD3 0LN
-                    created_at: "2024-06-19T12:12:50.563Z"
-                    updated_at: "2024-06-19T12:12:50.563Z"
-                    placement_id: dmeEwBa5pbLYMmvpWxaGozcW
-                  - urn: "921612"
-                    name: Marblewald High School
-                    postcode: WQ7E 5NE
-                    created_at: "2024-06-19T12:12:50.567Z"
-                    updated_at: "2024-06-19T12:12:50.567Z"
-                    placement_id: 43s95fid256faRgUpYrznm6H
+                - urn: '383175'
+                  name: Brighthurst Secondary College
+                  postcode: C9S 1JP
+                  created_at: '2024-07-05T14:00:52.097Z'
+                  updated_at: '2024-07-05T14:00:52.097Z'
+                  placement_id: ZrhkFrQK2YLekX8mr7PZPEgp
+                - urn: '966311'
+                  name: Mallowpond High
+                  postcode: YM7W 1NB
+                  created_at: '2024-07-05T14:00:52.102Z'
+                  updated_at: '2024-07-05T14:00:52.102Z'
+                  placement_id: 9t4LGcQM3MQFeJktJd4Wf57d
     post:
       summary: create
       tags:
-        - Api::Trainees::Placement
+      - Api::Trainees::Placement
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: g5VU5kK6Cju838quyRdfMhWv
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: tmztAHzUsEXJGYA4ZLfRHYmi
       requestBody:
         content:
           application/json:
@@ -4515,22 +5376,22 @@ paths:
                       nullable: true
                       type: integer
                   required:
-                    - address
-                    - name
-                    - postcode
-                    - urn
-                    - school_id
+                  - address
+                  - name
+                  - postcode
+                  - urn
+                  - school_id
               required:
-                - data
+              - data
             example:
               data:
                 address:
                 name:
                 postcode:
                 urn:
-                school_id: 109
+                school_id: 117
       responses:
-        "201":
+        '201':
           description: updates the progress attribute on the trainee
           content:
             application/json:
@@ -4553,25 +5414,24 @@ paths:
                       placement_id:
                         type: string
                     required:
-                      - urn
-                      - name
-                      - postcode
-                      - created_at
-                      - updated_at
-                      - placement_id
+                    - urn
+                    - name
+                    - postcode
+                    - created_at
+                    - updated_at
+                    - placement_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  urn: "595959"
-                  name: Mallowpond High School
-                  postcode: ZB4M 3UN
-                  created_at: "2024-06-19T12:12:51.402Z"
-                  updated_at: "2024-06-19T12:12:51.402Z"
-                  placement_id: xTVHAzcV73gCTgyDFNhW3jDQ
-        "404":
-          description:
-            does not create a new placement and returns a 422 status (unprocessable_entity)
+                  urn: '729091'
+                  name: Bluemeadow High
+                  postcode: WX0 2QX
+                  created_at: '2024-07-05T14:01:26.829Z'
+                  updated_at: '2024-07-05T14:01:26.829Z'
+                  placement_id: RxvYN3JGtgXHbuNWqDLYw2ia
+        '404':
+          description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
           content:
             application/json:
@@ -4588,17 +5448,16 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Trainee(s) not found
-        "422":
-          description:
-            does not create a new placements and returns a 422 status (unprocessable_entity)
+                - error: NotFound
+                  message: Trainee(s) not found
+        '422':
+          description: does not create a new placements and returns a 422 status (unprocessable_entity)
             status
           content:
             application/json:
@@ -4615,49 +5474,42 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: UnprocessableEntity
-                    message: Name can't be blank
-                  - error: UnprocessableEntity
-                    message: School can't be blank
-  "/api/{api_version}/trainees/{trainee_id}/placements/{placement_id}":
+                - error: UnprocessableEntity
+                  message: Name can't be blank
+                - error: UnprocessableEntity
+                  message: School can't be blank
+  "/api/{api_version}/trainees/{trainee_slug}/placements/{slug}":
     delete:
       summary: destroy
       tags:
-        - Api::Trainees::Placement
+      - Api::Trainees::Placement
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          example: non-existant
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: piDQPFbj8YKoZzp6JWdCLyoK
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties: {}
-            example: {}
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: vDbUAV3FFqTk8m2UYJPQX5yx
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: hJKBa3WHutaLnxq1oYnbufd8
       responses:
-        "200":
+        '200':
           description: removes the specified placement
           content:
             application/json:
@@ -4775,6 +5627,8 @@ paths:
                         type: string
                       provider_trainee_id:
                         type: string
+                      lead_partner_id:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -4845,12 +5699,12 @@ paths:
                             placement_id:
                               type: string
                           required:
-                            - urn
-                            - name
-                            - postcode
-                            - created_at
-                            - updated_at
-                            - placement_id
+                          - urn
+                          - name
+                          - postcode
+                          - created_at
+                          - updated_at
+                          - placement_id
                       degrees:
                         type: array
                         items: {}
@@ -4859,105 +5713,106 @@ paths:
                       trainee_id:
                         type: string
                       application_id:
-                        type: integer
+                        nullable: true
                     required:
-                      - first_names
-                      - last_name
-                      - date_of_birth
-                      - created_at
-                      - updated_at
-                      - email
-                      - middle_names
-                      - training_route
-                      - sex
-                      - diversity_disclosure
-                      - ethnic_group
-                      - ethnic_background
-                      - additional_ethnic_background
-                      - disability_disclosure
-                      - course_subject_one
-                      - itt_start_date
-                      - outcome_date
-                      - itt_end_date
-                      - trn
-                      - submitted_for_trn_at
-                      - withdraw_date
-                      - withdraw_reasons_details
-                      - defer_date
-                      - recommended_for_award_at
-                      - trainee_start_date
-                      - reinstate_date
-                      - course_min_age
-                      - course_max_age
-                      - course_subject_two
-                      - course_subject_three
-                      - awarded_at
-                      - training_initiative
-                      - study_mode
-                      - ebacc
-                      - region
-                      - course_education_phase
-                      - course_uuid
-                      - lead_school_not_applicable
-                      - employing_school_not_applicable
-                      - submission_ready
-                      - commencement_status
-                      - discarded_at
-                      - created_from_dttp
-                      - hesa_id
-                      - additional_dttp_data
-                      - created_from_hesa
-                      - hesa_updated_at
-                      - record_source
-                      - iqts_country
-                      - hesa_editable
-                      - withdraw_reasons_dfe_details
-                      - slug_sent_to_dqt_at
-                      - placement_detail
-                      - provider_trainee_id
-                      - ukprn
-                      - ethnicity
-                      - course_qualification
-                      - course_title
-                      - course_level
-                      - course_itt_start_date
-                      - course_age_range
-                      - expected_end_date
-                      - employing_school_urn
-                      - lead_partner_urn_ukprn
-                      - lead_school_urn
-                      - fund_code
-                      - bursary_level
-                      - previous_last_name
-                      - itt_aim
-                      - course_study_mode
-                      - course_year
-                      - pg_apprenticeship_start_date
-                      - funding_method
-                      - ni_number
-                      - additional_training_initiative
-                      - itt_qualification_aim
-                      - hesa_disabilities
-                      - nationality
-                      - withdraw_reasons
-                      - placements
-                      - degrees
-                      - state
-                      - trainee_id
-                      - application_id
+                    - first_names
+                    - last_name
+                    - date_of_birth
+                    - created_at
+                    - updated_at
+                    - email
+                    - middle_names
+                    - training_route
+                    - sex
+                    - diversity_disclosure
+                    - ethnic_group
+                    - ethnic_background
+                    - additional_ethnic_background
+                    - disability_disclosure
+                    - course_subject_one
+                    - itt_start_date
+                    - outcome_date
+                    - itt_end_date
+                    - trn
+                    - submitted_for_trn_at
+                    - withdraw_date
+                    - withdraw_reasons_details
+                    - defer_date
+                    - recommended_for_award_at
+                    - trainee_start_date
+                    - reinstate_date
+                    - course_min_age
+                    - course_max_age
+                    - course_subject_two
+                    - course_subject_three
+                    - awarded_at
+                    - training_initiative
+                    - study_mode
+                    - ebacc
+                    - region
+                    - course_education_phase
+                    - course_uuid
+                    - lead_school_not_applicable
+                    - employing_school_not_applicable
+                    - submission_ready
+                    - commencement_status
+                    - discarded_at
+                    - created_from_dttp
+                    - hesa_id
+                    - additional_dttp_data
+                    - created_from_hesa
+                    - hesa_updated_at
+                    - record_source
+                    - iqts_country
+                    - hesa_editable
+                    - withdraw_reasons_dfe_details
+                    - slug_sent_to_dqt_at
+                    - placement_detail
+                    - provider_trainee_id
+                    - lead_partner_id
+                    - ukprn
+                    - ethnicity
+                    - course_qualification
+                    - course_title
+                    - course_level
+                    - course_itt_start_date
+                    - course_age_range
+                    - expected_end_date
+                    - employing_school_urn
+                    - lead_partner_urn_ukprn
+                    - lead_school_urn
+                    - fund_code
+                    - bursary_level
+                    - previous_last_name
+                    - itt_aim
+                    - course_study_mode
+                    - course_year
+                    - pg_apprenticeship_start_date
+                    - funding_method
+                    - ni_number
+                    - additional_training_initiative
+                    - itt_qualification_aim
+                    - hesa_disabilities
+                    - nationality
+                    - withdraw_reasons
+                    - placements
+                    - degrees
+                    - state
+                    - trainee_id
+                    - application_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  first_names: Marylynn
-                  last_name: Skiles
-                  date_of_birth: "1988-11-05"
-                  created_at: "2024-06-19T12:13:16.177Z"
-                  updated_at: "2024-06-19T12:13:16.190Z"
-                  email: Marylynn.Skiles@example.com
-                  middle_names: Bruen
+                  first_names: Reginald
+                  last_name: Anderson
+                  date_of_birth: '1994-08-31'
+                  created_at: '2024-07-05T14:01:24.996Z'
+                  updated_at: '2024-07-05T14:01:25.042Z'
+                  email: Reginald.Anderson@example.com
+                  middle_names: Erdman
                   training_route:
-                  sex: "12"
+                  sex: '12'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   ethnic_background:
@@ -4981,7 +5836,7 @@ paths:
                   course_subject_three:
                   awarded_at:
                   training_initiative:
-                  study_mode: "01"
+                  study_mode: '01'
                   ebacc: false
                   region:
                   course_education_phase:
@@ -4992,7 +5847,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: "2759984951824"
+                  hesa_id: '5406354081593'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -5002,44 +5857,45 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail: has_placement_detail
-                  provider_trainee_id: 23/24-1022
-                  ukprn: "98516715"
+                  provider_trainee_id: 23/24-1009
+                  lead_partner_id:
+                  ukprn: '96732450'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
                   course_itt_start_date:
-                  course_age_range: "13918"
+                  course_age_range: '13912'
                   expected_end_date:
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
-                  fund_code: "7"
-                  bursary_level: C
-                  previous_last_name: Heathcote
-                  itt_aim: "202"
-                  course_study_mode: "01"
+                  fund_code: '2'
+                  bursary_level: B
+                  previous_last_name: Grant
+                  itt_aim: '202'
+                  course_study_mode: '01'
                   course_year: 2024
-                  pg_apprenticeship_start_date: "2024-06-19"
-                  funding_method: C
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: B
                   ni_number: QQ 12 34 56 C
-                  additional_training_initiative: "026"
-                  itt_qualification_aim: "001"
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '032'
                   hesa_disabilities: {}
                   nationality:
                   withdraw_reasons: []
                   placements:
-                    - urn: "893909"
-                      name: Ironston High
-                      postcode: GU6E 9AB
-                      created_at: "2024-06-19T12:13:16.194Z"
-                      updated_at: "2024-06-19T12:13:16.194Z"
-                      placement_id: TXzfDdZGBWoBd1uaYtQDH8ST
+                  - urn: '878582'
+                    name: Lakeacre Secondary College
+                    postcode: WH8P 6EQ
+                    created_at: '2024-07-05T14:01:25.068Z'
+                    updated_at: '2024-07-05T14:01:25.068Z'
+                    placement_id: GBZQfj1EZaTXhVu9jg9q7UkQ
                   degrees: []
                   state: draft
-                  trainee_id: B7Pxdr2frFUrrTWRBxGf4ZFe
-                  application_id: 123456
-        "404":
+                  trainee_id: hJKBa3WHutaLnxq1oYnbufd8
+                  application_id:
+        '404':
           description: returns status 404 with a valid JSON response
           content:
             application/json:
@@ -5056,39 +5912,46 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Placement(s) not found
+                - error: NotFound
+                  message: Trainee(s) not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+            example: {}
     get:
       summary: show
       tags:
-        - Api::Trainees::Placement
+      - Api::Trainees::Placement
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          example: non-existant
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: X6w35pvBXJMYrbd9fsqPnv2g
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: non-existant
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: ro94Z94ndfkc88HPZYiqri2k
       responses:
-        "200":
+        '200':
           description: returns status 200 with a valid JSON response
           content:
             application/json:
@@ -5111,23 +5974,23 @@ paths:
                       placement_id:
                         type: string
                     required:
-                      - urn
-                      - name
-                      - postcode
-                      - created_at
-                      - updated_at
-                      - placement_id
+                    - urn
+                    - name
+                    - postcode
+                    - created_at
+                    - updated_at
+                    - placement_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  urn: "847112"
-                  name: Ironston High
-                  postcode: P9E 3LL
-                  created_at: "2024-06-19T12:12:50.613Z"
-                  updated_at: "2024-06-19T12:12:50.613Z"
-                  placement_id: 3XLGmuVMksd8kAgT8SNenFiz
-        "404":
+                  urn: '230891'
+                  name: Lakeacre High
+                  postcode: KE1M 4BB
+                  created_at: '2024-07-05T14:00:51.931Z'
+                  updated_at: '2024-07-05T14:00:51.931Z'
+                  placement_id: k6cPJFkgytcxuY69ESMwwFo8
+        '404':
           description: returns status 404 with a valid JSON response
           content:
             application/json:
@@ -5144,37 +6007,37 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Placement(s) not found
+                - error: NotFound
+                  message: Placement(s) not found
     put:
       summary: update
       tags:
-        - Api::Trainees::Placement
+      - Api::Trainees::Placement
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          example: Z3bqwvcWdHFZ2sntNVBvpbCQ
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: 2xcPGj2NZHDsh7Jp3eZ2FH1g
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: BKBVpWtXaRMSYNJpxsms7SCc
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: YK8LXwmMjDcxF95Tk7RoDGAD
       requestBody:
         content:
           application/json:
@@ -5185,34 +6048,34 @@ paths:
                   type: object
                   properties:
                     address:
-                      type: string
                       nullable: true
+                      type: string
                     name:
-                      type: string
                       nullable: true
+                      type: string
                     postcode:
-                      type: string
                       nullable: true
+                      type: string
                     urn:
+                      nullable: true
                       type: string
-                      nullable: true
                     school_id:
-                      nullable: true
                       type: integer
+                      nullable: true
                   required:
-                    - postcode
+                  - postcode
               required:
-                - data
+              - data
             example:
               data:
-                address:
-                name:
-                postcode:
-                urn:
-                school_id: 100
+                address: 1455 Eliz Forest
+                name: Eastern Marvin Academy
+                postcode: GU1 1AA
+                urn: '709181'
+                school_id:
       responses:
-        "200":
-          description: updates an existing placement and returns a 200 (ok) status
+        '200':
+          description: partial update of an existing placement returns 200 (ok) status
           content:
             application/json:
               schema:
@@ -5234,25 +6097,24 @@ paths:
                       placement_id:
                         type: string
                     required:
-                      - urn
-                      - name
-                      - postcode
-                      - created_at
-                      - updated_at
-                      - placement_id
+                    - urn
+                    - name
+                    - postcode
+                    - created_at
+                    - updated_at
+                    - placement_id
                 required:
-                  - data
+                - data
               example:
                 data:
-                  urn: "491475"
-                  name: Icelyn High
-                  postcode: T4A 2PB
-                  created_at: "2024-06-19T12:12:50.213Z"
-                  updated_at: "2024-06-19T12:12:50.259Z"
-                  placement_id: Z3bqwvcWdHFZ2sntNVBvpbCQ
-        "404":
-          description:
-            does not create a new placement and returns a 422 status (unprocessable_entity)
+                  urn: '304657'
+                  name: Icelyn High School
+                  postcode: Y8U 6FA
+                  created_at: '2024-07-05T14:00:49.860Z'
+                  updated_at: '2024-07-05T14:00:49.900Z'
+                  placement_id: 2g5tyhodhQ48Q4QTjudS58Hv
+        '404':
+          description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
           content:
             application/json:
@@ -5269,17 +6131,16 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Trainee(s) not found
-        "422":
-          description:
-            does not create a new placements and returns a 422 status (unprocessable_entity)
+                - error: NotFound
+                  message: Trainee(s) not found
+        '422':
+          description: does not create a new placements and returns a 422 status (unprocessable_entity)
             status
           content:
             application/json:
@@ -5296,34 +6157,502 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: UnprocessableEntity
-                    message: Name can't be blank
-                  - error: UnprocessableEntity
-                    message: School can't be blank
-  "/api/{api_version}/trainees/{trainee_id}/withdraw":
+                - error: UnprocessableEntity
+                  message: Name can't be blank
+                - error: UnprocessableEntity
+                  message: School can't be blank
+  "/api/{api_version}/trainees/{trainee_slug}/recommend-for-qts":
     post:
       summary: create
       tags:
-        - Api::Trainees::Withdraw
+      - Api::Trainees::AwardRecommendation
       parameters:
-        - name: api_version
-          in: path
-          required: true
-          schema:
-            type: string
-          example: v1.0
-        - name: trainee_id
-          in: path
-          required: true
-          schema:
-            type: string
-          example: non-existant
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: QTFAXgCv6NNeMpuGStcKiHLY
+      responses:
+        '202':
+          description: recommends the trainee for a qts award
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      recommended_for_award_at:
+                        type: string
+                      first_names:
+                        type: string
+                      middle_names:
+                        type: string
+                      last_name:
+                        type: string
+                      email:
+                        type: string
+                      ethnic_background:
+                        nullable: true
+                      additional_ethnic_background:
+                        nullable: true
+                      trn:
+                        type: string
+                      withdraw_reasons_details:
+                        nullable: true
+                      withdraw_reasons_dfe_details:
+                        nullable: true
+                      region:
+                        nullable: true
+                      hesa_id:
+                        nullable: true
+                      course_subject_one:
+                        type: string
+                      course_subject_two:
+                        nullable: true
+                      course_subject_three:
+                        nullable: true
+                      date_of_birth:
+                        type: string
+                      created_at:
+                        type: string
+                      updated_at:
+                        type: string
+                      training_route:
+                        nullable: true
+                      sex:
+                        type: string
+                      diversity_disclosure:
+                        type: string
+                      ethnic_group:
+                        nullable: true
+                      disability_disclosure:
+                        nullable: true
+                      itt_start_date:
+                        type: string
+                      outcome_date:
+                        type: string
+                      itt_end_date:
+                        type: string
+                      submitted_for_trn_at:
+                        type: string
+                      withdraw_date:
+                        nullable: true
+                      defer_date:
+                        nullable: true
+                      trainee_start_date:
+                        type: string
+                      reinstate_date:
+                        nullable: true
+                      course_min_age:
+                        type: integer
+                      course_max_age:
+                        type: integer
+                      awarded_at:
+                        nullable: true
+                      training_initiative:
+                        type: string
+                      study_mode:
+                        nullable: true
+                      ebacc:
+                        type: boolean
+                      course_education_phase:
+                        type: string
+                      course_uuid:
+                        nullable: true
+                      lead_school_not_applicable:
+                        type: boolean
+                      employing_school_not_applicable:
+                        type: boolean
+                      submission_ready:
+                        type: boolean
+                      commencement_status:
+                        nullable: true
+                      discarded_at:
+                        nullable: true
+                      created_from_dttp:
+                        type: boolean
+                      additional_dttp_data:
+                        nullable: true
+                      created_from_hesa:
+                        type: boolean
+                      hesa_updated_at:
+                        nullable: true
+                      record_source:
+                        type: string
+                      iqts_country:
+                        nullable: true
+                      hesa_editable:
+                        type: boolean
+                      slug_sent_to_dqt_at:
+                        nullable: true
+                      placement_detail:
+                        nullable: true
+                      provider_trainee_id:
+                        type: string
+                      lead_partner_id:
+                        nullable: true
+                      ukprn:
+                        type: string
+                      ethnicity:
+                        nullable: true
+                      course_qualification:
+                        type: string
+                      course_title:
+                        nullable: true
+                      course_level:
+                        type: string
+                      course_itt_start_date:
+                        type: string
+                      course_age_range:
+                        nullable: true
+                      expected_end_date:
+                        type: string
+                      employing_school_urn:
+                        nullable: true
+                      lead_partner_urn_ukprn:
+                        nullable: true
+                      lead_school_urn:
+                        nullable: true
+                      fund_code:
+                        nullable: true
+                      bursary_level:
+                        nullable: true
+                      nationality:
+                        type: string
+                      withdraw_reasons:
+                        type: array
+                        items: {}
+                      placements:
+                        type: array
+                        items: {}
+                      degrees:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            uk_degree:
+                              type: string
+                            non_uk_degree:
+                              nullable: true
+                            created_at:
+                              type: string
+                            updated_at:
+                              type: string
+                            subject:
+                              type: string
+                            institution:
+                              type: string
+                            graduation_year:
+                              type: integer
+                            grade:
+                              type: string
+                            country:
+                              nullable: true
+                            other_grade:
+                              nullable: true
+                            institution_uuid:
+                              type: string
+                            uk_degree_uuid:
+                              type: string
+                            subject_uuid:
+                              type: string
+                            grade_uuid:
+                              type: string
+                            degree_id:
+                              type: string
+                          required:
+                          - uk_degree
+                          - non_uk_degree
+                          - created_at
+                          - updated_at
+                          - subject
+                          - institution
+                          - graduation_year
+                          - grade
+                          - country
+                          - other_grade
+                          - institution_uuid
+                          - uk_degree_uuid
+                          - subject_uuid
+                          - grade_uuid
+                          - degree_id
+                      state:
+                        type: string
+                      trainee_id:
+                        type: string
+                      application_id:
+                        nullable: true
+                    required:
+                    - recommended_for_award_at
+                    - first_names
+                    - middle_names
+                    - last_name
+                    - email
+                    - ethnic_background
+                    - additional_ethnic_background
+                    - trn
+                    - withdraw_reasons_details
+                    - withdraw_reasons_dfe_details
+                    - region
+                    - hesa_id
+                    - course_subject_one
+                    - course_subject_two
+                    - course_subject_three
+                    - date_of_birth
+                    - created_at
+                    - updated_at
+                    - training_route
+                    - sex
+                    - diversity_disclosure
+                    - ethnic_group
+                    - disability_disclosure
+                    - itt_start_date
+                    - outcome_date
+                    - itt_end_date
+                    - submitted_for_trn_at
+                    - withdraw_date
+                    - defer_date
+                    - trainee_start_date
+                    - reinstate_date
+                    - course_min_age
+                    - course_max_age
+                    - awarded_at
+                    - training_initiative
+                    - study_mode
+                    - ebacc
+                    - course_education_phase
+                    - course_uuid
+                    - lead_school_not_applicable
+                    - employing_school_not_applicable
+                    - submission_ready
+                    - commencement_status
+                    - discarded_at
+                    - created_from_dttp
+                    - additional_dttp_data
+                    - created_from_hesa
+                    - hesa_updated_at
+                    - record_source
+                    - iqts_country
+                    - hesa_editable
+                    - slug_sent_to_dqt_at
+                    - placement_detail
+                    - provider_trainee_id
+                    - lead_partner_id
+                    - ukprn
+                    - ethnicity
+                    - course_qualification
+                    - course_title
+                    - course_level
+                    - course_itt_start_date
+                    - course_age_range
+                    - expected_end_date
+                    - employing_school_urn
+                    - lead_partner_urn_ukprn
+                    - lead_school_urn
+                    - fund_code
+                    - bursary_level
+                    - nationality
+                    - withdraw_reasons
+                    - placements
+                    - degrees
+                    - state
+                    - trainee_id
+                    - application_id
+                required:
+                - data
+              example:
+                data:
+                  recommended_for_award_at: '2024-07-05T14:00:52Z'
+                  first_names: Trinidad
+                  middle_names: Rath
+                  last_name: Rath
+                  email: Trinidad.Rath@example.com
+                  ethnic_background:
+                  additional_ethnic_background:
+                  trn: '2411953'
+                  withdraw_reasons_details:
+                  withdraw_reasons_dfe_details:
+                  region:
+                  hesa_id:
+                  course_subject_one: '100403'
+                  course_subject_two:
+                  course_subject_three:
+                  date_of_birth: '1995-03-09'
+                  created_at: '2024-07-05T14:00:52.736Z'
+                  updated_at: '2024-07-05T14:00:52.736Z'
+                  training_route:
+                  sex: '96'
+                  diversity_disclosure: diversity_not_disclosed
+                  ethnic_group:
+                  disability_disclosure:
+                  itt_start_date: '2023-08-08'
+                  outcome_date: '2024-07-05'
+                  itt_end_date: '2024-07-08'
+                  submitted_for_trn_at: '2024-07-05T14:00:52.736Z'
+                  withdraw_date:
+                  defer_date:
+                  trainee_start_date: '2023-08-22'
+                  reinstate_date:
+                  course_min_age: 11
+                  course_max_age: 18
+                  awarded_at:
+                  training_initiative: '026'
+                  study_mode:
+                  ebacc: false
+                  course_education_phase: secondary
+                  course_uuid:
+                  lead_school_not_applicable: false
+                  employing_school_not_applicable: false
+                  submission_ready: true
+                  commencement_status:
+                  discarded_at:
+                  created_from_dttp: false
+                  additional_dttp_data:
+                  created_from_hesa: false
+                  hesa_updated_at:
+                  record_source: manual
+                  iqts_country:
+                  hesa_editable: false
+                  slug_sent_to_dqt_at:
+                  placement_detail:
+                  provider_trainee_id: 23/24-217
+                  lead_partner_id:
+                  ukprn: '72433722'
+                  ethnicity:
+                  course_qualification: QTS
+                  course_title:
+                  course_level: postgrad
+                  course_itt_start_date: '2023-08-08'
+                  course_age_range:
+                  expected_end_date: '2024-07-08'
+                  employing_school_urn:
+                  lead_partner_urn_ukprn:
+                  lead_school_urn:
+                  fund_code:
+                  bursary_level:
+                  nationality: JO
+                  withdraw_reasons: []
+                  placements: []
+                  degrees:
+                  - uk_degree: '305'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:00:52.736Z'
+                    updated_at: '2024-07-05T14:00:52.736Z'
+                    subject: '100632'
+                    institution: '0050'
+                    graduation_year: 2006
+                    grade: '01'
+                    country:
+                    other_grade:
+                    institution_uuid: b1c53e05-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: 656a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: a18270f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: WLpjxh3vCuGvSWKrC7YSsZdv
+                  state: recommended_for_award
+                  trainee_id: QTFAXgCv6NNeMpuGStcKiHLY
+                  application_id:
+        '404':
+          description: returns 404
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        error:
+                          type: string
+                        message:
+                          type: string
+                      required:
+                      - error
+                      - message
+                required:
+                - errors
+              example:
+                errors:
+                - error: NotFound
+                  message: Trainee(s) not found
+        '422':
+          description: does not recommend the trainee for a qts award
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        error:
+                          type: string
+                        message:
+                          type: string
+                      required:
+                      - error
+                      - message
+                required:
+                - errors
+              example:
+                errors:
+                - error: UnprocessableEntity
+                  message: QTS standards met date can't be blank
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    qts_standards_met_date:
+                      type: string
+                  required:
+                  - qts_standards_met_date
+              required:
+              - data
+            example:
+              data:
+                qts_standards_met_date: '2024-07-05'
+  "/api/{api_version}/trainees/{trainee_slug}/withdraw":
+    post:
+      summary: create
+      tags:
+      - Api::Trainees::Withdraw
+      parameters:
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v1.0
+      - name: trainee_slug
+        in: path
+        required: true
+        schema:
+          type: string
+        example: dyetNWMCUwNMG3RrsaYA28oP
       requestBody:
         content:
           application/json:
@@ -5341,21 +6670,22 @@ paths:
                 withdraw_reasons_dfe_details:
                   type: string
               required:
-                - reasons
-                - withdraw_date
-                - withdraw_reasons_details
-                - withdraw_reasons_dfe_details
+              - reasons
+              - withdraw_date
+              - withdraw_reasons_details
+              - withdraw_reasons_dfe_details
             example:
               reasons:
-                - unknown
-              withdraw_date: 2024-06-19 12:13:03 UTC
-              withdraw_reasons_details:
-                I'm not going there to die. I'm going to find
-                out if I'm really alive.
-              withdraw_reasons_dfe_details: A girl just fell from the sky, boss!
+              - unknown
+              withdraw_date: 2024-07-05 14:01:06 UTC
+              withdraw_reasons_details: When I was a cop, this was my beat. I’m the
+                Black Dog and when I bite I don’t let go. I have no regrets about
+                her, but I’ll settle this score on my own turf.
+              withdraw_reasons_dfe_details: I'm going up to my room now, where I may
+                die.
       responses:
-        "200":
-          description: calls the dqt withdraw service
+        '200':
+          description: change the trainee
           content:
             application/json:
               schema:
@@ -5441,8 +6771,8 @@ paths:
                       awarded_at:
                         nullable: true
                       training_initiative:
-                        nullable: true
                         type: string
+                        nullable: true
                       study_mode:
                         type: string
                       ebacc:
@@ -5477,6 +6807,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                      lead_partner_id:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -5554,6 +6886,7 @@ paths:
                               type: integer
                             grade:
                               type: string
+                              nullable: true
                             country:
                               nullable: true
                             other_grade:
@@ -5569,27 +6902,27 @@ paths:
                             degree_id:
                               type: string
                           required:
-                            - uk_degree
-                            - non_uk_degree
-                            - created_at
-                            - updated_at
-                            - subject
-                            - institution
-                            - graduation_year
-                            - grade
-                            - country
-                            - other_grade
-                            - institution_uuid
-                            - uk_degree_uuid
-                            - subject_uuid
-                            - grade_uuid
-                            - degree_id
+                          - uk_degree
+                          - non_uk_degree
+                          - created_at
+                          - updated_at
+                          - subject
+                          - institution
+                          - graduation_year
+                          - grade
+                          - country
+                          - other_grade
+                          - institution_uuid
+                          - uk_degree_uuid
+                          - subject_uuid
+                          - grade_uuid
+                          - degree_id
                       state:
                         type: string
                       trainee_id:
                         type: string
                       application_id:
-                        type: integer
+                        nullable: true
                       id:
                         type: integer
                       dttp_id:
@@ -5622,18 +6955,18 @@ paths:
                           iqts_country:
                             type: boolean
                         required:
-                          - personal_details
-                          - contact_details
-                          - degrees
-                          - placements
-                          - diversity
-                          - course_details
-                          - training_details
-                          - trainee_start_status
-                          - trainee_data
-                          - schools
-                          - funding
-                          - iqts_country
+                        - personal_details
+                        - contact_details
+                        - degrees
+                        - placements
+                        - diversity
+                        - course_details
+                        - training_details
+                        - trainee_start_status
+                        - trainee_data
+                        - schools
+                        - funding
+                        - iqts_country
                       provider_id:
                         type: integer
                       placement_assignment_dttp_id:
@@ -5669,105 +7002,107 @@ paths:
                       application_choice_id:
                         nullable: true
                     required:
-                      - commencement_status
-                      - withdraw_date
-                      - withdraw_reasons_details
-                      - withdraw_reasons_dfe_details
-                      - updated_at
-                      - first_names
-                      - middle_names
-                      - last_name
-                      - email
-                      - ethnic_background
-                      - additional_ethnic_background
-                      - trn
-                      - region
-                      - hesa_id
-                      - course_subject_one
-                      - course_subject_two
-                      - course_subject_three
-                      - record_source
-                      - date_of_birth
-                      - created_at
-                      - training_route
-                      - sex
-                      - diversity_disclosure
-                      - ethnic_group
-                      - disability_disclosure
-                      - itt_start_date
-                      - outcome_date
-                      - itt_end_date
-                      - submitted_for_trn_at
-                      - defer_date
-                      - recommended_for_award_at
-                      - trainee_start_date
-                      - reinstate_date
-                      - course_min_age
-                      - course_max_age
-                      - awarded_at
-                      - training_initiative
-                      - study_mode
-                      - ebacc
-                      - course_education_phase
-                      - course_uuid
-                      - lead_school_not_applicable
-                      - employing_school_not_applicable
-                      - submission_ready
-                      - discarded_at
-                      - created_from_dttp
-                      - additional_dttp_data
-                      - created_from_hesa
-                      - hesa_updated_at
-                      - iqts_country
-                      - hesa_editable
-                      - slug_sent_to_dqt_at
-                      - placement_detail
-                      - provider_trainee_id
-                      - state
+                    - commencement_status
+                    - withdraw_date
+                    - withdraw_reasons_details
+                    - withdraw_reasons_dfe_details
+                    - updated_at
+                    - first_names
+                    - middle_names
+                    - last_name
+                    - email
+                    - ethnic_background
+                    - additional_ethnic_background
+                    - trn
+                    - region
+                    - hesa_id
+                    - course_subject_one
+                    - course_subject_two
+                    - course_subject_three
+                    - record_source
+                    - date_of_birth
+                    - created_at
+                    - training_route
+                    - sex
+                    - diversity_disclosure
+                    - ethnic_group
+                    - disability_disclosure
+                    - itt_start_date
+                    - outcome_date
+                    - itt_end_date
+                    - submitted_for_trn_at
+                    - defer_date
+                    - recommended_for_award_at
+                    - trainee_start_date
+                    - reinstate_date
+                    - course_min_age
+                    - course_max_age
+                    - awarded_at
+                    - training_initiative
+                    - study_mode
+                    - ebacc
+                    - course_education_phase
+                    - course_uuid
+                    - lead_school_not_applicable
+                    - employing_school_not_applicable
+                    - submission_ready
+                    - discarded_at
+                    - created_from_dttp
+                    - additional_dttp_data
+                    - created_from_hesa
+                    - hesa_updated_at
+                    - iqts_country
+                    - hesa_editable
+                    - slug_sent_to_dqt_at
+                    - placement_detail
+                    - provider_trainee_id
+                    - lead_partner_id
+                    - state
                 required:
-                  - data
+                - data
               example:
                 data:
                   commencement_status:
-                  withdraw_date: "2024-06-19T12:13:03.000Z"
-                  withdraw_reasons_details:
-                    I'm not going there to die. I'm going
-                    to find out if I'm really alive.
-                  withdraw_reasons_dfe_details: A girl just fell from the sky, boss!
-                  updated_at: "2024-06-19T12:13:03.162Z"
-                  first_names: Rodrick
-                  middle_names: Klein
-                  last_name: Crooks
-                  email: Rodrick.Crooks@example.com
+                  withdraw_date: '2024-07-05T14:01:06.000Z'
+                  withdraw_reasons_details: When I was a cop, this was my beat. I’m
+                    the Black Dog and when I bite I don’t let go. I have no regrets
+                    about her, but I’ll settle this score on my own turf.
+                  withdraw_reasons_dfe_details: I'm going up to my room now, where
+                    I may die.
+                  updated_at: '2024-07-05T14:01:06.294Z'
+                  first_names: Mitchell
+                  middle_names: Hilll
+                  last_name: McClure
+                  email: Mitchell.McClure@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: "8278776"
+                  trn: '3195976'
                   region:
-                  hesa_id: "3510602142207"
-                  course_subject_one: "100403"
+                  hesa_id: '2075563986795'
+                  course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: "1970-07-17"
-                  created_at: "2024-06-19T12:13:03.152Z"
+                  date_of_birth: '1995-04-15'
+                  created_at: '2024-07-05T14:01:06.281Z'
                   training_route:
-                  sex: "99"
+                  sex: '10'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: "2023-08-14"
+                  itt_start_date: '2023-08-27'
                   outcome_date:
-                  itt_end_date: "2025-07-11"
-                  submitted_for_trn_at: "2024-06-19T12:13:03.156Z"
+                  itt_end_date: '2025-07-20'
+                  submitted_for_trn_at: '2024-07-05T14:01:06.285Z'
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: "2023-08-17"
+                  trainee_start_date: '2023-08-30'
                   reinstate_date:
                   course_min_age: 11
-                  course_max_age: 16
+                  course_max_age: 18
                   awarded_at:
                   training_initiative:
-                  study_mode: "01"
+                  study_mode: '01'
                   ebacc: false
                   course_education_phase: secondary
                   course_uuid:
@@ -5783,55 +7118,56 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 23/24-242
-                  ukprn: "20734231"
+                  provider_trainee_id: 23/24-232
+                  lead_partner_id:
+                  ukprn: '12849068'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: "2023-08-14"
-                  course_age_range: "13914"
-                  expected_end_date: "2025-07-11"
+                  course_itt_start_date: '2023-08-27'
+                  course_age_range: '13917'
+                  expected_end_date: '2025-07-20'
                   employing_school_urn:
                   lead_partner_urn_ukprn:
                   lead_school_urn:
-                  fund_code: "2"
-                  bursary_level: "9"
-                  previous_last_name: Reichel
-                  itt_aim: "202"
-                  course_study_mode: "01"
+                  fund_code: '2'
+                  bursary_level: B
+                  previous_last_name: Cremin
+                  itt_aim: '202'
+                  course_study_mode: '01'
                   course_year: 2024
-                  pg_apprenticeship_start_date: "2024-06-19"
-                  funding_method: "9"
+                  pg_apprenticeship_start_date: '2024-07-05'
+                  funding_method: B
                   ni_number: QQ 12 34 56 C
-                  additional_training_initiative: "026"
-                  itt_qualification_aim: "028"
+                  additional_training_initiative: '026'
+                  itt_qualification_aim: '003'
                   hesa_disabilities: {}
-                  nationality: GN
+                  nationality: AE
                   withdraw_reasons:
-                    - unknown
+                  - unknown
                   placements: []
                   degrees:
-                    - uk_degree: "078"
-                      non_uk_degree:
-                      created_at: "2024-06-19T12:13:03.163Z"
-                      updated_at: "2024-06-19T12:13:03.163Z"
-                      subject: "100456"
-                      institution: "0126"
-                      graduation_year: 1980
-                      grade: "13"
-                      country:
-                      other_grade:
-                      institution_uuid: f58f17b0-a141-e811-80ff-3863bb351d40
-                      uk_degree_uuid: 116a5652-c197-e711-80d8-005056ac45bb
-                      subject_uuid: bf8170f0-5dce-e911-a985-000d3ab79618
-                      grade_uuid: df874702-2bcc-4aab-adaa-2efdd3a8dec4
-                      degree_id: FM36BawcUTVpehrxwHAbADCL
+                  - uk_degree: '302'
+                    non_uk_degree:
+                    created_at: '2024-07-05T14:01:06.295Z'
+                    updated_at: '2024-07-05T14:01:06.295Z'
+                    subject: '101202'
+                    institution: '0049'
+                    graduation_year: 1982
+                    grade: '14'
+                    country:
+                    other_grade:
+                    institution_uuid: dfdb7129-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: 5f6a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: ed8570f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
+                    degree_id: 8w8YbMBNP3f3df1BbYqxinBM
                   state: withdrawn
-                  trainee_id: 9WUiBBd4tzH9HFNVBB8Fm66S
-                  application_id: 123456
-                  id: 204
-                  dttp_id: c8705b0a-6ac6-4335-8b25-950714ddd382
+                  trainee_id: UhRq6M56D1JbiXXrrtX4LpEj
+                  application_id:
+                  id: 190
+                  dttp_id: 4c58db6b-b7aa-42e6-836c-5ee5fcf14a19
                   progress:
                     personal_details: true
                     contact_details: true
@@ -5845,9 +7181,9 @@ paths:
                     schools: true
                     funding: true
                     iqts_country: false
-                  provider_id: 222
+                  provider_id: 208
                   placement_assignment_dttp_id:
-                  slug: smrd5zpRQbjLAZkUSBm3hk9K
+                  slug: cbfB7yAAGHxKJB32XPjQDaoa
                   dttp_update_sha:
                   dormancy_dttp_id:
                   lead_school_id:
@@ -5862,7 +7198,7 @@ paths:
                   end_academic_cycle_id:
                   hesa_trn_submission_id:
                   application_choice_id:
-        "401":
+        '401':
           description: did not change the trainee
           content:
             application/json:
@@ -5872,10 +7208,10 @@ paths:
                   error:
                     type: string
                 required:
-                  - error
+                - error
               example:
                 error: Unauthorized
-        "404":
+        '404':
           description: returns status 404 with a valid JSON response
           content:
             application/json:
@@ -5892,15 +7228,15 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: NotFound
-                    message: Trainee(s) not found
-        "422":
+                - error: NotFound
+                  message: Trainee(s) not found
+        '422':
           description: returns status 422 with a valid JSON response
           content:
             application/json:
@@ -5917,16 +7253,13 @@ paths:
                         message:
                           type: string
                       required:
-                        - error
-                        - message
+                      - error
+                      - message
                 required:
-                  - errors
+                - errors
               example:
                 errors:
-                  - error: UnprocessableEntity
-                    message: Withdraw date Choose a withdrawal date
-                  - error: UnprocessableEntity
-                    message:
-                      Reasons Choose one or more reasons why the trainee withdrew
-                      from the course, or select "Unknown"
+                - error: StateTransitionError
+                  message: It's not possible to perform this action while the trainee
+                    is in its current state
 servers: []

--- a/spec/requests/api/v1_0/trainees/post_withdraw_spec.rb
+++ b/spec/requests/api/v1_0/trainees/post_withdraw_spec.rb
@@ -9,11 +9,11 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
     let!(:provider) { auth_token.provider }
 
     context "non existant trainee" do
-      let(:slug) { "non-existant" }
+      let(:trainee_id) { "non-existant" }
 
       it "returns status 404 with a valid JSON response" do
         post(
-          "/api/v1.0/trainees/#{slug}/withdraw",
+          "/api/v1.0/trainees/#{trainee_id}/withdraw",
           headers: { Authorization: "Bearer #{token}", **json_headers },
         )
 
@@ -33,23 +33,23 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
           withdraw_reasons_dfe_details: Faker::JapaneseMedia::StudioGhibli.quote,
         }
       end
-      let(:slug) { trainee.slug }
+      let(:trainee_id) { trainee.slug }
 
       it "returns status 200 with a valid JSON response" do
         post(
-          "/api/v1.0/trainees/#{slug}/withdraw",
+          "/api/v1.0/trainees/#{trainee_id}/withdraw",
           headers: { Authorization: "Bearer #{token}", **json_headers },
           params: params.to_json,
         )
         expect(response).to have_http_status(:ok)
 
-        expect(response.parsed_body.dig(:data, :trainee_id)).to eql(slug)
+        expect(response.parsed_body.dig(:data, :trainee_id)).to eql(trainee_id)
       end
 
       it "change the trainee" do
         expect {
           post(
-            "/api/v1.0/trainees/#{slug}/withdraw",
+            "/api/v1.0/trainees/#{trainee_id}/withdraw",
             headers: { Authorization: "Bearer #{token}", **json_headers },
             params: params.to_json,
           )
@@ -62,7 +62,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
         expect(Trainees::Withdraw).to receive(:call).with(trainee:).at_least(:once)
 
         post(
-          "/api/v1.0/trainees/#{slug}/withdraw",
+          "/api/v1.0/trainees/#{trainee_id}/withdraw",
           headers: { Authorization: "Bearer #{token}", **json_headers },
           params: params.to_json,
         )
@@ -72,7 +72,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
         expect(Api::V10::TraineeSerializer).to receive(:new).with(trainee).and_return(double(as_hash: trainee.attributes)).at_least(:once)
 
         post(
-          "/api/v1.0/trainees/#{slug}/withdraw",
+          "/api/v1.0/trainees/#{trainee_id}/withdraw",
           headers: { Authorization: "Bearer #{token}", **json_headers },
           params: params.to_json,
         )
@@ -83,7 +83,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
 
         it "returns status 422 with a valid JSON response" do
           post(
-            "/api/v1.0/trainees/#{slug}/withdraw",
+            "/api/v1.0/trainees/#{trainee_id}/withdraw",
             headers: { Authorization: "Bearer #{token}", **json_headers },
             params: params.to_json,
           )
@@ -98,7 +98,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
 
         it "did not change the trainee" do
           expect {
-            post "/api/v1.0/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat", **json_headers }
+            post "/api/v1.0/trainees/#{trainee_id}/withdraw", headers: { Authorization: "Bearer bat", **json_headers }
           }.not_to change(trainee, :withdraw_date)
         end
       end
@@ -106,11 +106,11 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
 
     context "with a non-withdrawable trainee" do
       let(:trainee) { create(:trainee, :itt_start_date_in_the_future, provider:) }
-      let(:slug) { trainee.slug }
+      let(:trainee_id) { trainee.slug }
 
       it "returns status 422 with a valid JSON response" do
         post(
-          "/api/v1.0/trainees/#{slug}/withdraw",
+          "/api/v1.0/trainees/#{trainee_id}/withdraw",
           headers: { Authorization: "Bearer #{token}", **json_headers },
         )
         expect(response).to have_http_status(:unprocessable_entity)
@@ -119,7 +119,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
 
       it "did not change the trainee" do
         expect {
-          post "/api/v1.0/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat", **json_headers }
+          post "/api/v1.0/trainees/#{trainee_id}/withdraw", headers: { Authorization: "Bearer bat", **json_headers }
         }.not_to change(trainee, :withdraw_date)
       end
     end


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/pw2kXUkK)

We want to refactor the withdraw endpoint to have the params sent in the request body (rather than the query string) so that it is consistent with the other POST ‘action’ endpoints like defer and recommend-for-qts.

### Changes proposed in this pull request
The [withdrawal controller](https://github.com/DFE-Digital/register-trainee-teachers/blob/de2f12d48a63bf7dba6410291d1507bbceea9192/app/controllers/api/trainees/withdraw_controller.rb#L29) for the API already supported sending params in the request body, as well as query params. So the only things to update were the documentation and the [hopscotch settings](https://hoppscotch.io/). 

#### _Updated Reference Page_
`api-docs/v1.0/reference#code-post-trainees-trainee_id-withdraw-code`
Updated by editing [app/views/api_docs/reference/v1.0/_reference.md](https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/views/api_docs/reference/v1.0/_reference.md) manually. 

<img width="400" alt="Screenshot 2024-07-05 at 15 49 10" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/4200630/4fd92420-97d6-4bce-8337-3d776feeb882">

#### _Updated Open API Page_
`api-docs/v1.0/openapi#tag/Api::Trainees::Withdraw`
Updated using the rspec-[openapi](https://github.com/exoego/rspec-openapi) gem: 
* Ran the following command `OPENAPI=1 bundle exec rspec spec/requests/api/v1_0/`
* Checked that the `public/openapi/v1.0.yaml` file had been changed. The specs themselves were already POST-ing the parameters in the request body. 

<img width="400" alt="Screenshot 2024-07-05 at 15 28 47" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/4200630/8aadb3ba-7302-455e-b829-a53fe89a1ac5">

#### Hopscotch Updated
<img width="1000" alt="Screenshot 2024-07-05 at 15 58 03" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/4200630/8e2ef3e9-8d32-42aa-b005-a6ca8bc61cce">

### Guidance to review
Is it necessary at this point to have both the reference markdown files and the openapi pages generated with rspec? Having the rspec-openapi pages seems much more convenient, can we just stick with those and discard the reference files? 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
