### PR TITLE
[7585] Refactor course_min_age, course_max_age

### DIFF
--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -17,8 +17,7 @@ module Api
         date_of_birth: { type: :date },
         email: {},
         course_education_phase: {},
-        course_min_age: {},
-        course_max_age: {},
+        course_age_range: {},
         trainee_start_date: {},
         sex: {},
         training_route: {},
@@ -52,6 +51,8 @@ module Api
         employing_school_not_applicable: { type: :boolean, options: { default: false } },
         ethnic_group: { type: :string, options: { default: Diversities::ETHNIC_GROUP_ENUMS[:not_provided] } },
         ethnic_background: { type: :string, options: { default: Diversities::NOT_PROVIDED } },
+        course_min_age: {},
+        course_max_age: {},
       }.freeze.each do |name, config|
         attribute(name, config[:type], **config.fetch(:options, {}))
       end

--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -7,6 +7,8 @@ module Api
       include ActiveModel::Attributes
       include ActiveModel::Validations::Callbacks
 
+      include PrimaryCourseSubjects
+
       before_validation :set_course_allocation_subject_id
       after_validation :set_progress
 
@@ -17,7 +19,6 @@ module Api
         date_of_birth: { type: :date },
         email: {},
         course_education_phase: {},
-        course_age_range: {},
         trainee_start_date: {},
         sex: {},
         training_route: {},
@@ -139,7 +140,8 @@ module Api
             :nationalisations_attributes,
             :hesa_trainee_detail_attributes,
             :trainee_disabilities_attributes,
-          ))
+          )
+        )
 
         self.nationalisations_attributes = []
         new_attributes[:nationalisations_attributes]&.each do |nationalisation_params|
@@ -153,6 +155,8 @@ module Api
         new_attributes[:disabilities]&.each do |disability|
           trainee_disabilities_attributes << { disability_id: disability.id }
         end
+
+        self.attributes = primary_course_subjects(attributes) if primary_education_phase?
       end
 
       def update_hesa_trainee_detail_attributes(new_attributes)
@@ -203,6 +207,7 @@ module Api
         params_with_updated_disabilities = params_with_updated_disabilities(new_trainee_attributes, params_for_update)
 
         new_trainee_attributes.assign_attributes(params_with_updated_disabilities)
+
         new_trainee_attributes
       end
 

--- a/app/services/api/v0_1/hesa_mapper/attributes.rb
+++ b/app/services/api/v0_1/hesa_mapper/attributes.rb
@@ -56,6 +56,7 @@ module Api
           .merge(lead_partner_and_employing_school_attributes)
           .compact
 
+
           if update && !disabilities?
             mapped_params = mapped_params.except(:hesa_disabilities, :disability_disclosure, :disabilities)
           end
@@ -168,10 +169,6 @@ module Api
 
         def course_age_range
           DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[params[:course_age_range]]
-        end
-
-        def course_max_age
-          params[:course_max_age]
         end
 
         def course_study_mode

--- a/app/services/api/v0_1/hesa_mapper/attributes.rb
+++ b/app/services/api/v0_1/hesa_mapper/attributes.rb
@@ -56,7 +56,6 @@ module Api
           .merge(lead_partner_and_employing_school_attributes)
           .compact
 
-
           if update && !disabilities?
             mapped_params = mapped_params.except(:hesa_disabilities, :disability_disclosure, :disabilities)
           end
@@ -145,15 +144,15 @@ module Api
           ::Hesa::CodeSets::CourseSubjects::MAPPING[subject_code]
         end
 
-        def course_subject_one_name
+        def course_subject_one
           course_subject_name(params[:course_subject_one])
         end
 
-        def course_subject_two_name
+        def course_subject_two
           course_subject_name(params[:course_subject_two])
         end
 
-        def course_subject_three_name
+        def course_subject_three
           course_subject_name(params[:course_subject_three])
         end
 

--- a/app/services/concerns/has_course_attributes.rb
+++ b/app/services/concerns/has_course_attributes.rb
@@ -23,6 +23,12 @@ module HasCourseAttributes
     attributes
   end
 
+private
+
+  def course_education_phase
+    COURSE_EDUCATION_PHASE_ENUMS[:secondary]
+  end
+
   def course_min_age
     course_age_range && course_age_range[0]
   end

