### PR TITLE
Metrics Endpoint for API Monitoring 

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -82,10 +82,36 @@ module Api
 
     def track_request_metrics
       start = Time.zone.now
-      Yabeda.register_api.requests_total.increment({})
-      yield
+      track_total_requests
+      begin
+        yield
+      rescue => ex
+        track_unsuccessful_requests
+        raise ex
+      ensure
+        track_request_duration(start:)
+      end
+    end
+
+    def track_total_requests
+      Yabeda.register_api.requests_total.increment(tracking_labels)
+    end
+
+    def track_unsuccessful_requests
+      Yabeda.register_api.unsuccessful_requests_total.increment(tracking_labels)
+    end
+
+    def track_request_duration(start:)
       duration = Time.zone.now - start
-      Yabeda.register_api.request_duration.measure({}, duration)
+      Yabeda.register_api.request_duration.measure(tracking_labels, duration)
+    end
+
+    def tracking_labels
+      @tracking_labels ||= {
+        method: request.method,
+        controller: controller_name,
+        action: action_name
+      }
     end
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -86,7 +86,7 @@ module Api
       begin
         yield
       rescue => ex
-        track_unsuccessful_requests
+        track_unsuccessful_requests(ex)
         raise ex
       ensure
         track_request_duration(start:)
@@ -98,8 +98,9 @@ module Api
       Yabeda.register_api.requests_total.increment(tracking_labels)
     end
 
-    def track_unsuccessful_requests
-      Yabeda.register_api.unsuccessful_requests_total.increment(tracking_labels)
+    def track_unsuccessful_requests(ex)
+      labels = tracking_labels.merge(error_code: ex.class.name, error_message: ex.message[0, 100])
+      Yabeda.register_api.unsuccessful_requests_total.increment(labels)
     end
 
     def track_request_duration(start:)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -90,6 +90,7 @@ module Api
         raise ex
       ensure
         track_request_duration(start:)
+        track_response_size
       end
     end
 
@@ -104,6 +105,11 @@ module Api
     def track_request_duration(start:)
       duration = Time.zone.now - start
       Yabeda.register_api.request_duration.measure(tracking_labels, duration)
+    end
+
+    def track_response_size
+      response_size = response.body.bytesize
+      Yabeda.register_api.response_size.measure(tracking_labels, response_size)
     end
 
     def tracking_labels

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,7 +6,6 @@ module Api
     include ApiMonitorable
 
     before_action :check_feature_flag!, :authenticate!
-    around_action :track_request_metrics
 
     rescue_from ActiveRecord::RecordNotFound do |e|
       render_not_found(message: "#{e.model}(s) not found")
@@ -80,4 +79,5 @@ module Api
         @auth_token = AuthenticationToken.authenticate(bearer_token)
       end
     end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
     render "errors/forbidden", status: :forbidden, formats: [:html]
   end
 
-  before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
+  before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required?(request.path) }
 
   helper_method :current_user, :authenticated?, :audit_user, :trainee_editable?
 

--- a/app/controllers/concerns/api_monitorable.rb
+++ b/app/controllers/concerns/api_monitorable.rb
@@ -1,0 +1,50 @@
+module ApiMonitorable
+  extend ActiveSupport::Concern
+
+  included do
+    around_action :monitor_api_request
+  end
+
+  private
+
+  def monitor_api_request
+    start = Time.zone.now
+    track_total_requests
+    begin
+      yield
+    rescue => ex
+      track_unsuccessful_requests(ex)
+      raise ex
+    ensure
+      track_request_duration(start)
+      track_response_size
+    end
+  end
+
+  def track_total_requests
+    Yabeda.register_api.requests_total.increment(tracking_labels)
+  end
+
+  def track_unsuccessful_requests(ex)
+    labels = tracking_labels.merge(error_code: ex.class.name, error_message: ex.message[0, 100])
+    Yabeda.register_api.unsuccessful_requests_total.increment(labels)
+  end
+
+  def track_request_duration(start)
+    duration = Time.zone.now - start
+    Yabeda.register_api.request_duration.measure(tracking_labels, duration)
+  end
+
+  def track_response_size
+    response_size = response.body.bytesize
+    Yabeda.register_api.response_size.measure(tracking_labels, response_size)
+  end
+
+  def tracking_labels
+    @tracking_labels ||= {
+      method: request.method,
+      controller: controller_name,
+      action: action_name
+    }
+  end
+end

