### PR TITLE
[7335] Drop `school_direct_tuition_fee` route from 2024

### DIFF
--- a/app/lib/hesa/code_sets/training_routes.rb
+++ b/app/lib/hesa/code_sets/training_routes.rb
@@ -12,6 +12,10 @@ module Hesa
         "11" => TRAINING_ROUTE_ENUMS[:provider_led_undergrad],
         "12" => TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
       }.freeze
+
+      def self.mapping_for(recruitment_cycle_year:)
+        recruitment_cycle_year.to_i <= 2023 ? MAPPING : MAPPING.except("02")
+      end
     end
   end
 end

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -162,7 +162,9 @@ module Trainees
     end
 
     def training_route
-      ::Hesa::CodeSets::TrainingRoutes::MAPPING[hesa_trainee[:training_route]]
+      ::Hesa::CodeSets::TrainingRoutes.mapping_for(
+        recruitment_cycle_year: AcademicCycle.for_date(trainee_start_date)&.start_year,
+      )[hesa_trainee[:training_route]]
     end
 
     def ethnic_background


### PR DESCRIPTION
### Context
This PR updates HESA mappings for training routes. See https://trello.com/c/ONNiLolU/7335-update-hesa-mappings

### Changes proposed in this pull request
- We drop the `school_direct_tuition_fee` route from the 2024-25 academic cycle.

### Guidance to review
- The other requirement specified on the ticket, dropping the `provider_led_postgrad_salaried` route has already been covered in https://github.com/DFE-Digital/register-trainee-teachers/pull/4462
- Is there a tidier way to express conditional mappings (the conditional logic in `Hesa::CodeSets::TrainingRoutes`.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
