### PR TITLE
Fix RemoveDuplicates Rake Task

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -319,7 +319,7 @@ trainee_id,email
 Suppose you have a CSV file named `trainees.csv` in the root directory of your project. To run the Rake task, you would use:
 
 ```
-rake trainee:remove_duplicates trainees.csv
+bundle exec rake trainee:remove_duplicates\[trainees.csv\]
 ```
 
 This command will:

--- a/lib/tasks/remove_duplicates.rake
+++ b/lib/tasks/remove_duplicates.rake
@@ -4,7 +4,7 @@ require "csv"
 
 namespace :trainee do
   desc "Remove duplicate trainees based on email address, given a CSV file with trainee ids"
-  task remove_duplicates: :environment do |_t, args|
+  task :remove_duplicates, [:file_path] => [:environment]  do |_t, args|
     file_path = args[:file_path]
 
     if file_path.nil? || !File.exist?(file_path)

--- a/lib/tasks/remove_duplicates.rake
+++ b/lib/tasks/remove_duplicates.rake
@@ -4,7 +4,7 @@ require "csv"
 
 namespace :trainee do
   desc "Remove duplicate trainees based on email address, given a CSV file with trainee ids"
-  task :remove_duplicates, [:file_path] => [:environment]  do |_t, args|
+  task :remove_duplicates, [:file_path] => [:environment] do |_t, args|
     file_path = args[:file_path]
 
     if file_path.nil? || !File.exist?(file_path)


### PR DESCRIPTION
### Context
When trying to run this rake task, we noticed that the file path argument could not be found, even when it was explicitly specified.

### Changes proposed in this pull request
This updates the task and the documentation around it, to reflect the now working version. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
