### PR TITLE
[7505] - Add ex accredited provider to new accredited provider mapping

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -71,7 +71,8 @@ module Trainees
        .merge(course_attributes)
        .merge(submitted_for_trn_attributes)
        .merge(funding_attributes)
-       .merge(school_attributes)
+       .merge(lead_partner_attributes)
+       .merge(employing_school_attributes)
        .merge(training_initiative_attributes)
        .merge(apply_attributes)
     end
@@ -130,7 +131,7 @@ module Trainees
       { submitted_for_trn_at: Time.zone.now }
     end
 
-    def school_attributes
+    def lead_partner_attributes
       attrs = {}
 
       if hesa_trainee[:ukprn].in?(LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys)
@@ -140,6 +141,12 @@ module Trainees
       else
         attrs.merge!(lead_partner: LeadPartner.find_by(urn: hesa_trainee[:lead_school_urn]), lead_partner_not_applicable: false)
       end
+
+      attrs
+    end
+
+    def employing_school_attributes
+      attrs = {}
 
       if hesa_trainee[:employing_school_urn].present?
         if NOT_APPLICABLE_SCHOOL_URNS.include?(hesa_trainee[:employing_school_urn])

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -15,13 +15,13 @@ module Trainees
     MIN_NUMBER_OF_DAYS_SUGGESTING_COURSE_CHANGE = 30
 
     LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING = {
-      "10006841" => { urn: "133794", ukprn: "10000571" }, # University of Bolton => Bath Spa University
-      "10000961" => { urn: "133897", ukprn: "10000571" }, # Brunel University => Bath Spa University
-      "10007146" => { urn: "133876", ukprn: "10007851" }, # University of Greenwich => University of Derby
-      "10007806" => { urn: "133795", ukprn: "10007137" }, # University of Sussex => University of Chichester
-      "10007842" => { urn: "135398", ukprn: "10007163" }, # University of Cumbria => University of Warwick
-      "10007164" => { urn: "133798", ukprn: "10005790" }, # University of the West of England => Sheffield Hallam University
-      "10007789" => { urn: "133853", ukprn: "10007139" }, # University of East Anglia => University of Worcester
+      "10006841" => "10000571", # University of Bolton => Bath Spa University
+      "10000961" => "10000571", # Brunel University => Bath Spa University
+      "10007146" => "10007851", # University of Greenwich => University of Derby
+      "10007806" => "10007137", # University of Sussex => University of Chichester
+      "10007842" => "10007163", # University of Cumbria => University of Warwick
+      "10007164" => "10005790", # University of the West of England => Sheffield Hallam University
+      "10007789" => "10007139", # University of East Anglia => University of Worcester
     }.freeze
 
     class HesaImportError < StandardError; end
@@ -118,16 +118,16 @@ module Trainees
     end
 
     def lead_partner_attributes
-      return {} unless LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys.include?(hesa_trainee[:ukprn])
+      return {} unless hesa_trainee[:ukprn].in?(LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys)
 
-      lead_partner = LeadPartner.find_by(urn: LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[hesa_trainee[:ukprn]][:urn])
+      lead_partner = LeadPartner.find_by(ukprn: hesa_trainee[:ukprn])
 
       lead_partner ? { lead_partner: } : {}
     end
 
     def provider_attributes
-      provider = if LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys.include?(hesa_trainee[:ukprn])
-                   Provider.find_by(ukprn: LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[hesa_trainee[:ukprn]][:ukprn])
+      provider = if hesa_trainee[:ukprn].in?(LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys)
+                   Provider.find_by(ukprn: LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[hesa_trainee[:ukprn]])
                  else
                    Provider.find_by(ukprn: hesa_trainee[:ukprn])
                  end

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -14,7 +14,7 @@ module Trainees
 
     MIN_NUMBER_OF_DAYS_SUGGESTING_COURSE_CHANGE = 30
 
