### PR TITLE
[7354] Implement ITT reform on Register API - part 2

### DIFF
--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -85,6 +85,17 @@ module Api
       validate :validate_trainee_start_date
       validates(:sex, inclusion: Hesa::CodeSets::Sexes::MAPPING.values, allow_blank: true)
       validates :placements_attributes, :degrees_attributes, :nationalisations_attributes, :hesa_trainee_detail_attributes, nested_attributes: true
+      validates :training_route, inclusion: {
+        in: lambda do |trainee_attributes|
+          start_year = AcademicCycle.for_date(trainee_attributes.trainee_start_date)&.start_year
+
+          if start_year.to_i > 2023
+            Hesa::CodeSets::TrainingRoutes::MAPPING.values.excluding(TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
+          else
+            Hesa::CodeSets::TrainingRoutes::MAPPING.values
+          end
+        end,
+      }, allow_blank: true, if: -> { errors[:trainee_start_date].blank? }
 
       def initialize(new_attributes = {})
         new_attributes = new_attributes.to_h.with_indifferent_access

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -81,8 +81,13 @@ FactoryBot.define do
       imported_from_hesa
     end
 
-    trait :without_required_placements do
+    trait :with_training_route do
       training_route { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
+    end
+
+    trait :without_required_placements do
+      with_training_route
+
       awarded
     end
 

--- a/spec/models/api/v0_1/trainee_attributes_spec.rb
+++ b/spec/models/api/v0_1/trainee_attributes_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe Api::V01::TraineeAttributes do
           let!(:academic_cycle) { create(:academic_cycle, cycle_year:) }
 
           before do
+            Timecop.travel academic_cycle.start_date
+
             subject.trainee_start_date = academic_cycle.start_date
           end
 
@@ -54,10 +56,6 @@ RSpec.describe Api::V01::TraineeAttributes do
           context "when AcademicCycle::start_date > 2023" do
             let(:cycle_year) { 2024 }
 
-            before do
-              Timecop.travel academic_cycle.start_date
-            end
-
             it do
               expect(subject).to validate_inclusion_of(:training_route)
                 .in_array(Hesa::CodeSets::TrainingRoutes::MAPPING.values.excluding(TRAINING_ROUTE_ENUMS[:provider_led_postgrad]))
@@ -79,6 +77,10 @@ RSpec.describe Api::V01::TraineeAttributes do
 
           context "when trainee_start_date is not valid" do
             let(:cycle_year) { 2025 }
+
+            before do
+              Timecop.return
+            end
 
             it do
               expect(subject).not_to validate_inclusion_of(:training_route)

--- a/spec/models/api/v0_1/trainee_attributes_spec.rb
+++ b/spec/models/api/v0_1/trainee_attributes_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Api::V01::TraineeAttributes do
     it { is_expected.to validate_presence_of(:last_name) }
     it { is_expected.to validate_presence_of(:date_of_birth) }
     it { is_expected.to validate_presence_of(:sex) }
-    it { is_expected.to validate_presence_of(:training_route) }
     it { is_expected.to validate_presence_of(:itt_start_date) }
     it { is_expected.to validate_presence_of(:itt_end_date) }
     it { is_expected.to validate_presence_of(:diversity_disclosure) }
@@ -22,6 +21,73 @@ RSpec.describe Api::V01::TraineeAttributes do
 
     it { is_expected.to validate_inclusion_of(:sex).in_array(Hesa::CodeSets::Sexes::MAPPING.values) }
     it { is_expected.to validate_inclusion_of(:ethnicity).in_array(Hesa::CodeSets::Ethnicities::MAPPING.keys).allow_nil }
+
+    describe "training_route" do
+      it { is_expected.to validate_presence_of(:training_route) }
+
+      describe "inclusion" do
+        context "when trainee_start_date is present" do
+          let!(:academic_cycle) { create(:academic_cycle, cycle_year:) }
+
+          before do
+            subject.trainee_start_date = academic_cycle.start_date
+          end
+
+          context "when AcademicCycle#start_date < 2023" do
+            let(:cycle_year) { 2022 }
+
+            it do
+              expect(subject).to validate_inclusion_of(:training_route)
+                .in_array(Hesa::CodeSets::TrainingRoutes::MAPPING.values)
+            end
+          end
+
+          context "when AcademicCycle::start_date == 2023" do
+            let(:cycle_year) { 2023 }
+
+            it do
+              expect(subject).to validate_inclusion_of(:training_route)
+                .in_array(Hesa::CodeSets::TrainingRoutes::MAPPING.values)
+            end
+          end
+
+          context "when AcademicCycle::start_date > 2023" do
+            let(:cycle_year) { 2024 }
+
+            before do
+              Timecop.travel academic_cycle.start_date
+            end
+
+            it do
+              expect(subject).to validate_inclusion_of(:training_route)
+                .in_array(Hesa::CodeSets::TrainingRoutes::MAPPING.values.excluding(TRAINING_ROUTE_ENUMS[:provider_led_postgrad]))
+            end
+          end
+
+          context "when AcademicCycle::for_date is nil" do
+            let(:cycle_year) { 2024 }
+
+            before do
+              allow(AcademicCycle).to receive(:for_date)
+            end
+
+            it do
+              expect(subject).to validate_inclusion_of(:training_route)
+                .in_array(Hesa::CodeSets::TrainingRoutes::MAPPING.values)
+            end
+          end
+
+          context "when trainee_start_date is not valid" do
+            let(:cycle_year) { 2025 }
+
+            it do
+              expect(subject).not_to validate_inclusion_of(:training_route)
+                .in_array(Hesa::CodeSets::TrainingRoutes::MAPPING.values.excluding(TRAINING_ROUTE_ENUMS[:provider_led_postgrad]))
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "nested attribute validations" do

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -11,6 +11,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       :with_lead_partner,
       :with_employing_school,
       :with_diversity_information,
+      :with_training_route,
       first_names: "Bob",
     )
   end
@@ -388,6 +389,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
               :trainee,
               :in_progress,
               :with_hesa_trainee_detail,
+              :with_training_route,
               lead_partner_not_applicable: true,
               employing_school_not_applicable: true,
             )
