### PR TITLE
[7501] Added a rake task to manuelly import apply application and creation of trainners

### DIFF
--- a/lib/tasks/trainees_create_from_apply.rake
+++ b/lib/tasks/trainees_create_from_apply.rake
@@ -10,15 +10,14 @@ namespace :trainees do
     .where(recruitment_cycle_year:)
     .maximum(:created_at)
 
-    if recruitment_cycle_year.blank? || changed_since.blank?
-      puts "No viable recruitment_cycle_year inputted or changed_since found"
-      exit 1
-    end
+    raise "No viable recruitment_cycle_year inputted" if recruitment_cycle_year.blank?
+
+    raise "No viable changed_since found" if changed_since.blank?
 
     RecruitsApi::RetrieveApplications.call(changed_since:, recruitment_cycle_year:).each do |application_data|
-      application = ImportApplication.call(application_data:)
+      application = RecruitsApi::ImportApplication.call(application_data:)
 
-      CreateFromApply.call(application:) if application&.importable? && application&.provider&.apply_sync_enabled
+      Trainees::CreateFromApply.call(application:) if application&.importable? && application&.provider&.apply_sync_enabled
     end
   end
 end

--- a/lib/tasks/trainees_create_from_apply.rake
+++ b/lib/tasks/trainees_create_from_apply.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :trainees do
+  desc "creates trainees from apply"
+  task :create_from_apply, %i[recruitment_cycle_year] => [:environment] do |_, args|
+    recruitment_cycle_year = args.recruitment_cycle_year
+
+    changed_since = ApplyApplicationSyncRequest
+    .successful
+    .where(recruitment_cycle_year:)
+    .maximum(:created_at)
+
+    if recruitment_cycle_year.blank? || changed_since.blank?
+      puts "No viable recruitment_cycle_year inputted or changed_since found"
+      exit 1
+    end
+
+    RecruitsApi::RetrieveApplications.call(changed_since:, recruitment_cycle_year:).each do |application_data|
+      application = ImportApplication.call(application_data:)
+
+      CreateFromApply.call(application:) if application&.importable? && application&.provider&.apply_sync_enabled
+    end
+  end
+end

--- a/spec/factories/apply_applications.rb
+++ b/spec/factories/apply_applications.rb
@@ -5,8 +5,9 @@ FactoryBot.define do
     sequence(:apply_id)
     application { JSON.parse(ApiStubs::RecruitsApi.application(degree_attributes:)) }
     invalid_data { {} }
-    accredited_body_code { create(:provider).code }
+    accredited_body_code { create(:provider, apply_sync_enabled: true).code }
     recruitment_cycle_year { Settings.apply_applications.create.recruitment_cycle_year }
+    state { :importable }
 
     transient do
       degree_slug { SecureRandom.base58(Sluggable::SLUG_LENGTH).to_s }

--- a/spec/lib/tasks/trainees_create_from_apply_spec.rb
+++ b/spec/lib/tasks/trainees_create_from_apply_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "trainees:create_from_apply" do
+  let(:args) {
+    Rake::TaskArguments.new(%i[recruitment_cycle_year], [recruitment_cycle_year])
+  }
+
+  let(:apply_application_sync_request) { create(:apply_application_sync_request, :successful, recruitment_cycle_year:) }
+
+  let(:recruitment_cycle_year) { 2023 }
+  let(:application_data) { JSON.parse(ApiStubs::RecruitsApi.application) }
+  let(:application) { build(:apply_application, :importable) }
+
+  it "called retrieved applications" do
+    apply_application_sync_request
+
+    allow(RecruitsApi::RetrieveApplications).to receive(:call).with({ changed_since: apply_application_sync_request.created_at, recruitment_cycle_year: recruitment_cycle_year }).and_return([application_data])
+    allow(RecruitsApi::ImportApplication).to receive(:call).with({ application_data: }).and_return(application)
+    expect(Trainees::CreateFromApply).to receive(:call).with({ application: })
+
+    Rake::Task["trainees:create_from_apply"].execute(args)
+
+    subject
+  end
+end


### PR DESCRIPTION
### Context
There is a gap, whereby an applicant can be a trainee missing vital checkpoints.

### Changes proposed in this pull request
Added ability to be able to go back in time to add a trainee.

### Guidance to review
A provider on `apply` finally gets around to marking an applicant/candidate as recruited`` after the end of the academic year has elapsed.
 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
