### PR TITLE
[7460] - use slug in error reporting

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 nodejs 18.18.2
 ruby 3.2.2
-yarn 1.22.19
+yarn 1.22.22
 bundler 2.4.16
 terraform 1.4.5
 azure-cli 2.59.0

--- a/app/lib/notify_on_timeout.rb
+++ b/app/lib/notify_on_timeout.rb
@@ -2,7 +2,10 @@
 
 module NotifyOnTimeout
   def send_message_to_slack(trainee, class_name)
-    SlackNotifierService.call(message: "#{class_name} for Trainee id: #{trainee.id} has timed out after #{Settings.jobs.max_poll_duration_days} days.",
-                              icon_emoji: ":this-is-fine:", username: "Register Trainee Teachers: Job Failure")
+    SlackNotifierService.call(
+      message: "#{class_name} for Trainee with slug: #{trainee.slug} has timed out after #{Settings.jobs.max_poll_duration_days} days.\n#{Settings.base_url}/trainees/#{trainee.slug}",
+      icon_emoji: ":this-is-fine:",
+      username: "Register Trainee Teachers: Job Failure"
+    )
   end
 end

--- a/app/lib/notify_on_timeout.rb
+++ b/app/lib/notify_on_timeout.rb
@@ -5,7 +5,7 @@ module NotifyOnTimeout
     SlackNotifierService.call(
       message: "#{class_name} for Trainee with slug: #{trainee.slug} has timed out after #{Settings.jobs.max_poll_duration_days} days.\n#{Settings.base_url}/trainees/#{trainee.slug}",
       icon_emoji: ":this-is-fine:",
-      username: "Register Trainee Teachers: Job Failure"
+      username: "Register Trainee Teachers: Job Failure",
     )
   end
 end

--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -18,14 +18,14 @@ module Dqt
       if trainee.trn.blank?
         raise(
           TraineeUpdateMissingTrn,
-          <<~TEXT
+          <<~TEXT,
             Cannot update trainee on DQT without a trn
             slug: #{trainee.slug}
             id: #{trainee.id}
             #{Settings.base_url}/trainees/#{trainee.slug}
           TEXT
         )
-      end 
+      end
 
       dqt_update(
         "/v2/teachers/update/#{trainee.trn}?slugId=#{trainee.slug}&birthDate=#{trainee.date_of_birth.iso8601}",

--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -15,7 +15,17 @@ module Dqt
       return unless FeatureService.enabled?(:integrate_with_dqt)
       return if trainee.submitted_for_trn?
 
-      raise(TraineeUpdateMissingTrn, "Cannot update trainee on DQT without a trn (id: #{trainee.id})") if trainee.trn.blank?
+      if trainee.trn.blank?
+        raise(
+          TraineeUpdateMissingTrn,
+          <<~TEXT
+            Cannot update trainee on DQT without a trn
+            slug: #{trainee.slug}
+            id: #{trainee.id}
+            #{Settings.base_url}/trainees/#{trainee.slug}
+          TEXT
+        )
+      end 
 
       dqt_update(
         "/v2/teachers/update/#{trainee.trn}?slugId=#{trainee.slug}&birthDate=#{trainee.date_of_birth.iso8601}",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "extends": "stylelint-config-gds/scss"
   },
   "license": "MIT",
-  "packageManager": "yarn@4.0.1"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
### Context

Sentry trainee related error should use trainee slug and not id

### Changes proposed in this pull request

Replaces ID with slug and provides a URL to the trainee