@@ -531,7 +533,9 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     context "when read only attributes are submitted" do
       let(:ethnic_background) { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
       let(:ethnic_group) { Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }&.keys&.first }
-      let(:trainee) { create(:trainee, :in_progress, :with_hesa_trainee_detail, :with_diversity_information, ethnic_group:, ethnic_background:) }
+      let(:trainee) do
+        create(:trainee, :in_progress, :with_training_route, :with_hesa_trainee_detail, :with_diversity_information, ethnic_group:, ethnic_background:)
+      end
 
       before do
         put(
@@ -604,7 +608,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     end
 
     describe "with ethnicity" do
-      let(:trainee) { create(:trainee, :in_progress, :with_hesa_trainee_detail, :with_diversity_information, ethnic_group:, ethnic_background:) }
+      let(:trainee) { create(:trainee, :in_progress, :with_training_route, :with_hesa_trainee_detail, :with_diversity_information, ethnic_group:, ethnic_background:) }
       let(:ethnic_background) { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
       let(:ethnic_group) { Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }&.keys&.first }
 
@@ -675,6 +679,96 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         it do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+        end
+      end
+    end
+
+    describe "with training_route" do
+      context "when present" do
+        let(:params) do
+          {
+            data: {
+              itt_start_date:,
+              training_route:,
+            },
+          }
+        end
+
+        let(:itt_start_date) { "2023-01-01" }
+        let(:training_route) { Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]] }
+
+        before do
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        it do
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body[:data][:training_route]).to eq(training_route)
+        end
+      end
+
+      context "when not present" do
+        let(:params) do
+          {
+            data: {
+              training_route:,
+            },
+          }
+        end
+
+        let(:training_route) { nil }
+
+        before do
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        it do
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body[:data][:training_route]).to eq(
+            Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_postgrad]],
+          )
+          expect(trainee.reload.training_route).to eq(TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
+        end
+      end
+
+      context "when invalid" do
+        let(:params) do
+          {
+            data: {
+              itt_start_date:,
+              itt_end_date:,
+              training_route:,
+            },
+          }
+        end
+
+        let(:itt_start_date) { "2024-08-01" }
+        let(:itt_end_date)   { "2025-01-01" }
+        let(:training_route) { Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_postgrad]] }
+
+        let!(:academic_cycle) { create(:academic_cycle, cycle_year: 2024, next_cycle: true) }
+
+        before do
+          Timecop.travel(itt_start_date)
+
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        it do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body[:errors]).to contain_exactly("Training route is not included in the list")
         end
       end
     end

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -600,6 +600,80 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
         end
       end
     end
