### PR TITLE
unschedule create from apply job on sandbox

### DIFF
--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -26,7 +26,7 @@ module Trainees
       end
 
       # Courses can be missing in non-prod environments
-      raise(MissingCourseError, "Cannot find course with uuid: #{raw_course['course_uuid']}") if !::Rails.env.sandbox? && course.nil?
+      raise(MissingCourseError, "Cannot find course with uuid: #{raw_course['course_uuid']}") if course.nil?
 
       trainee.save!
       save_other_disability_text!

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -8,54 +8,54 @@ import_trn_data_from_hesa:
   class: "Hesa::RetrieveTrnDataJob"
   queue: hesa
 malware_scan_uploads:
-  cron: "*/20 * * * *"  # Every 20 minutes of every day.
+  cron: "*/20 * * * *" # Every 20 minutes of every day.
   class: "MalwareScanningJob"
   queue: default
 remove_duplicate_dead_jobs:
-  cron: "*/5 * * * *"  # Every 5 minutes of every day.
+  cron: "*/5 * * * *" # Every 5 minutes of every day.
   class: "Sidekiq::RemoveDeadDuplicatesJob"
   queue: default
 
 # Jobs that run once a day at a specific time, sorted by their running time
 truncate_activerecord_session_store:
-  cron: "0 0 * * *"  # Every day at 00:00 (midnight).
+  cron: "0 0 * * *" # Every day at 00:00 (midnight).
   class: "SessionStoreTruncateJob"
   queue: default
 delete_empty_trainees:
-  cron: "0 0 * * *"  # Every day at 00:00 (midnight).
+  cron: "0 0 * * *" # Every day at 00:00 (midnight).
   class: "DeleteEmptyTraineesJob"
   queue: default
 import_applications_from_apply:
-  cron: "0 1 * * *"  # Every day at 01:00.
+  cron: "0 1 * * *" # Every day at 01:00.
   class: "RecruitsApi::ImportApplicationsJob"
   queue: default
 import_subjects_from_ttapi:
-  cron: "0 2 * * *"  # Every day at 02:00.
+  cron: "0 2 * * *" # Every day at 02:00.
   class: "TeacherTrainingApi::ImportSubjectsJob"
   queue: default
 import_courses_from_ttapi:
-  cron: "0 3 * * *"  # Every day at 03:00.
+  cron: "0 3 * * *" # Every day at 03:00.
   class: "TeacherTrainingApi::ImportCoursesJob"
   queue: default
 create_trainees_from_apply:
-  cron: "0 4 * * *"  # Every day at 04:00.
+  cron: <%= '"0 4 * * *" # Every day at 04:00.' unless ENV.fetch("RAILS_ENV") == "sandbox" %>
   class: "Trainees::CreateFromApplyJob"
   queue: default
 sync_hesa_students:
-  cron: "0 5 * * *"  # Every day at 05:00.
+  cron: "0 5 * * *" # Every day at 05:00.
   class: "Hesa::SyncStudentsJob"
   queue: hesa
 upload_trn_file_to_hesa:
-  cron: "10 10 * * *"  # Every day at 10:10.
+  cron: "10 10 * * *" # Every day at 10:10.
   class: "Hesa::UploadTrnFileJob"
   queue: hesa
 send_entity_table_checks_to_bigquery:
-  cron: "30 0 * * *"  # Every day at 00:30.
+  cron: "30 0 * * *" # Every day at 00:30.
   class: "DfE::Analytics::EntityTableCheckJob"
   queue: dfe_analytics
 
 # Jobs that run less than once a day
 sync_dqt_teachers:
-  cron: "0 2 * * 1"  # Every Monday at 02:00.
+  cron: "0 2 * * 1" # Every Monday at 02:00.
   class: "Dqt::SyncTeachersJob"
   queue: default


### PR DESCRIPTION
### Context

https://trello.com/c/R0hNBrBl/7452-missingcourseerrors-in-sandbox

### Changes proposed in this pull request

Apply sandbox is trying to create courses that don't exist. For now we will disable the import job on the sandbox environment.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
