### PR TITLE
[7349] Switch productiondata to import 2024 Apply apps

### DIFF
--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -46,5 +46,12 @@ features:
 current_recruitment_cycle_year: 2024
 current_default_course_year: 2024
 
+apply_applications:
+  import:
+    recruitment_cycle_years:
+      - 2024
+  create:
+    recruitment_cycle_year: 2024
+
 environment:
   name: productiondata


### PR DESCRIPTION
### Context
We need to set the recruitment cycle to 2024 to get a supply of Apply applications to productiondata in order to test the integration for the new academic cycle.

I've also reset the last successful import timestamp manually for 2024 by deleting `ApplyApplicationSyncRequest` records. So once we deploy this hange we _should_ start seeing new Apply applications appear in productiondata.

Note that the 2 jobs that perform the import run at 1am and 4am.

### Changes proposed in this pull request
Change Apply import to pull 2024 applications rather than 2023.

### Guidance to review
Is there anything missing?

### After deploy
We'll have to test this by either manually triggering the `RecruitsApi::ImportApplicationsJob` and then `Trainees::CreateFromApplyJob` once the first job finishes or waiting for the overnight run.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