+
+    context "with training_route" do
+      context "when present" do
+        let(:params) do
+          {
+            data: data.merge(
+              itt_start_date:,
+              training_route:,
+            ),
+          }
+        end
+
+        let(:itt_start_date) { "2023-01-01" }
+        let(:training_route) { Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]] }
+
+        before do
+          post "/api/v1.0/trainees", params: params, headers: { Authorization: token }, as: :json
+        end
+
+        it do
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body[:data][:training_route]).to eq(training_route)
+        end
+      end
+
+      context "when not present" do
+        let(:params) do
+          {
+            data: data.merge(
+              training_route:,
+            ),
+          }
+        end
+
+        let(:training_route) { nil }
+
+        before do
+          post "/api/v1.0/trainees", params: params, headers: { Authorization: token }, as: :json
+        end
+
+        it do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body[:errors]).to contain_exactly("Training route can't be blank")
+        end
+      end
+
+      context "when invalid" do
+        let(:params) do
+          {
+            data: data.merge(
+              itt_start_date: itt_start_date,
+              itt_end_date: itt_end_date,
+              training_route: "12",
+            ),
+          }
+        end
+
+        let(:itt_start_date) { "2024-08-01" }
+        let(:itt_end_date)   { "2025-01-01" }
+
+        let!(:academic_cycle) { create(:academic_cycle, cycle_year: 2024) }
+
+        before do
+          Timecop.travel(itt_start_date)
+
+          post "/api/v1.0/trainees", params: params, headers: { Authorization: token }, as: :json
+        end
+
+        it do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body[:errors]).to contain_exactly("Training route is not included in the list")
+        end
+      end
+    end
   end
 
   context "when the trainee record is invalid", feature_register_api: true do

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -19,6 +19,8 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
   let(:itt_start_date) { "2023-01-01" }
   let(:itt_end_date) { "2023-10-01" }
 
