### PR TITLE
[7566] Update API reference docs for `withdraw` endpoint

### DIFF
--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -1240,11 +1240,11 @@ Withdrawal details
         </p>
         <p class="govuk-body">
           The reason(s) for the withdrawal. Valid values are arrays containing one or more of these string values: 
-          `financial_problems`, `another_reason`, `got_a_job`, `problems_with_their_health`, `unknown`,
-          `could_not_give_enough_time`, `course_was_not_suitable`, `did_not_make_progress`,
-          `did_not_meet_entry_requirements`, `does_not_want_to_become_a_teacher`, `family_problems`,
-          `stopped_responding_to_messages`, `teaching_placement_problems`, `unacceptable_behaviour`,
-          `unhappy_with_course_provider_or_employing_school`.
+          <code>financial_problems</code>, <code>another_reason</code>, <code>got_a_job</code>, <code>problems_with_their_health</code>, <code>unknown</code>,
+          <code>could_not_give_enough_time</code>, <code>course_was_not_suitable</code>, <code>did_not_make_progress</code>,
+          <code>did_not_meet_entry_requirements</code>, <code>does_not_want_to_become_a_teacher</code>, <code>family_problems</code>,
+          <code>stopped_responding_to_messages</code>, <code>teaching_placement_problems</code>, <code>unacceptable_behaviour</code>,
+          <code>unhappy_with_course_provider_or_employing_school</code>.
         </p>
     </dd>
 </div>
@@ -1284,6 +1284,26 @@ Withdrawal details
         </p>
     </dd>
 </div>
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">Example request body</span></summary>
+  <div class="govuk-details__text">
+    <pre class="json-code-sample">
+    {
+      "data": {
+        "reasons": [
+          "got_a_job",
+          "could_not_give_enough_time",
+          "course_was_not_suitable"
+        ],
+        "withdraw_date": "2024-02-15 15:17:09 UTC",
+        "withdraw_reasons_details": "I decided to pursue other career options because I was not able to dedicate enough time to teacher training",
+        "withdraw_reasons_dfe_details": "The course did not match my expectations"
+      }
+    }
+    </pre>
+  </div>
+</details>
 
 #### Possible responses
 


### PR DESCRIPTION
### Context
Feedback from vendors suggest that we need to improve the API docs for `POST /trainees/{trainee_id}/withdraw`.

### Changes proposed in this pull request
- Missing list of valid reason values - should list the values in `WithdrawalReasons::REASONS`
- Fix copy and paste error _Recommendation details_ -> _Withdrawal details_
- Add an example request body

![image](https://github.com/user-attachments/assets/5678006b-1d8c-4e3f-9a5a-c613a90e6daa)

### Guidance to review
- I've only included the current (not legacy) `WithdrawalReasons::REASONS` in the docs (it's already quite a long list).

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
