### PR TITLE
[7352] Update Lead Partner to Accredited Provider mapping for 2024 onwards

### DIFF
--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -15,6 +15,7 @@ module Trainees
     let(:hesa_age_range_codes) { DfE::ReferenceData::AgeRanges::HESA_CODE_SETS.invert }
     let!(:start_academic_cycle) { create(:academic_cycle, cycle_year: 2022) }
     let!(:end_academic_cycle) { create(:academic_cycle, cycle_year: 2023) }
+    let!(:itt_reform_academic_cycle) { create(:academic_cycle, cycle_year: 2024) }
     let!(:after_next_academic_cycle) { create(:academic_cycle, one_after_next_cycle: true) }
     let(:first_disability_name) { Diversities::LEARNING_DIFFICULTY }
     let!(:first_disability) { create(:disability, name: first_disability_name) }
@@ -103,12 +104,26 @@ module Trainees
         end
       end
 
-      context "when ukprn is from an ex-accredited HEI" do
+      context "when ukprn is from a formerly accredited HEI in academic year 2022" do
         let(:hesa_stub_attributes) { { ukprn: former_accredited_provider_ukprn } }
 
-        it "sets the correct accredited provider for the lead partner" do
-          expect(trainee.lead_partner.ukprn).to eq(former_accredited_provider_ukprn)
+        it "sets the correct accredited provider and lead partner" do
+          expect(trainee.provider.ukprn).to eq(former_accredited_provider_ukprn)
+          expect(trainee.lead_partner.urn).to eq(school.urn)
+        end
+      end
+
+      context "when ukprn is from a formerly accredited HEI in academic year 2024" do
+        let(:hesa_stub_attributes) do
+          {
+            ukprn: former_accredited_provider_ukprn,
+            trainee_start_date: "2024-09-01",
+          }
+        end
+
+        it "sets the correct accredited provider and lead partner" do
           expect(trainee.provider.ukprn).to eq(accredited_provider_ukprn)
+          expect(trainee.lead_partner.ukprn).to eq(former_accredited_provider_ukprn)
         end
       end
 

--- a/spec/smoke/login_spec.rb
+++ b/spec/smoke/login_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper_smoke"
 
 describe "User login spec" do
   before do
-    skip "DfE sign-in not enabled" unless Settings.features.sign_in_method == "dfe-sign-in"
+    skip "DfE sign-in not enabled" if Settings.features.sign_in_method != "dfe-sign-in" || Settings.environment.name == "staging"
   end
 
   scenario "signing in successfully", js: true do


### PR DESCRIPTION
### Context

As the create from HESA process also updates existing trainees, we want to make sure that we only apply the LP to AP matching for trainees in academic year 2024 and onwards.

### Changes proposed in this pull request

* Add logic to check the start academic year is 2024 or later before doing LP to AP matching

### Guidance to review

* Does the new logic make sense?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