--- a/app/services/concerns/has_course_attributes.rb
+++ b/app/services/concerns/has_course_attributes.rb
@@ -7,7 +7,7 @@ module HasCourseAttributes
       course_subject_one: course_subject_one_name,
       course_subject_two: course_subject_two_name,
       course_subject_three: course_subject_three_name,
-      course_min_age: course_age_range && course_age_range[0],
+      course_min_age: course_min_age,
       course_max_age: course_max_age,
       study_mode: study_mode,
       itt_start_date: itt_start_date,
@@ -19,12 +19,16 @@ module HasCourseAttributes
     primary_education_phase? ? fix_invalid_primary_course_subjects(attributes) : attributes
   end
 
-  def primary_education_phase?
-    course_max_age && course_max_age <= DfE::ReferenceData::AgeRanges::UPPER_BOUND_PRIMARY_AGE
+  def course_min_age
+    course_age_range && course_age_range[0]
   end
 
   def course_max_age
     course_age_range && course_age_range[1]
+  end
+
+  def primary_education_phase?
+    course_max_age && course_max_age <= DfE::ReferenceData::AgeRanges::UPPER_BOUND_PRIMARY_AGE
   end
 
   def fix_invalid_primary_course_subjects(course_attributes)

--- a/app/services/concerns/has_course_attributes.rb
+++ b/app/services/concerns/has_course_attributes.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
 module HasCourseAttributes
+  include PrimaryCourseSubjects
+
   def course_attributes
     attributes = {
-      course_education_phase: course_education_phase,
-      course_subject_one: course_subject_one_name,
-      course_subject_two: course_subject_two_name,
-      course_subject_three: course_subject_three_name,
-      course_min_age: course_min_age,
-      course_max_age: course_max_age,
-      study_mode: study_mode,
-      itt_start_date: itt_start_date,
-      itt_end_date: itt_end_date,
-      trainee_start_date: trainee_start_date,
-      course_allocation_subject: course_allocation_subject,
+      course_education_phase:,
+      course_subject_one:,
+      course_subject_two:,
+      course_subject_three:,
+      course_min_age:,
+      course_max_age:,
+      study_mode:,
+      itt_start_date:,
+      itt_end_date:,
+      trainee_start_date:,
+      course_allocation_subject:,
     }
 
-    primary_education_phase? ? fix_invalid_primary_course_subjects(attributes) : attributes
+    return attributes.merge(primary_course_subjects(attributes)) if primary_education_phase?
+
+    attributes
   end
 
   def course_min_age
@@ -27,24 +31,7 @@ module HasCourseAttributes
     course_age_range && course_age_range[1]
   end
 
-  def primary_education_phase?
-    course_max_age && course_max_age <= DfE::ReferenceData::AgeRanges::UPPER_BOUND_PRIMARY_AGE
-  end
-
-  def fix_invalid_primary_course_subjects(course_attributes)
-    # This always ensures "primary teaching" is the first subject or inserts it if it's missing
-    other_subjects = course_subjects - [CourseSubjects::PRIMARY_TEACHING]
-
-    course_attributes.merge(course_subject_one: CourseSubjects::PRIMARY_TEACHING,
-                            course_subject_two: other_subjects.first,
-                            course_subject_three: other_subjects.second)
-  end
-
-  def course_subjects
-    [course_subject_one_name, course_subject_two_name, course_subject_three_name].compact
-  end
-
   def course_allocation_subject
-    SubjectSpecialism.find_by(name: course_subject_one_name)&.allocation_subject
+    SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject
   end
 end

--- a/app/services/concerns/primary_course_subjects.rb
+++ b/app/services/concerns/primary_course_subjects.rb
@@ -8,23 +8,14 @@ module PrimaryCourseSubjects
     other_subjects = course_subjects - [CourseSubjects::PRIMARY_TEACHING]
 
     {
-      course_education_phase: course_education_phase,
+      course_education_phase: COURSE_EDUCATION_PHASE_ENUMS[:primary],
       course_subject_one: CourseSubjects::PRIMARY_TEACHING,
       course_subject_two: other_subjects.first,
       course_subject_three: other_subjects.second,
     }
   end
 
-  # change this
-  def course_education_phase
-    return COURSE_EDUCATION_PHASE_ENUMS[:primary] if primary_education_phase?
-
-    COURSE_EDUCATION_PHASE_ENUMS[:secondary]
-  end
-
-  # def course_subjects
-  # [course_subject_one, course_subject_two, course_subject_three]
-  # end
+private
 
   def primary_education_phase?
     course_max_age && course_max_age <= DfE::ReferenceData::AgeRanges::UPPER_BOUND_PRIMARY_AGE

