### PR TITLE
add degree validation on recommend for qts endpoint

### DIFF
--- a/app/services/api/trainees/award_recommendation_service.rb
+++ b/app/services/api/trainees/award_recommendation_service.rb
@@ -21,6 +21,8 @@ module Api
 
       validates_with AwardRecommendationValidator
 
+      validate :trainee_has_degrees?
+
       def initialize(params, trainee)
         super(params)
 
@@ -44,6 +46,10 @@ module Api
         {
           outcome_date: qts_standards_met_date,
         }
+      end
+
+      def trainee_has_degrees?
+        errors.add(:trainee, :degrees) if trainee.degrees.empty?
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1379,6 +1379,7 @@ en:
         trainee:
           attributes:
             training_route: Select a type of training
+            degrees: "Degree information must be sumitted for trainee before QTS recommendation"
         degree:
           attributes:
             uk_degree:
@@ -1983,6 +1984,7 @@ en:
             trainee:
               state: state is invalid must be [trn_received]
               submission_ready: submission ready is invalid must be true
+              degrees: degree information must be sumitted before QTS recommendation
             qts_standards_met_date:
               future: must be in the past
               itt_start_date: &qts_itt_start_date must not be before the ITT start date

--- a/spec/requests/api/v1_0_pre/trainees/post_recommend_for_qts_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_recommend_for_qts_spec.rb
@@ -51,6 +51,31 @@ RSpec.describe "POST /api/v1.0-pre/trainees/:trainee_id/recommend-for-qts", feat
       end
     end
 
+    context "when the trainee has no degree information" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :without_degrees,
+          :trn_received,
+        )
+      end
+
+      it "does not recommend the trainee for a qts award" do
+        post "/api/v1.0-pre/trainees/#{trainee.slug}/recommend-for-qts",
+             headers: { authorization: "Bearer #{token}" },
+             params: { data: { qts_standards_met_date: Time.zone.today } }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(trainee.recommended_for_award_at).to be_nil
+        expect(trainee.recommended_for_award?).to be(false)
+
+        expect(response.parsed_body[:errors]).to contain_exactly(
+          "error" => "UnprocessableEntity",
+          "message" => "Trainee degree information must be sumitted before QTS recommendation",
+        )
+      end
+    end
+
     it "does not recommend the trainee for a qts award" do
       post "/api/v1.0-pre/trainees/#{trainee.slug}/recommend-for-qts",
            headers: { authorization: "Bearer #{token}" },


### PR DESCRIPTION
### Context

https://trello.com/c/waoHtZQA/7560-roll-back-degree-requirement-via-state-transition-check-and-implement-on-recommend-for-qts-endpoint

### Changes proposed in this pull request

Add validation of the `recommend-for-qts` api endpoint to check that trainee has submitted degree information

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