+  let(:endpoint) { "/api/v1.0-pre/trainees" }
+
   let(:data) do
     {
       first_names: "John",
@@ -74,7 +76,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     end
 
     it "creates a trainee" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(response.parsed_body[:data][:first_names]).to eq("John")
       expect(response.parsed_body[:data][:last_name]).to eq("Doe")
@@ -83,19 +85,19 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     end
 
     it "sets the correct state" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(Trainee.last.state).to eq("submitted_for_trn")
     end
 
     it "sets the correct study_mode" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(response.parsed_body[:data][:study_mode]).to eq("63")
     end
 
     it "sets the correct disabilities" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       parsed_body = response.parsed_body[:data]
 
@@ -110,7 +112,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     end
 
     it "sets the correct funding attributes" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       parsed_body = response.parsed_body[:data]
 
@@ -126,7 +128,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     end
 
     it "sets the correct school attributes" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       parsed_body = response.parsed_body[:data]
 
@@ -137,7 +139,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     end
 
     it "creates the degrees if provided in the request body" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       degree_attributes = response.parsed_body[:data][:degrees]&.first
 
@@ -162,7 +164,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
 
     context "with school_attributes" do
       before do
-        post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+        post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
       end
 
       context "when lead_partner_urn is blank" do
@@ -290,7 +292,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       let(:itt_start_date) { "2023-02-30" }
 
       before do
-        post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+        post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
       end
 
       it "does not create a trainee record and returns a 422 status with meaningful error message" do
@@ -303,7 +305,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       let(:graduation_year) { "2003-01-01" }
 
       before do
-        post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+        post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
       end
 
       it "creates the degrees with the correct graduation_year" do
@@ -317,7 +319,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       let(:graduation_year) { 2003 }
 
       before do
-        post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+        post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
       end
 
       it "creates the degrees with the correct graduation_year" do
@@ -354,7 +356,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     end
 
     it "creates the placements if provided in the request body" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       placement_attributes = response.parsed_body[:data][:placements]&.first
 
@@ -364,37 +366,37 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     end
 
     it "returns status code 201" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(response).to have_http_status(:created)
     end
 
     it "creates the nationalities" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(Trainee.last.nationalities.first.name).to eq("british")
     end
 
     it "sets the correct course allocation subject" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(Trainee.last.course_allocation_subject).to eq(course_allocation_subject)
     end
 
     it "sets the progress data structure" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(Trainee.last.progress.personal_details).to be(true)
     end
 
     it "sets the record source to `api`" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(Trainee.last.api_record?).to be(true)
     end
 
     it "sets the provider_trainee_id" do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
       expect(Trainee.last.provider_trainee_id).to eq("99157234/2/01")
     end
@@ -405,7 +407,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       let(:ethnic_background) { "Another Mixed background" }
 
       before do
-        post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+        post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
       end
 
       context "when the ethnicity is provided" do
@@ -473,7 +475,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     context "with course subjects" do
       context "when HasCourseAttributes#primary_education_phase? is true" do
         before do
-          post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+          post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
         end
 
         context "when '100511' is not present" do
@@ -539,7 +541,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
         end
 
         before do
-          post "/api/v1.0-pre/trainees", params: params, headers: { Authorization: token }, as: :json
+          post endpoint, params: params, headers: { Authorization: token }, as: :json
         end
 
         it "sets the correct subjects" do
@@ -558,7 +560,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
 
     context "with ethnicity" do
       before do
-        post "/api/v1.0-pre/trainees", params: params, headers: { Authorization: token }, as: :json
+        post endpoint, params: params, headers: { Authorization: token }, as: :json
       end
 
       context "when present" do
@@ -616,7 +618,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
         let(:training_route) { Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]] }
 
         before do
-          post "/api/v1.0/trainees", params: params, headers: { Authorization: token }, as: :json
+          post endpoint, params: params, headers: { Authorization: token }, as: :json
         end
 
         it do
@@ -637,7 +639,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
         let(:training_route) { nil }
 
         before do
-          post "/api/v1.0/trainees", params: params, headers: { Authorization: token }, as: :json
+          post endpoint, params: params, headers: { Authorization: token }, as: :json
         end
 
         it do
@@ -665,7 +667,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
         before do
           Timecop.travel(itt_start_date)
 
-          post "/api/v1.0/trainees", params: params, headers: { Authorization: token }, as: :json
+          post endpoint, params: params, headers: { Authorization: token }, as: :json
         end
 
         it do
@@ -678,7 +680,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
 
   context "when the trainee record is invalid", feature_register_api: true do
     before do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
     end
 
     let(:params) { { data: { email: "Doe" } } }
@@ -744,7 +746,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
 
   context "when a placement is invalid", feature_register_api: true do
     before do
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
     end
 
     let(:params) { { data: data.merge({ placements_attributes: [{ not_an_attribute: "invalid" }] }) } }
@@ -758,7 +760,8 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
   context "when a degree is invalid", feature_register_api: true do
     before do
       params[:data][:degrees_attributes].first[:graduation_year] = "3000-01-01"
-      post "/api/v1.0-pre/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
+      post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
     end
 
     it "return status code 422 with a meaningful error message" do


### PR DESCRIPTION
### Context

[7354-implement-itt-reform-on-register-api](https://trello.com/c/gMzDEEyF/7354-implement-itt-reform-on-register-api)

As part of the ITT reform introduce an inclusion validation for trainee training route

### Changes proposed in this pull request

* Add an inclusion validation for `training_route` dependant on the ITT reform year

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