--- a/app/services/concerns/primary_course_subjects.rb
+++ b/app/services/concerns/primary_course_subjects.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PrimaryCourseSubjects
+  extend ActiveSupport::Concern
+
+  def primary_course_subjects(_attributes)
+    # This always ensures "primary teaching" is the first subject or inserts it if it's missing
+    other_subjects = course_subjects - [CourseSubjects::PRIMARY_TEACHING]
+
+    {
+      course_education_phase: course_education_phase,
+      course_subject_one: CourseSubjects::PRIMARY_TEACHING,
+      course_subject_two: other_subjects.first,
+      course_subject_three: other_subjects.second,
+    }
+  end
+
+  # change this
+  def course_education_phase
+    return COURSE_EDUCATION_PHASE_ENUMS[:primary] if primary_education_phase?
+
+    COURSE_EDUCATION_PHASE_ENUMS[:secondary]
+  end
+
+  # def course_subjects
+  # [course_subject_one, course_subject_two, course_subject_three]
+  # end
+
+  def primary_education_phase?
+    course_max_age && course_max_age <= DfE::ReferenceData::AgeRanges::UPPER_BOUND_PRIMARY_AGE
+  end
+
+  def course_subjects
+    [course_subject_one, course_subject_two, course_subject_three].compact
+  end
+end

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -238,15 +238,15 @@ module Trainees
       csv_row["Course education phase"].downcase.parameterize(separator: "_")
     end
 
-    def course_subject_one_name
+    def course_subject_one
       course_subject_name("Course ITT subject 1")
     end
 
-    def course_subject_two_name
+    def course_subject_two
       course_subject_name("Course ITT subject 2")
     end
 
-    def course_subject_three_name
+    def course_subject_three
       course_subject_name("Course ITT Subject 3")
     end
 

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -256,15 +256,15 @@ module Trainees
       ::Hesa::CodeSets::CourseSubjects::MAPPING[subject_code]
     end
 
-    def course_subject_one_name
+    def course_subject_one
       course_subject_name(hesa_trainee[:course_subject_one])
     end
 
-    def course_subject_two_name
+    def course_subject_two
       course_subject_name(hesa_trainee[:course_subject_two])
     end
 
-    def course_subject_three_name
+    def course_subject_three
       course_subject_name(hesa_trainee[:course_subject_three])
     end
 

--- a/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
@@ -494,6 +494,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
     context "with course subjects" do
       context "when HasCourseAttributes#primary_education_phase? is true" do
+        let(:course_age_range) { "13914" }
+
         before do
           post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
         end
@@ -548,6 +550,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       end
 
       context "when HasCourseAttributes#primary_education_phase? is false" do
+        let(:course_age_range) { "13917" }
         let(:params) do
           {
             data: data.merge(

--- a/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
@@ -89,6 +89,15 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       expect(Trainee.last.state).to eq("submitted_for_trn")
     end
 
+    it "sets the correct course_min_age and course_max_age" do
+      course_min_age, course_max_age = DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[course_age_range]
+
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
+      expect(response.parsed_body[:data][:course_min_age]).to eq(course_min_age)
+      expect(response.parsed_body[:data][:course_max_age]).to eq(course_max_age)
+    end
+
     it "sets the correct study_mode" do
       post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
 
@@ -496,7 +505,6 @@ describe "`POST /api/v0.1/trainees` endpoint" do
                 course_subject_one: "100346",
                 course_subject_two: "101410",
                 course_subject_three: "100366",
-                course_max_age: 11,
               ),
             }
           end
@@ -521,7 +529,6 @@ describe "`POST /api/v0.1/trainees` endpoint" do
                 course_subject_one: "100511",
                 course_subject_two: "101410",
                 course_subject_three: "100366",
-                course_max_age: 11,
               ),
             }
           end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -918,6 +918,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
       context "when HasCourseAttributes#primary_education_phase? is true" do
         before do
+          trainee.update!(course_age_range: [7, 11])
+
           put(
             endpoint,
             headers: { Authorization: "Bearer #{token}", **json_headers },
@@ -932,7 +934,6 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
                 course_subject_one: "100346",
                 course_subject_two: "101410",
                 course_subject_three: "100366",
-                course_max_age: 11,
               },
             }
           end
