### PR TITLE
[7374] Add _Previously accredited_ tag to provider

### DIFF
--- a/app/components/provider_card/view.html.erb
+++ b/app/components/provider_card/view.html.erb
@@ -7,5 +7,5 @@
   </p>
 
   <%= govuk_tag(text: "Deleted", colour: "red") if provider.discarded? %>
-
+  <%= govuk_tag(text: "Previously accredited", colour: "grey") unless provider.accredited? %>
 </div>

--- a/spec/components/provider_card/view_spec.rb
+++ b/spec/components/provider_card/view_spec.rb
@@ -21,6 +21,17 @@ module ProviderCard
       it "render the correct provider details" do
         expect(rendered_content).to have_text("University of Wantage")
         expect(rendered_content).to have_text("2 users")
+        expect(rendered_content).not_to have_text("Previously accredited")
+      end
+
+      context "when the provider has lost accreditation" do
+        let(:provider) { create(:provider, name: "University of Wantage", accredited: false) }
+
+        it "render the correct provider details and tag to indicate that the provider was previously accredited" do
+          expect(rendered_content).to have_text("University of Wantage")
+          expect(rendered_content).to have_text("2 users")
+          expect(rendered_content).to have_text("Previously accredited")
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
In the support console it's useful to be able to see which providers have lost accreditation (and become lead partners).

### Changes proposed in this pull request
![image](https://github.com/user-attachments/assets/14e99b3d-bf1d-4fc1-adfb-3ba4a89793ae)

### Guidance to review
This page will be re-designed in the near future. This is a short-term change to highlight loss of accreditation.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