--- a/app/controllers/concerns/basic_authenticable.rb
+++ b/app/controllers/concerns/basic_authenticable.rb
@@ -3,8 +3,14 @@
 # Enforces HTTP Basic Auth
 module BasicAuthenticable
   class << self
-    def required?
-      Settings.features.basic_auth
+    WHITELISTED_PATHS = %w(/metrics).freeze
+
+    def required?(path)
+      Settings.features.basic_auth && !whitelisted?(path)
+    end
+
+    def whitelisted?(path)
+      WHITELISTED_PATHS.include?(path)
     end
 
     def authenticate(username, password)

--- a/app/controllers/concerns/basic_authenticable.rb
+++ b/app/controllers/concerns/basic_authenticable.rb
@@ -3,7 +3,7 @@
 # Enforces HTTP Basic Auth
 module BasicAuthenticable
   class << self
-    WHITELISTED_PATHS = %w(/metrics).freeze
+    WHITELISTED_PATHS = %w[/metrics].freeze
 
     def required?(path)
       Settings.features.basic_auth && !whitelisted?(path)

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -2,11 +2,22 @@
 
 Yabeda.configure do
   group :register_api do
-    counter   :requests_total, comment: "Total number of Register API requests"
+    counter   :requests_total,
+              comment: "Total number of Register API requests",
+              tags: %i[method controller action]
     histogram :request_duration,
               buckets: [0.1, 0.5, 1, 5, 10],
               unit: :seconds,
-              comment: "Request API request duration"
-    counter :unsuccessful_requests_total, comment: "Total number of unsuccessful Register API requests"
+              comment: "Request API request duration",
+              tags: %i[method controller action]
+    counter :unsuccessful_requests_total,
+            comment: "Total number of unsuccessful Register API requests",
+            tags: %i[method controller action]
+    histogram :response_size,
+              buckets: [100, 1_000, 10_000, 100_000, 1_000_000],
+              comment: "Response sizes",
+              unit: :byte,
+              per: :request,
+              tags: %i[method controller action]
   end
 end

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -5,14 +5,17 @@ Yabeda.configure do
     counter   :requests_total,
               comment: "Total number of Register API requests",
               tags: %i[method controller action]
+
     histogram :request_duration,
               buckets: [0.1, 0.5, 1, 5, 10],
               unit: :seconds,
               comment: "Request API request duration",
               tags: %i[method controller action]
+
     counter :unsuccessful_requests_total,
             comment: "Total number of unsuccessful Register API requests",
-            tags: %i[method controller action]
+            tags: %i[method controller action error_code error_message]
+
     histogram :response_size,
               buckets: [100, 1_000, 10_000, 100_000, 1_000_000],
               comment: "Response sizes",

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -2,10 +2,11 @@
 
 Yabeda.configure do
   group :register_api do
-    counter   :requests_total, comment: "Total number of Request API requests"
+    counter   :requests_total, comment: "Total number of Register API requests"
     histogram :request_duration,
               buckets: [0.1, 0.5, 1, 5, 10],
               unit: :seconds,
               comment: "Request API request duration"
+    counter :unsuccessful_requests_total, comment: "Total number of unsuccessful Register API requests"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   extend ApiRoutes
   extend AutocompleteRoutes
 
+  mount Yabeda::Prometheus::Exporter => "/metrics"
+
   if Settings.dttp.portal_host.present?
     constraints(->(req) { req.host == Settings.dttp.portal_host }) do
       dttp_replaced_url = "#{Settings.base_url}/dttp-replaced"

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -7,8 +7,6 @@ module SystemAdminRoutes
         require "sidekiq/web"
         require "sidekiq/cron/web"
 
-        mount Yabeda::Prometheus::Exporter => "/metrics"
-
         mount Blazer::Engine, at: "/blazer", constraints: RouteConstraints::SystemAdminConstraint.new
         get "/blazer", to: redirect("/sign-in"), status: 302
 

