### PR TITLE
Remove type column from lead_partners#index

### DIFF
--- a/app/views/system_admin/lead_partners/index.html.erb
+++ b/app/views/system_admin/lead_partners/index.html.erb
@@ -29,7 +29,6 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-half no-wrap">Lead partner name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half no-wrap">Type</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-half no-wrap">URN</th>
     </tr>
   </thead>
@@ -41,12 +40,6 @@
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <%= govuk_link_to(lead_partner.name, lead_partner_path(lead_partner)) %>
-          </span>
-        </td>
-
-        <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= lead_partner.record_type.humanize %>
           </span>
         </td>
 


### PR DESCRIPTION
### Context

[Support console: remove 'type' column from Lead partners tab](https://trello.com/c/ZAvDqLhv/7423-support-console-remove-type-column-from-lead-partners-tab)

<img width="1039" alt="Screenshot 2024-08-01 at 16 38 05" src="https://github.com/user-attachments/assets/605049f9-48bf-473f-a4ec-85d7feac6695">

### Changes proposed in this pull request

* Remove type column from Lead Partners system admin index page

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
