### PR TITLE
[7177] Optionally add lead partner

### DIFF
--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -562,10 +562,6 @@ FactoryBot.define do
       lead_school factory: %i[school lead]
     end
 
-    trait :with_lead_partner do
-      lead_partner factory: %i[lead_partner lead_school]
-    end
-
     trait :with_employing_school do
       employing_school factory: %i[school]
     end


### PR DESCRIPTION
### Context

https://trello.com/c/VFds9crk/7177-update-existing-provider-led-routes-so-that-providers-can-optionally-add-a-lead-partner

### Changes proposed in this pull request

Allow users to optionally add Lead Partner and Employing Schools on the new trainee journey. Also replaces Lead Schools with Lead Partners on the same journey and in the playback.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
