### PR TITLE
Migrate to azure-blob Gem From azure-storage-blob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,13 +125,12 @@ gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.13.0"
 
 gem "ruby-progressbar" # useful for tracking long running rake tasks
 
-# version is constrained due to azure-storage-common
-gem "faraday", "~> 1.10.3"
+gem "faraday"
 
 gem "csv-safe"
 gem "progress_bar" # useful to track progress of long running data migrations using scripts or rake tasks
 
-gem "azure-storage-blob", "~> 2"
+gem "azure-blob"
 gem "cssbundling-rails"
 gem "jsbundling-rails"
 gem "rack-attack"
@@ -139,7 +138,6 @@ gem "strong_migrations"
 
 group :qa, :review, :staging, :production do
   # Pull list of CloudFront proxies so request.remote_ip returns the correct IP.
-  gem "azure-storage-common", "~> 2.0", ">= 2.0.4"
   gem "cloudfront-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,14 +119,8 @@ GEM
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
     awesome_print (1.9.2)
-    azure-storage-blob (2.0.3)
-      azure-storage-common (~> 2.0)
-      nokogiri (~> 1, >= 1.10.8)
-    azure-storage-common (2.0.4)
-      faraday (~> 1.0)
-      faraday_middleware (~> 1.0, >= 1.0.0.rc1)
-      net-http-persistent (~> 4.0)
-      nokogiri (~> 1, >= 1.10.8)
+    azure-blob (0.4.2)
+      rexml
     base32 (0.3.4)
     base64 (0.2.0)
     benchmark-malloc (0.2.0)
@@ -261,8 +255,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     ferrum (0.15)
       addressable (~> 2.5)
       concurrent-ruby (~> 1.1)
@@ -780,8 +772,7 @@ DEPENDENCIES
   audited (~> 5.6)
   auto_strip_attributes
   awesome_print
-  azure-storage-blob (~> 2)
-  azure-storage-common (~> 2.0, >= 2.0.4)
+  azure-blob
   base32
   benchmark-memory
   blazer
@@ -808,7 +799,7 @@ DEPENDENCIES
   erb_lint
   factory_bot_rails
   faker
-  faraday (~> 1.10.3)
+  faraday
   flamegraph
   foreman
   front_matter_parser

--- a/app/lib/malware_scan.rb
+++ b/app/lib/malware_scan.rb
@@ -43,7 +43,7 @@ private
       AzureBlob::Client.new(
         account_name: Settings.azure.storage.temp_data_account,
         access_key: Settings.azure.storage.temp_data_access_key,
-        container: nil,
+        container: Settings.azure.storage.temp_data_container,
       )
   end
 

--- a/app/lib/malware_scan.rb
+++ b/app/lib/malware_scan.rb
@@ -3,11 +3,6 @@
 class MalwareScan
   include ServicePattern
 
-  # Only later versions of the Azure Storage REST API support tags operations.
-  Kernel.silence_warnings do
-    Azure::Storage::Blob::Default::STG_VERSION = "2022-11-02"
-  end
-
   SCAN_RESULT_TAG_KEY = /Malware Scanning scan result/
   SCAN_RESULT_TAG_VALUE_CLEAN = /No threats found/
 

--- a/app/lib/malware_scan.rb
+++ b/app/lib/malware_scan.rb
@@ -18,19 +18,15 @@ class MalwareScan
 
     response = fetch_scan_result
 
-    if response.is_a?(Net::HTTPSuccess)
-      if response.body =~ SCAN_RESULT_TAG_KEY
-        upload.update!(
-          malware_scan_result: malware_scan_result_from_response(response),
-        )
-        if upload.scan_result_suspect?
-          upload.destroy
-        end
+    if response =~ SCAN_RESULT_TAG_KEY
+      upload.update!(
+        malware_scan_result: malware_scan_result_from_response(response),
+      )
+      if upload.scan_result_suspect?
+        upload.destroy
       end
-    else
-      upload.update!(malware_scan_result: "error")
     end
-  rescue AzureBlob::Http::Error
+  rescue AzureBlob::Http::Error, Net::HTTPClientError
     upload.update!(malware_scan_result: "error")
   end
 
@@ -52,6 +48,6 @@ private
   end
 
   def malware_scan_result_from_response(response)
-    response.body =~ SCAN_RESULT_TAG_VALUE_CLEAN ? "clean" : "suspect"
+    response =~ SCAN_RESULT_TAG_VALUE_CLEAN ? "clean" : "suspect"
   end
 end

--- a/app/lib/malware_scan.rb
+++ b/app/lib/malware_scan.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "azure_blob"
+
 class MalwareScan
   include ServicePattern
 
@@ -16,7 +18,7 @@ class MalwareScan
 
     response = fetch_scan_result
 
