### PR TITLE
[7349] Turn on Apply Import for `productiondata` for 24/25

### DIFF
--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -48,3 +48,10 @@ current_default_course_year: 2024
 
 environment:
   name: productiondata
+
+apply_applications:
+  import:
+    recruitment_cycle_years:
+      - 2024
+  create:
+    recruitment_cycle_year: 2024


### PR DESCRIPTION
### Context
We need to test and turn on the Apply import for the 2024 to 2025 academic year. This is so trainees can be imported from Apply to be registered by SCITTs on Register.

### Changes proposed in this pull request
This updates the `productiondata` settings file, adding entries for the apply application import. Now that we have a [sidekiq worker](https://github.com/DFE-Digital/register-trainee-teachers/pull/4473) on that environment, those values will be used by the [ImportApplicationsJob](https://github.com/DFE-Digital/register-trainee-teachers/blob/03319182136ff608bff771b6d216f8ff7b84b00d/app/jobs/recruits_api/import_applications_job.rb#L7) to import the data: 

```ruby
class ImportApplicationsJob < ApplicationJob
  queue_as :default

  def perform(from_date: nil, recruitment_cycle_years: Settings.apply_applications.import.recruitment_cycle_years)
    @from_date = from_date

    return unless FeatureService.enabled?("import_applications_from_apply")

    recruitment_cycle_years.each do |recruitment_cycle_year|
      new_applications(recruitment_cycle_year).each do |application_data|
        ImportApplicationJob.perform_later(application_data)
      end
    end
  end
end
```

### Guidance to review
The feature flag required in this job `import_applications_from_apply` was already set to true. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
