### PR TITLE
[7515] Add Developer Support guidance for: Resolving Incorrect `provider_type` on Publish, Ensuring Trainees are Created on Register

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -328,3 +328,32 @@ This command will:
 3. If found, it will find and discard any other trainee that has the same email address.
 4. If not found, it will print a message stating that the trainee was not found.
 5. Once the task finishes running through all rows in the CSV, it will print "Task completed."
+
+### Resolving Incorrect `provider_type` on Publish: Ensuring Trainees are Created on Register
+
+**Steps to Take:**
+1. **Correct the `provider_type` on Publish**
+    - Once the provider type is corrected, the Apply applications will be imported, and new trainees will be created.
+2. **Identify the `apply_id` on Register**
+    - Retrieve the `apply_id` from the `ApplyApplication` table using the following query:
+
+    `application_choice_ids = ApplyApplication.where(accredited_body_code: "2N2", recruitment_cycle_year: 2024, state: :non_importable_hei).pluck(:apply_id)`
+
+3. **Touch All Relevant `ApplicationChoice` Entries on Apply**
+
+    - Touch the relevant `ApplicationChoice` records so that when Register calls the API endpoint with the `changed_since` parameter it will return the applications again:
+    
+    `ApplicationChoice.where(id: application_choice_ids).touch_all`
+
+4. **Delete Related `ApplyApplication` Entries on Register**
+    
+    - Remove the associated `ApplyApplication` records from the Register:
+
+    `ApplyApplication.where(apply_id: application_choice_ids).delete_all`
+
+5. **Initiate Sidekiq Jobs on Register**
+    - Trigger the following Sidekiq jobs to complete the process:
+      - `import_applications_from_apply`
+      - `create_trainees_from_apply`
+
+Note: This process will import a fresh copy of the applicants' details and use them to create new records. This ensures that the system realigns with its normal mode of operation, correcting any issues caused by previously imported, potentially stale data.

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -329,7 +329,7 @@ This command will:
 4. If not found, it will print a message stating that the trainee was not found.
 5. Once the task finishes running through all rows in the CSV, it will print "Task completed."
 
-### Resolving Incorrect `provider_type` on Publish: Ensuring Trainees are Created on Register
+## Resolving Incorrect `provider_type` on Publish: Ensuring Trainees are Created on Register
 
 **Steps to Take:**
 1. **Correct the `provider_type` on Publish**
@@ -337,19 +337,26 @@ This command will:
 2. **Identify the `apply_id` on Register**
     - Retrieve the `apply_id` from the `ApplyApplication` table using the following query:
 
-    `application_choice_ids = ApplyApplication.where(accredited_body_code: "2N2", recruitment_cycle_year: 2024, state: :non_importable_hei).pluck(:apply_id)`
+
+      ```ruby
+      application_choice_ids = ApplyApplication.where(accredited_body_code: "2N2", recruitment_cycle_year: 2024, state: :non_importable_hei).pluck(:apply_id)
+      ```
 
 3. **Touch All Relevant `ApplicationChoice` Entries on Apply**
 
     - Touch the relevant `ApplicationChoice` records so that when Register calls the API endpoint with the `changed_since` parameter it will return the applications again:
     
-    `ApplicationChoice.where(id: application_choice_ids).touch_all`
+      ```ruby
+      ApplicationChoice.where(id: application_choice_ids).touch_all
+      ```
 
 4. **Delete Related `ApplyApplication` Entries on Register**
     
     - Remove the associated `ApplyApplication` records from the Register:
 
-    `ApplyApplication.where(apply_id: application_choice_ids).delete_all`
+      ```ruby
+      ApplyApplication.where(apply_id: application_choice_ids).delete_all
+      ```
 
 5. **Initiate Sidekiq Jobs on Register**
     - Trigger the following Sidekiq jobs to complete the process:


### PR DESCRIPTION
### Context

An issue was identified where the incorrect `provider_type` on Publish prevented the creation of trainees on Register. 

This misalignment disrupted the normal flow of application data between systems, leading to missing trainees.

### Changes proposed in this pull request

Added guidance to the support playbook to assist in addressing this issue should it arise again.

### Guidance to review

:shipit: 

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
