### PR TITLE
Revert "Enable Sidekiq worker for productiondata"

### DIFF
--- a/terraform/aks/workspace-variables/productiondata.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata.tfvars.json
@@ -18,7 +18,7 @@
   "worker_apps": {
     "worker": {
       "startup_command": ["/bin/sh", "-c", "bundle exec sidekiq -C config/sidekiq.yml"],
-      "replicas": 1,
+      "replicas": 0,
       "memory_max": "1Gi"
     }
   },


### PR DESCRIPTION
### Context

[7425-turn-off-productiondata-worker
](https://trello.com/c/YZpa5ud6/7425-turn-off-productiondata-worker)

This reverts commit eed1bb43f247d89f4f8c7d2eee87271a546c4c25.

### Changes proposed in this pull request

* Switch off worker for `productiondata`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