-    LEAD_PARTNER_URN_TO_ACCREDITED_PROVIDER_UKPRN_MAPPING = {
+    LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING = {
       "10006841" => { urn: "133794", ukprn: "10000571" }, # University of Bolton => Bath Spa University
       "10000961" => { urn: "133897", ukprn: "10000571" }, # Brunel University => Bath Spa University
       "10007146" => { urn: "133876", ukprn: "10007851" }, # University of Greenwich => University of Derby
@@ -118,16 +118,16 @@ module Trainees
     end
 
     def lead_partner_attributes
-      return {} unless LEAD_PARTNER_URN_TO_ACCREDITED_PROVIDER_UKPRN_MAPPING.keys.include?(hesa_trainee[:ukprn])
+      return {} unless LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys.include?(hesa_trainee[:ukprn])
 
-      lead_partner = LeadPartner.find_by(urn: LEAD_PARTNER_URN_TO_ACCREDITED_PROVIDER_UKPRN_MAPPING[hesa_trainee[:ukprn]][:urn])
+      lead_partner = LeadPartner.find_by(urn: LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[hesa_trainee[:ukprn]][:urn])
 
       lead_partner ? { lead_partner: } : {}
     end
 
     def provider_attributes
-      provider = if LEAD_PARTNER_URN_TO_ACCREDITED_PROVIDER_UKPRN_MAPPING.keys.include?(hesa_trainee[:ukprn])
-                   Provider.find_by(ukprn: LEAD_PARTNER_URN_TO_ACCREDITED_PROVIDER_UKPRN_MAPPING[hesa_trainee[:ukprn]][:ukprn])
+      provider = if LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys.include?(hesa_trainee[:ukprn])
+                   Provider.find_by(ukprn: LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[hesa_trainee[:ukprn]][:ukprn])
                  else
                    Provider.find_by(ukprn: hesa_trainee[:ukprn])
                  end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -21,9 +21,9 @@ module Trainees
     let(:second_disability_name) { Diversities::DEVELOPMENT_CONDITION }
     let!(:second_disability) { create(:disability, name: second_disability_name) }
     let(:record_source) { Trainee::HESA_COLLECTION_SOURCE }
-    let(:former_accredited_provider_ukprn) { described_class::LEAD_PARTNER_URN_TO_ACCREDITED_PROVIDER_UKPRN_MAPPING.keys.sample }
-    let(:lead_partner_urn) { described_class::LEAD_PARTNER_URN_TO_ACCREDITED_PROVIDER_UKPRN_MAPPING[former_accredited_provider_ukprn][:urn] }
-    let(:accredited_provider_ukprn) { described_class::LEAD_PARTNER_URN_TO_ACCREDITED_PROVIDER_UKPRN_MAPPING[former_accredited_provider_ukprn][:ukprn] }
+    let(:former_accredited_provider_ukprn) { described_class::LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys.sample }
+    let(:lead_partner_urn) { described_class::LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[former_accredited_provider_ukprn][:urn] }
+    let(:accredited_provider_ukprn) { described_class::LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[former_accredited_provider_ukprn][:ukprn] }
 
     let!(:course_allocation_subject) do
       create(:subject_specialism, name: CourseSubjects::BIOLOGY).allocation_subject

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -103,7 +103,7 @@ module Trainees
         end
       end
 
-      context "when lead_partner_urn is from an ex-accreddited HEI" do
+      context "when ukprn is from an ex-accreddited HEI" do
         let(:hesa_stub_attributes) { { ukprn: former_accredited_provider_ukprn } }
 
         it "sets the correct accredited provider for the lead partner" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -22,8 +22,7 @@ module Trainees
     let!(:second_disability) { create(:disability, name: second_disability_name) }
     let(:record_source) { Trainee::HESA_COLLECTION_SOURCE }
     let(:former_accredited_provider_ukprn) { described_class::LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING.keys.sample }
-    let(:lead_partner_urn) { described_class::LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[former_accredited_provider_ukprn][:urn] }
-    let(:accredited_provider_ukprn) { described_class::LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[former_accredited_provider_ukprn][:ukprn] }
+    let(:accredited_provider_ukprn) { described_class::LEAD_PARTNER_TO_ACCREDITED_PROVIDER_MAPPING[former_accredited_provider_ukprn] }
 
     let!(:course_allocation_subject) do
       create(:subject_specialism, name: CourseSubjects::BIOLOGY).allocation_subject
@@ -39,7 +38,7 @@ module Trainees
       create(:nationality, name: nationality_name)
       create(:provider, ukprn: student_attributes[:ukprn])
       create(:provider, ukprn: accredited_provider_ukprn)
-      create(:lead_partner, :hei, urn: lead_partner_urn)
+      create(:lead_partner, :hei, ukprn: former_accredited_provider_ukprn)
       create(:school, urn: student_attributes[:lead_school_urn])
       create(:withdrawal_reason, :with_all_reasons)
       create_custom_state
@@ -103,11 +102,11 @@ module Trainees
         end
       end
 
-      context "when ukprn is from an ex-accreddited HEI" do
+      context "when ukprn is from an ex-accredited HEI" do
         let(:hesa_stub_attributes) { { ukprn: former_accredited_provider_ukprn } }
 
         it "sets the correct accredited provider for the lead partner" do
-          expect(trainee.lead_partner.urn).to eq(lead_partner_urn)
+          expect(trainee.lead_partner.ukprn).to eq(former_accredited_provider_ukprn)
           expect(trainee.provider.ukprn).to eq(accredited_provider_ukprn)
         end
       end


### PR DESCRIPTION
### Context

https://trello.com/c/9eFE9tuU/7505-implement-lp-to-ap-matching-for-2024-2025-for-7-partnerships

### Changes proposed in this pull request

There are seven formerly accredited providers who will be importing trainees for the 24-25 academic cycle. The ex-accredited provider will be set as the lead partner and the new accredited provider will be set in their place.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
