### PR TITLE
Add `analytics_hidden_pii.yml`

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,4 +1,4 @@
 ---
-:shared:
-  :trainees:
+shared:
+  trainees:
     - trn


### PR DESCRIPTION
### Context
This change integrates Register with the latest version of DfE-Analytics so that we can declare attributes that are sent separately to BigQuery and hidden by default.

### Changes proposed in this pull request
Initially we just declare `Trainee#trn` as hidden PII.

### Guidance to review

Should follow these instructions: https://github.com/DFE-Digital/dfe-analytics?tab=readme-ov-file#4-send-database-events

Is there anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
