### PR TITLE
[xxxx] Revert disable HESA integration on production

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -37,10 +37,10 @@ features:
   google:
     send_data_to_big_query: true
   integrate_with_dqt: true
-  hesa_trn_requests: false
+  hesa_trn_requests: true
   hesa_import:
-    sync_collection: false
-    sync_trn_data: false
+    sync_collection: true
+    sync_trn_data: true
   dqt_import:
     sync_teachers: true
   register_api: false


### PR DESCRIPTION
### Context

HESA have let us know that they are waiting for a Provider to commit some data to the 23053 collection so we need to switch on the HESA integration until this is complete and HESA are ready to switch to the new 24053 test collection.

### Changes proposed in this pull request

* Revert the HESA integration switch off

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