--- a/docs/api-monitoring.md
+++ b/docs/api-monitoring.md
@@ -1,0 +1,63 @@
+# API Monitoring Guide for Register
+
+* We use [yabeda](https://github.com/yabeda-rb/yabeda) with the [yabeda-rails](https://github.com/yabeda-rb/yabeda-rails) gem to define and collect custom metrics from our Rails application. 
+* Yabeda is a framework that provides a simple DSL to declare and manage monitoring metrics. The `yabeda-rails` gem automatically configures Yabeda with Rails specific hooks. 
+* We then use [yabeda-prometheus](https://github.com/yabeda-rb/yabeda-prometheus) to expose our collected metrics to Prometheus using a `/metrics` endpoint. 
+* Prometheus then ingests them and allows us to build dashboards around them using [Grafana](https://grafana.com). At the time of writing, we do this in our routes file like so: 
+
+```ruby
+mount Yabeda::Prometheus::Exporter => "/metrics"
+```
+
+### Configuration
+
+The configuration of Yabeda within our application is defined in the intializer `app/initializers/yabeda.rb`. Here we define all of the metrics that we want to track throughout our app. Things like the total number of requests, the request duration etc. 
+
+```ruby
+Yabeda.configure do
+  group :register_api do
+    counter   :requests_total,
+              comment: "Total number of Register API requests",
+              tags: %i[method controller action]
+  end
+end
+```
+
+We then add to these metrics from anywhere in our app that we choose. At the time of writing we're doing this in our API's base controller with an around_action: 
+
+```ruby
+...
+  included do
+    around_action :monitor_api_request
+  end
+
+  private
+
+  def monitor_api_request
+    start = Time.zone.now
+    track_total_requests
+    begin
+      yield
+    rescue => ex
+      track_unsuccessful_requests(ex)
+      raise ex
+    ensure
+      track_request_duration(start)
+      track_response_size
+    end
+  end
+...
+```
+
+### Grafana Dashboards
+
+Grafana is configured to visualize the metrics collected by Prometheus. It supports additional data sources, providing a comprehensive view of our application’s operational metrics.
+
+### Accessing Grafana Instances
+
+* Test Environment: [https://grafana.test.teacherservices.cloud/](https://grafana.test.teacherservices.cloud/)
+* Production Environment: [https://grafana.teacherservices.cloud/](https://grafana.test.teacherservices.cloud/)
+
+### Adding New Dashboards
+
+To add new dashboards or modify existing ones in Grafana, follow the Monitoring documentation in the [teacher-services-cloud](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/developer-onboarding.md#monitoring) repository. Or reach out to someone on the infrastructure team to help with this.

--- a/docs/api-monitoring.md
+++ b/docs/api-monitoring.md
@@ -11,7 +11,7 @@ mount Yabeda::Prometheus::Exporter => "/metrics"
 
 ### Configuration
 
-The configuration of Yabeda within our application is defined in the intializer `app/initializers/yabeda.rb`. Here we define all of the metrics that we want to track throughout our app. Things like the total number of requests, the request duration etc. 
+The configuration of Yabeda within our application is defined in the initializer `app/initializers/yabeda.rb`. Here we define all of the metrics that we want to track throughout our app. Things like the total number of requests, the request duration etc. 
 
 ```ruby
 Yabeda.configure do

--- a/docs/api-monitoring.md
+++ b/docs/api-monitoring.md
@@ -56,7 +56,7 @@ Grafana is configured to visualize the metrics collected by Prometheus. It suppo
 ### Accessing Grafana Instances
 
 * Test Environment: [https://grafana.test.teacherservices.cloud/](https://grafana.test.teacherservices.cloud/)
-* Production Environment: [https://grafana.teacherservices.cloud/](https://grafana.test.teacherservices.cloud/)
+* Production Environment: [https://grafana.teacherservices.cloud/](https://grafana.teacherservices.cloud/)
 
 ### Adding New Dashboards
 

--- a/spec/requests/api/monitoring_spec.rb
+++ b/spec/requests/api/monitoring_spec.rb
@@ -1,6 +1,8 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-describe 'API Monitoring', type: :request do
+require "rails_helper"
+
+describe "API Monitoring" do
   let(:token) { "trainee_token" }
   let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }
   let!(:trainee) { create(:trainee, :with_hesa_trainee_detail, slug: "12345", provider: auth_token.provider) }
@@ -12,18 +14,18 @@ describe 'API Monitoring', type: :request do
     )
   end
 
-  it 'increments request_total and measures request_duration for successful request' do
+  it "increments request_total and measures request_duration for successful request" do
     expect(Yabeda.register_api.requests_total).to receive(:increment)
     expect(Yabeda.register_api.request_duration).to receive(:measure)
     response
   end
 
-  it 'measures response size for every request' do
+  it "measures response size for every request" do
     expect(Yabeda.register_api.response_size).to receive(:measure)
     response
   end
 
-  it 'increments unsuccessful_requests_total for failed request' do
+  it "increments unsuccessful_requests_total for failed request" do
     allow_any_instance_of(Api::TraineesController).to receive(:show).and_raise(StandardError)
     expect(Yabeda.register_api.unsuccessful_requests_total).to receive(:increment)
     expect { response }.to raise_error(StandardError)

--- a/spec/requests/api/monitoring_spec.rb
+++ b/spec/requests/api/monitoring_spec.rb
@@ -26,7 +26,10 @@ describe "API Monitoring" do
   end
 
   it "increments unsuccessful_requests_total for failed request" do
-    allow_any_instance_of(Api::TraineesController).to receive(:show).and_raise(StandardError)
+    controller = Api::TraineesController.new
+    allow(Api::TraineesController).to receive(:new).and_return(controller)
+    allow(controller).to receive(:show).and_raise(StandardError)
+
     expect(Yabeda.register_api.unsuccessful_requests_total).to receive(:increment)
     expect { response }.to raise_error(StandardError)
   end

--- a/spec/requests/api/monitoring_spec.rb
+++ b/spec/requests/api/monitoring_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'API Monitoring', type: :request do
+  let(:token) { "trainee_token" }
+  let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }
+  let!(:trainee) { create(:trainee, :with_hesa_trainee_detail, slug: "12345", provider: auth_token.provider) }
+  let(:metrics) { Yabeda::CollectorsRegistry.all }
+  let(:response) do
+    get(
+      "/api/v1.0/trainees/#{trainee.slug}",
+      headers: { Authorization: "Bearer #{token}" },
+    )
+  end
+
+  it 'increments request_total and measures request_duration for successful request' do
+    expect(Yabeda.register_api.requests_total).to receive(:increment)
+    expect(Yabeda.register_api.request_duration).to receive(:measure)
+    response
+  end
+
+  it 'measures response size for every request' do
+    expect(Yabeda.register_api.response_size).to receive(:measure)
+    response
+  end
+
+  it 'increments unsuccessful_requests_total for failed request' do
+    allow_any_instance_of(Api::TraineesController).to receive(:show).and_raise(StandardError)
+    expect(Yabeda.register_api.unsuccessful_requests_total).to receive(:increment)
+    expect { response }.to raise_error(StandardError)
+  end
+end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -12,7 +12,11 @@ describe "authentication" do
     end
   end
 
-  context "attempting to visit a public path" do
+  context "attempting to visit a whitelisted path" do
+    before do
+      allow(Settings.features).to receive(:basic_auth).and_return(true)
+    end
+
     it "does not require basic auth" do
       get "/metrics"
       expect(response).to have_http_status(:ok)

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -11,4 +11,11 @@ describe "authentication" do
       end
     end
   end
+
+  context "attempting to visit a public path" do
+    it "does not require basic auth" do
+      get "/metrics"
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/tVYRKhhR)

After speaking to @RMcVelia about what's needed to get Grafana set up for Register, it turns out that our `/metrics` endpoint is behind basic auth, so our Prometheus instance can't pull metrics from it at the moment. Prometheus also requires that the endpoint is just `/metrics` and not `system-admin/metrics` or anything like that. 

### Changes proposed in this pull request
* I've moved the metrics route to the correct place and added a test to make sure that basic auth is not enforced.
* I've also added some additional metrics that I thought would be useful.
    * Number of unsuccessful API requests
    * The size (in bytes) of the responses we're sending. 
    * The types of errors were returning, with their codes and messages.    
* Since the logic around monitoring was starting to grow, I moved it out into a controller concern called `ApiMonitorable` 
* I also added some basic documentation about our monitoring setup, since it's not obvious if you haven't come across some of these gems and tools before. 

### Guidance to review
This won't complete our monitoring setup. But it's the next step so that the infrastructure team can point Prometheus to it and start to ingest data. After that, we can follow the steps (outlined in the docs) to start adding dashboards in Grafana, setting up alerting etc. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
