### PR TITLE
Upgrade prod postgres sku to GP_Standard_D4ds_v5

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -78,7 +78,7 @@ module "postgres_snapshot" {
   alert_window_size       = var.alert_window_size
   azure_extensions        = ["PGCRYPTO","BTREE_GIST","CITEXT","PG_TRGM"]
   server_version          = var.postgres_version
-  azure_sku_name          = var.postgres_flexible_server_sku
+  azure_sku_name          = var.snapshot_flexible_server_sku
 
   azure_enable_high_availability      = false
   azure_maintenance_window            = var.azure_maintenance_window

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -95,6 +95,7 @@ variable "main_app" {
 
 variable "azure_maintenance_window" { default = null }
 variable "postgres_flexible_server_sku" { default = "B_Standard_B1ms" }
+variable "snapshot_flexible_server_sku" { default = "GP_Standard_D2ds_v4" }
 variable "postgres_enable_high_availability" { default = false }
 variable "azure_enable_backup_storage" { default = true }
 variable "enable_container_monitoring" { default = false }

--- a/terraform/aks/workspace-variables/production.tfvars.json
+++ b/terraform/aks/workspace-variables/production.tfvars.json
@@ -27,7 +27,7 @@
     "start_hour": 3,
     "start_minute": 0
   },
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
   "postgres_enable_high_availability": true,
   "snapshot_databases_to_deploy": 1,
   "deploy_temp_data_storage_account": true,


### PR DESCRIPTION
### Context

We’ve received production Postgres CPU usage alerts and usage will keep increasing as the API is released. 
So we would like to upgrade to a more powerful server.

There may be some service impact, so this will be merged at 6pm Wed 28th.

### Changes proposed in this pull request

Change from GP_Standard_D2ds_v4 to GP_Standard_D4ds_v5
which increases
- from 2 to 4 vcpu
- from 8G to 16G 

Separate the snapshot db (analysis) sku as that uses the same setting as prod, and that doesn't need to be updated.

### Guidance to review

make production deploy-plan

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