-    if response.success?
+    if response.is_a?(Net::HTTPSuccess)
       if response.body =~ SCAN_RESULT_TAG_KEY
         upload.update!(
           malware_scan_result: malware_scan_result_from_response(response),
@@ -28,7 +30,7 @@ class MalwareScan
     else
       upload.update!(malware_scan_result: "error")
     end
-  rescue Azure::Core::Http::HTTPError
+  rescue AzureBlob::Http::Error
     upload.update!(malware_scan_result: "error")
   end
 
@@ -36,24 +38,17 @@ private
 
   attr_reader :upload
 
-  def blob_service
-    @blob_service ||=
-      Azure::Storage::Blob::BlobService.new(
-        storage_account_name: Settings.azure.storage.temp_data_account,
-        storage_access_key: Settings.azure.storage.temp_data_access_key,
+  def blob_client
+    @blob_client ||=
+      AzureBlob::Client.new(
+        account_name: Settings.azure.storage.temp_data_account,
+        access_key: Settings.azure.storage.temp_data_access_key,
+        container: nil,
       )
   end
 
   def fetch_scan_result
-    blob_service.call(:get, tags_for_blob_url)
-  end
-
-  def tags_for_blob_url
-    @tags_for_blob_url ||=
-      blob_service.generate_uri(
-        File.join("tempdata", upload.file.key),
-        { comp: "tags" },
-      )
+    blob_client.get_blob(upload.file.key)
   end
 
   def malware_scan_result_from_response(response)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,6 +35,7 @@ azure:
   storage:
     temp_data_access_key: set-me-in-env
     temp_data_acount: set-me-in-env
+    temp_data_container: tempdata
 
 # Used to add feature flags in the app to control access to certain features.
 features:

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,11 +7,10 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 microsoft:
-  service: AzureStorage
+  service: AzureBlob
   storage_account_name: <%= ENV.fetch('SETTINGS__AZURE__STORAGE__TEMP_DATA_ACCOUNT', nil) %>
   storage_access_key: <%= ENV.fetch('SETTINGS__AZURE__STORAGE__TEMP_DATA_ACCESS_KEY', nil) %>
   container: tempdata
-
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/spec/lib/malware_scan_spec.rb
+++ b/spec/lib/malware_scan_spec.rb
@@ -17,29 +17,29 @@ RSpec.describe MalwareScan do
       </Tags>
     XML
 
-    let(:stubbed_blob_service) do
-      instance_double(Azure::Storage::Blob::BlobService, generate_uri: tags_url)
+    let(:stubbed_blob_client) do
+      instance_double(AzureBlob::Client, generate_uri: tags_url)
     end
 
     let(:stubbed_response) do
       instance_double(
-        Azure::Core::Http::HttpResponse,
-        success?: response_success,
+        Net::HTTPResponse,
         body: response_body,
+        is_a?: response_success,
       )
     end
 
     subject(:malware_scan) { described_class.call(upload:) }
 
     before do
-      allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(
-        stubbed_blob_service,
+      allow(AzureBlob::Client).to receive(:new).and_return(
+        stubbed_blob_client,
       )
-      allow(stubbed_blob_service).to receive(:call).and_return(stubbed_response)
+      allow(stubbed_blob_client).to receive(:get_blob).and_return(stubbed_response)
     end
 
     it "calls the Azure Storage REST API for the scan result" do
-      expect(stubbed_blob_service).to receive(:call).with(:get, tags_url)
+      expect(stubbed_blob_client).to receive(:get_blob).with(upload.file.key)
       malware_scan
     end
 

--- a/spec/lib/malware_scan_spec.rb
+++ b/spec/lib/malware_scan_spec.rb
@@ -21,21 +21,13 @@ RSpec.describe MalwareScan do
       instance_double(AzureBlob::Client, generate_uri: tags_url)
     end
 
-    let(:stubbed_response) do
-      instance_double(
-        Net::HTTPResponse,
-        body: response_body,
-        is_a?: response_success,
-      )
-    end
-
     subject(:malware_scan) { described_class.call(upload:) }
 
     before do
       allow(AzureBlob::Client).to receive(:new).and_return(
         stubbed_blob_client,
       )
-      allow(stubbed_blob_client).to receive(:get_blob).and_return(stubbed_response)
+      allow(stubbed_blob_client).to receive(:get_blob).and_return(response_body)
     end
 
     it "calls the Azure Storage REST API for the scan result" do
@@ -60,7 +52,10 @@ RSpec.describe MalwareScan do
     end
 
     context "with an unsuccessful response" do
-      let(:response_success) { false }
+      before do
+        allow(AzureBlob::Client).to receive(:new).and_return(stubbed_blob_client)
+        allow(stubbed_blob_client).to receive(:get_blob).and_raise(AzureBlob::Http::Error)
+      end
 
       it "saves an error result" do
         malware_scan


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/8PO7X0Ej)

Azure Storage Ruby client libraries will be retired on 13 September 2024.

### Changes proposed in this pull request
https://github.com/testdouble/azure-blob has been developed as a replacement gem. This PR follows the migration steps there and makes other changes as necessary.

We have a library class called [MalwareScan](https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/lib/malware_scan.rb), which was using `Azure::Storage::Blob::BlobService` directly. The API for that is now different, so I've changed that class and the spec for it to use the new interface.  

Our version of Faraday was also being constrained because of the old gem. So I've updated this as well as part of this. 

### Guidance to review
* The new gem requires that the client is initialised with the name of an Azure container. I wasn't sure of the name, but I saw a reference to `tempdata` in the terraform files, so I've used that. But let me know if that's wrong: 

```ruby
AzureBlob::Client.new(
  account_name: Settings.azure.storage.temp_data_account,
  access_key: Settings.azure.storage.temp_data_access_key,
  container: Settings.azure.storage.temp_data_container,
)
``` 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