@@ -957,7 +958,6 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
                 course_subject_one: "100511",
                 course_subject_two: "101410",
                 course_subject_three: "100366",
-                course_max_age: 11,
               },
             }
           end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -176,6 +176,28 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       end
     end
 
+    context "when updating with valid course_age_range" do
+      let(:data) { { course_age_range: } }
+
+      let(:course_age_range) { "13909" }
+
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
+      it "returns status 200" do
+        course_min_age, course_max_age = DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[course_age_range]
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:data][:course_min_age]).to eq(course_min_age)
+        expect(response.parsed_body[:data][:course_max_age]).to eq(course_max_age)
+      end
+    end
+
     context "when course_age_range is empty" do
       let(:data) { { course_age_range: "" } }
 

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -90,6 +90,16 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       expect(Trainee.last.state).to eq("submitted_for_trn")
     end
 
+    it "sets the correct course_min_age and course_max_age" do
+      course_min_age, course_max_age = DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[course_age_range]
+
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
+      expect(response.parsed_body[:data][:course_min_age]).to eq(course_min_age)
+      expect(response.parsed_body[:data][:course_max_age]).to eq(course_max_age)
+    end
+
+
     it "sets the correct study_mode" do
       post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -99,7 +99,6 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       expect(response.parsed_body[:data][:course_max_age]).to eq(course_max_age)
     end
 
-
     it "sets the correct study_mode" do
       post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
@@ -484,6 +483,8 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
 
     context "with course subjects" do
       context "when HasCourseAttributes#primary_education_phase? is true" do
+        let(:course_age_range) { "13914" }
+
         before do
           post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
         end
@@ -495,7 +496,6 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
                 course_subject_one: "100346",
                 course_subject_two: "101410",
                 course_subject_three: "100366",
-                course_max_age: 11,
               ),
             }
           end
@@ -520,7 +520,6 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
                 course_subject_one: "100511",
                 course_subject_two: "101410",
                 course_subject_three: "100366",
-                course_max_age: 11,
               ),
             }
           end

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -208,6 +208,28 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
       end
     end
 
+    context "when updating with valid course_age_range" do
+      let(:data) { { course_age_range: } }
+
+      let(:course_age_range) { "13909" }
+
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
+      it "returns status 200" do
+        course_min_age, course_max_age = DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[course_age_range]
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:data][:course_min_age]).to eq(course_min_age)
+        expect(response.parsed_body[:data][:course_max_age]).to eq(course_max_age)
+      end
+    end
+
     context "when course_age_range is empty" do
       let(:data) { { course_age_range: "" } }
 

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -958,13 +958,14 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
         end
 
         context "when '100511' is not present" do
+          let(:course_age_range) { "13914" }
           let(:params) do
             {
               data: {
                 course_subject_one: "100346",
                 course_subject_two: "101410",
                 course_subject_three: "100366",
-                course_max_age: 11,
+                course_age_range: course_age_range,
               },
             }
           end
@@ -972,6 +973,7 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
           it "sets the correct subjects" do
             trainee.reload
 
+            expect(trainee.course_age_range).to eq(DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[course_age_range])
             expect(trainee.course_subject_one).to eq("primary teaching")
             expect(trainee.course_subject_two).to eq("biology")
             expect(trainee.course_subject_three).to eq("historical linguistics")
@@ -989,7 +991,6 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
                 course_subject_one: "100511",
                 course_subject_two: "101410",
                 course_subject_three: "100366",
-                course_max_age: 11,
               },
             }
           end


### PR DESCRIPTION
### Context

[7585-investigate-issues-saving-serialising-coursemaxage-and-courseminage-with-post-trainees-api-endpoint
](https://trello.com/c/5hlI6uSg/7585-investigate-issues-saving-serialising-coursemaxage-and-courseminage-with-post-trainees-api-endpoint)

`course_max_age` wasn't be set as it was returning `params[:course_max_age]` instead the value from `course_age_range`.

There was also an issue with `course_subjects` as the order of courses were determined in the HESA attributes mapper where for existing trainees on update the order of subjects could not been determined as the Trainee record is not available.

### Changes proposed in this pull request

* Fix issue determining course_min_age and course_max_age based on course_age_range
* Extract course subjects order logic to `PrimaryCourseSubjects` concern

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
