### PR TITLE
[7333] Revise the What type of training are they doing? page for 2024-2025 academic year

### DIFF
--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -22,13 +22,11 @@
     <% end %>
 
     <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "s", text: t(".training_course_routes.postgrad_salaried"), tag: "h2" }) do %>
-      <% if FeatureService.enabled?("routes.provider_led_postgrad_salaried") %>
-        <%= f.govuk_radio_button(
-          :training_route,
-          TRAINING_ROUTE_ENUMS[:provider_led_postgrad_salaried],
-          label: { text: t("activerecord.attributes.trainee.training_routes.itt.provider_led_postgrad_salaried") }
-        ) %>
-      <% end %>
+      <%= f.govuk_radio_button(
+        :training_route,
+        TRAINING_ROUTE_ENUMS[:school_direct_salaried],
+        label: { text: t("activerecord.attributes.trainee.training_routes.itt.school_direct_salaried") }
+      ) %>
       <% [:pg_teaching_apprenticeship, :early_years_salaried].each do |option| %>
         <%= f.govuk_radio_button(
           :training_route,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1212,7 +1212,7 @@ en:
         hints:
           provider_led_postgrad: &provider_led_hint Training run by higher education institutions (HEIs) or school centred initial teacher training (SCITT) providers
           provider_led_undergrad: *provider_led_hint
-        lede: Provider led training is run by higher education institues (HEIs) or school centred initial teacher training (SCITTs) providers.
+        lede: Primary and secondary training is run by higher education institutions (HEIS) or school centred initial teacher training (SCITTs) providers.
         training_course_routes:
           postgrad_fee_funded: Post-grad (fee funded)
           postgrad_salaried: Post-grad (salaried)
@@ -1309,10 +1309,11 @@ en:
             early_years_salaried: Early years
             early_years_undergrad: Early years
             iqts: International qualified teacher status (iQTS)
-            provider_led_postgrad: Provider-led
+            provider_led_postgrad: &provider_led_postgrad Primary and secondary
             provider_led_postgrad_salaried: Provider-led
-            provider_led_undergrad: Provider-led
+            provider_led_undergrad: *provider_led_postgrad
             pg_teaching_apprenticeship: Teaching apprenticeship
+            school_direct_salaried: School direct
             hpitt_postgrad: HPITT
             opt_in_undergrad: Opt-in
             provider_led_postgrad_salaried: Provider-led

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1212,7 +1212,7 @@ en:
         hints:
           provider_led_postgrad: &provider_led_hint Training run by higher education institutions (HEIs) or school centred initial teacher training (SCITT) providers
           provider_led_undergrad: *provider_led_hint
-        lede: Primary and secondary training is run by higher education institutions (HEIS) or school centred initial teacher training (SCITTs) providers.
+        lede: Primary and secondary training is run by higher education institutions (HEIs) or school centred initial teacher training (SCITTs) providers.
         training_course_routes:
           postgrad_fee_funded: Post-grad (fee funded)
           postgrad_salaried: Post-grad (salaried)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1214,8 +1214,8 @@ en:
           provider_led_undergrad: *provider_led_hint
         lede: Primary and secondary training is run by higher education institutions (HEIs) or school centred initial teacher training (SCITTs) providers.
         training_course_routes:
-          postgrad_fee_funded: Post-grad (fee funded)
-          postgrad_salaried: Post-grad (salaried)
+          postgrad_fee_funded: Postgrad (fee funded)
+          postgrad_salaried: Postgrad (salaried)
           undergrad_fee_funded: Undergrad (fee funded)
           other: Other
     start_statuses:

--- a/spec/features/end_to_end/provider_led_postgrad_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_postgrad_salaried_journey_spec.rb
@@ -17,12 +17,11 @@ feature "provider-led (postgrad) salaried end-to-end journey" do
 
     scenario(
       "submit for TRN",
-      "feature_routes.provider_led_postgrad_salaried": true,
       feature_itt_reform: true,
       feature_publish_course_details: true,
     ) do
       ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-      given_i_have_created_a_provider_led_salaried_trainee
+      given_i_have_created_a_school_direct_salaried_trainee
       and_the_personal_details_is_complete
       and_the_contact_details_is_complete
       and_the_diversity_information_is_complete

--- a/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
@@ -57,8 +57,7 @@ feature "Create trainee journey" do
     and_i_should_not_see_school_direct_tuition_fee_route
   end
 
-  scenario "school direct radio buttons should not be shown when itt reform feature set to true", feature_itt_reform: true do
-    and_i_should_not_see_school_direct_salaried_route
+  scenario "school direct tuition fee radio button should not be shown when itt reform feature set to true", feature_itt_reform: true do
     and_i_should_not_see_school_direct_tuition_fee_route
   end
 


### PR DESCRIPTION
### Context

Apply requested changes from Market Regs

[7333-revise-the-what-type-of-training-are-they-doing-page-for-2024-2025-academic-year](https://trello.com/c/DLD69f6E/7333-revise-the-what-type-of-training-are-they-doing-page-for-2024-2025-academic-year)

<img width="552" alt="Screenshot 2024-07-11 at 09 58 11" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/350425/ecbf3c9b-c7a8-4baa-b6d2-020b2682e02f">

### Changes proposed in this pull request

* Refactor `training_routes/form_fields.html.erb`
* Refactor `en.yml`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
