### PR TITLE
[7323] Fix bulk award uploads

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -405,6 +405,10 @@ module Reports
       trainee.hesa_id&.starts_with?("'") ? trainee.hesa_id : trainee.hesa_id&.prepend("'") # prevent Excel from converting it to scientific notation
     end
 
+    def sanitised_hesa_id
+      trainee.hesa_id&.gsub(/[^\d]/, "")
+    end
+
   private
 
     def placements

--- a/app/services/bulk_update/recommendations_uploads/validate_csv_row.rb
+++ b/app/services/bulk_update/recommendations_uploads/validate_csv_row.rb
@@ -102,7 +102,7 @@ module BulkUpdate
       def hesa_id
         return unless column_exists?(Reports::BulkRecommendReport::HESA_ID)
 
-        @messages << error_message(:hesa_id) if trainee.hesa_id != row.sanitised_hesa_id
+        @messages << error_message(:hesa_id) if trainee.sanitised_hesa_id != row.sanitised_hesa_id
       end
 
       def provider_trainee_id


### PR DESCRIPTION
### Context

Following on from https://github.com/DFE-Digital/register-trainee-teachers/pull/4405 there was an issue when prefixed `hesa_id`s were compared after the CSV upload.

### Changes proposed in this pull request

* Sanitise both `hesa_id`s before comparing so that prefixed quotes `'` are ignored.

### Guidance to review

Generate a bulk award CSV, download it and add an award date, then upload it to check that no errors are shown.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
