### PR TITLE
[7602] Update API documentation for Placements

### DIFF
--- a/app/models/api/v0_1/placement_attributes.rb
+++ b/app/models/api/v0_1/placement_attributes.rb
@@ -20,7 +20,7 @@ module Api
       ].freeze.each { |attr| attribute(attr) }
 
       validates :urn, format: { with: URN_REGEX }, if: -> { urn.present? }
-      validates :name, presence: true, if: -> { school_id.blank? }
+      validates :name, presence: true, if: -> { school_id.nil? && !School.exists?(urn:) }
       validates :postcode, postcode: true
 
       def self.from_placement(placement)

--- a/app/models/api/v0_1/placement_attributes.rb
+++ b/app/models/api/v0_1/placement_attributes.rb
@@ -24,17 +24,22 @@ module Api
       validates :postcode, postcode: true
 
       def self.from_placement(placement)
-        new(placement.attributes.with_indifferent_access)
+        new(
+          placement.attributes.select do |k, _v|
+            ATTRIBUTES.include?(k.to_sym) || INTERNAL_ATTRIBUTES.include?(k.to_sym)
+          end,
+        )
       end
 
       def assign_attributes(new_attributes)
-        if (school = School.find_by(urn: new_attributes[:urn]))
-          new_attributes[:urn]         = nil
-          new_attributes[:name]        = nil
-          new_attributes[:postcode]    = nil
+        if new_attributes.key?("urn") && (school = School.find_by(urn: new_attributes["urn"]))
+          new_attributes["urn"]      = nil
+          new_attributes["name"]     = nil
+          new_attributes["address"]  = nil
+          new_attributes["postcode"] = nil
         end
 
-        new_attributes[:school_id] = school&.id
+        new_attributes["school_id"] = school&.id if new_attributes.key?("urn")
 
         super(
           new_attributes.select do |k, _v|

--- a/app/models/api/v0_1/placement_attributes.rb
+++ b/app/models/api/v0_1/placement_attributes.rb
@@ -32,12 +32,13 @@ module Api
 
       def assign_attributes(new_attributes)
         if new_attributes.key?("urn") && (school = School.find_by(urn: new_attributes["urn"]))
-          new_attributes["urn"]      = nil
-          new_attributes["name"]     = nil
-          new_attributes["postcode"] = nil
+          new_attributes["urn"]       = nil
+          new_attributes["name"]      = nil
+          new_attributes["postcode"]  = nil
+          new_attributes["school_id"] = school.id
+        else
+          new_attributes["school_id"] = nil
         end
-
-        new_attributes["school_id"] = school&.id if new_attributes.key?("urn")
 
         super(
           new_attributes.select do |k, _v|

--- a/app/models/api/v0_1/placement_attributes.rb
+++ b/app/models/api/v0_1/placement_attributes.rb
@@ -11,7 +11,6 @@ module Api
       ATTRIBUTES = %i[
         urn
         name
-        address
         postcode
       ].freeze.each { |attr| attribute(attr) }
 
@@ -35,7 +34,6 @@ module Api
         if new_attributes.key?("urn") && (school = School.find_by(urn: new_attributes["urn"]))
           new_attributes["urn"]      = nil
           new_attributes["name"]     = nil
-          new_attributes["address"]  = nil
           new_attributes["postcode"] = nil
         end
 

--- a/app/models/api/v0_1/placement_attributes.rb
+++ b/app/models/api/v0_1/placement_attributes.rb
@@ -24,7 +24,7 @@ module Api
       validates :postcode, postcode: true
 
       def self.from_placement(placement)
-        new(placement.attributes)
+        new(placement.attributes.with_indifferent_access)
       end
 
       def assign_attributes(new_attributes)
@@ -34,10 +34,18 @@ module Api
           new_attributes[:name]      ||= school.name
           new_attributes[:postcode]  ||= school.postcode
 
-          super
+          super(
+            new_attributes.select do |k, _v|
+              INTERNAL_ATTRIBUTES.include?(k.to_sym)
+            end
+          )
         end
 
-        super(new_attributes.select { |k, _v| ATTRIBUTES.include?(k.to_sym) })
+        super(
+          new_attributes.select do |k, _v|
+            ATTRIBUTES.include?(k.to_sym)
+          end
+        )
       end
     end
   end

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -66,7 +66,7 @@ class Placement < ApplicationRecord
                      ["URN #{school.urn}", school.town, school.postcode]
                    end
 
-    full_address.join(", ")
+    full_address.join(", ").presence
   end
 
   def created_by_hesa?

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -44,7 +44,7 @@ class Placement < ApplicationRecord
   scope :with_urn, -> { where.not(urn: nil) }
 
   def name
-    super || school&.name
+    school&.name || super
   end
 
   def full_address

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -47,18 +47,22 @@ class Placement < ApplicationRecord
     school&.name || super
   end
 
+  def urn
+    school&.urn || super
+  end
+
+  def postcode
+    school&.postcode || super
+  end
+
   def full_address
     return if Trainees::CreateFromHesa::NOT_APPLICABLE_SCHOOL_URNS.include?(urn)
 
-    full_address = if school.blank?
-                     parts = [address, postcode].compact
-
-                     urn.present? ? parts.unshift("URN #{urn}") : parts
-                   else
-                     ["URN #{school.urn}", school.town, school.postcode]
-                   end
-
-    full_address.join(", ")
+    if school.blank?
+      [address, postcode].compact
+    else
+      ["URN #{school.urn}", school.town, school.postcode]
+    end.join(", ")
   end
 
   def created_by_hesa?

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -44,7 +44,7 @@ class Placement < ApplicationRecord
   scope :with_urn, -> { where.not(urn: nil) }
 
   def name
-    school&.name || super
+    super || school&.name
   end
 
   def full_address

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -58,11 +58,15 @@ class Placement < ApplicationRecord
   def full_address
     return if Trainees::CreateFromHesa::NOT_APPLICABLE_SCHOOL_URNS.include?(urn)
 
-    if school.blank?
-      [address, postcode].compact
-    else
-      ["URN #{school.urn}", school.town, school.postcode]
-    end.join(", ")
+    full_address = if school.blank?
+                     parts = [address, postcode].compact
+
+                     urn.present? ? parts.unshift("URN #{urn}") : parts
+                   else
+                     ["URN #{school.urn}", school.town, school.postcode]
+                   end
+
+    full_address.join(", ")
   end
 
   def created_by_hesa?

--- a/app/serializers/api/v0_1/placement_serializer.rb
+++ b/app/serializers/api/v0_1/placement_serializer.rb
@@ -27,6 +27,7 @@ module Api
       def school_attributes
         {
           "placement_id" => placement.slug,
+          "address" => placement.full_address,
         }
       end
     end

--- a/app/serializers/api/v0_1/placement_serializer.rb
+++ b/app/serializers/api/v0_1/placement_serializer.rb
@@ -8,29 +8,26 @@ module Api
         slug
         trainee_id
         school_id
-        address
       ].freeze
+
+      attr_reader :placement
 
       def initialize(placement)
         @placement = placement
       end
 
       def as_hash
-        @placement.attributes.except(*EXCLUDED_ATTRIBUTES).merge(
-          placement_id: @placement.slug,
-          **school_attributes,
-        )
+        placement
+          .attributes
+          .except(*EXCLUDED_ATTRIBUTES)
+          .merge(school_attributes)
       end
 
     private
 
       def school_attributes
-        return {} if @placement.school.blank?
-
         {
-          urn: @placement.school.urn,
-          name: @placement.school.name,
-          postcode: @placement.school.postcode,
+          "placement_id" => placement.slug,
         }
       end
     end

--- a/app/serializers/api/v0_1/placement_serializer.rb
+++ b/app/serializers/api/v0_1/placement_serializer.rb
@@ -18,8 +18,7 @@ module Api
 
       def as_hash
         placement
-          .attributes
-          .except(*EXCLUDED_ATTRIBUTES)
+          .as_json(except: EXCLUDED_ATTRIBUTES)
           .merge(school_attributes)
       end
 

--- a/app/services/api/trainees/save_degree_response.rb
+++ b/app/services/api/trainees/save_degree_response.rb
@@ -50,7 +50,7 @@ module Api
             attributes_klass.new(params, trainee:)
           else
             attributes = attributes_klass.from_degree(degree, trainee:)
-            attributes.assign_attributes(params)
+            attributes.assign_attributes(params.to_h)
             attributes
           end
       end

--- a/app/services/api/trainees/save_placement_response.rb
+++ b/app/services/api/trainees/save_placement_response.rb
@@ -42,14 +42,13 @@ module Api
       def model = :placement
 
       def placement_attributes
-        @placement_attributes ||=
-          if new_record?
-            attributes_klass.new(params)
-          else
-            attributes = attributes_klass.from_placement(placement)
-            attributes.assign_attributes(params)
-            attributes
-          end
+        @placement_attributes ||= if new_record?
+                                    attributes_klass.new(params.to_h)
+                                  else
+                                    new_attributes = attributes_klass.from_placement(placement)
+                                    new_attributes.assign_attributes(params.to_h)
+                                    new_attributes
+                                  end
       end
 
       def errors = placement_attributes.errors.presence || placement.errors

--- a/app/services/api/trainees/save_placement_response.rb
+++ b/app/services/api/trainees/save_placement_response.rb
@@ -27,7 +27,7 @@ module Api
       end
 
       delegate :assign_attributes, :new_record?, :trainee, to: :placement
-      delegate :valid?, :attributes, to: :placement_attributes
+      delegate :valid?, :attributes, :attributes=, to: :placement_attributes
 
     private
 

--- a/app/services/api/trainees/save_placement_response.rb
+++ b/app/services/api/trainees/save_placement_response.rb
@@ -27,7 +27,7 @@ module Api
       end
 
       delegate :assign_attributes, :new_record?, :trainee, to: :placement
-      delegate :valid?, :attributes, :attributes=, to: :placement_attributes
+      delegate :valid?, :attributes, to: :placement_attributes
 
     private
 

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PostcodeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    unless UKPostcode.parse(value).valid?
+      record.errors.add(
+        attribute, I18n.t(".activemodel.errors.validators.postcode.invalid")
+      )
+    end
+  end
+end

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -402,9 +402,9 @@ Get a single trainee.
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -488,9 +488,9 @@ Get many placements for a trainee.
       "data": [
         {
           "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-          "school_id": 26214,
           "urn": "123456",
           "name": "Meadow Creek School",
+          "address": "URN 123456, AB1 2CD",
           "postcode": "AB1 2CD",
           "created_at": "2024-01-18T08:02:42.672Z",
           "updated_at": "2024-01-18T08:02:42.672Z"
@@ -554,9 +554,9 @@ Get a single placement for a trainee.
     {
       "data": {
         "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-        "school_id": 26214,
         "urn": "123456",
         "name": "Meadow Creek School",
+        "address": "URN 123456, AB1 2CD",
         "postcode": "AB1 2CD",
         "created_at": "2024-01-18T08:02:42.672Z",
         "updated_at": "2024-01-18T08:02:42.672Z"
@@ -904,9 +904,9 @@ Trainee details
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -1044,6 +1044,7 @@ Trainee details
             {
               "urn": "900020",
               "name": "London School",
+              "address": "URN 900020",
               "postcode": null,
               "created_at": "2024-09-11T15:12:45.090Z",
               "updated_at": "2024-09-11T15:12:45.090Z",
@@ -1149,9 +1150,9 @@ Placement details
     {
       "data": {
         "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-        "school_id": 26214,
         "urn": "123456",
         "name": "Meadow Creek School",
+        "address": "URN 123456, AB1 2CD",
         "postcode": "AB1 2CD",
         "created_at": "2024-01-18T08:02:42.672Z",
         "updated_at": "2024-01-18T08:02:42.672Z"
@@ -1475,9 +1476,9 @@ Note that multiple values for the reasons parameter can be provided by repeating
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -1690,9 +1691,9 @@ Recommendation details
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -1905,9 +1906,9 @@ Deferral details
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -2089,9 +2090,9 @@ Deletes an existing degree for this trainee.
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -2270,9 +2271,9 @@ Trainee details
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -2404,9 +2405,9 @@ Placement details
     <pre class="json-code-sample">
     {
       "data": {
-        "trainee_id": 644065,
-        "address": null,
+        "urn": null,
         "name": "Wellsway School",
+        "address": null,
         "postcode": null,
         "created_at": "2024-03-19T22:23:48.619Z",
         "updated_at": "2024-03-19T22:23:48.619Z"
@@ -2708,9 +2709,9 @@ Deletes an existing placement for this trainee.
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -367,9 +367,9 @@ Get a single trainee.
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -883,6 +883,7 @@ Trainee details
           {
             "urn": "900020",
             "name": "London School",
+            "address": "URN 900020",
             "postcode": null,
             "created_at": "2024-09-11T15:12:45.090Z",
             "updated_at": "2024-09-11T15:12:45.090Z",
@@ -1024,6 +1025,7 @@ Trainee details
             {
               "urn": "900020",
               "name": "London School",
+              "address": "URN 900020",
               "postcode": null,
               "created_at": "2024-09-11T15:12:45.090Z",
               "updated_at": "2024-09-11T15:12:45.090Z",
@@ -1526,9 +1528,9 @@ Withdrawal details
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -1741,9 +1743,9 @@ Recommendation details
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -1956,9 +1958,9 @@ Deferral details
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -2140,9 +2142,9 @@ Deletes an existing degree for this trainee.
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -2321,9 +2323,9 @@ Trainee details
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"
@@ -2455,10 +2457,11 @@ Placement details
     <pre class="json-code-sample">
     {
       "data": {
-        "trainee_id": 644065,
-        "address": null,
+        "urn": "137523",
         "name": "Wellsway School",
+        "address": "URN 137523",
         "postcode": null,
+        "placement_id": 4fjxTZgHxFgzYrwB8L3UNRvM,
         "created_at": "2024-03-19T22:23:48.619Z",
         "updated_at": "2024-03-19T22:23:48.619Z"
       }
@@ -2759,9 +2762,9 @@ Deletes an existing placement for this trainee.
         "placements": [
           {
             "placement_id": "AXsRAS4LfwZZXvSX7aAfNUb4",
-            "school_id": 26214,
             "urn": "123456",
             "name": "Meadow Creek School",
+            "address": "URN 123456, AB1 2CD",
             "postcode": "AB1 2CD",
             "created_at": "2024-01-18T08:02:42.672Z",
             "updated_at": "2024-01-18T08:02:42.672Z"

--- a/public/openapi/v0.1.yaml
+++ b/public/openapi/v0.1.yaml
@@ -1851,6 +1851,8 @@ paths:
                               type: string
                             name:
                               type: string
+                            address:
+                              type: string
                             postcode:
                               nullable: true
                             created_at:
@@ -2139,6 +2141,7 @@ paths:
                   placements:
                   - urn: '900020'
                     name: Establishment does not have a URN
+                    address: URN 900020
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
@@ -2659,12 +2662,21 @@ paths:
                       items:
                         type: object
                         properties:
-                          name:
-                            type: string
                           urn:
+                            nullable: true
                             type: string
-                        required:
-                        - urn
+                            description: |
+                              The URN of the object.
+                              If School 'urn' does not exist in the system, 'name' is required.
+                          name:
+                            nullable: true
+                            type: string
+                            description: |
+                              The name of the object.
+                              Required if School 'urn' does not exist in the system.
+                          postcode:
+                            nullable: true
+                            type: string
                     itt_aim:
                       type: integer
                     itt_qualification_aim:
@@ -3637,6 +3649,7 @@ paths:
                   placements:
                   - urn: '900020'
                     name: Establishment does not have a URN
+                    address:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
@@ -5284,6 +5297,8 @@ paths:
                           type: string
                         name:
                           type: string
+                        address:
+                          type: string
                         postcode:
                           type: string
                         created_at:
@@ -5295,6 +5310,7 @@ paths:
                       required:
                       - urn
                       - name
+                      - address
                       - postcode
                       - created_at
                       - updated_at
@@ -5341,9 +5357,6 @@ paths:
                       description: |
                         The name of the object.
                         Required if School 'urn' does not exist in the system.
-                    address:
-                      nullable: true
-                      type: string
                     postcode:
                       nullable: true
                       type: string
@@ -5351,11 +5364,9 @@ paths:
               - data
             example:
               data:
-                address: 57663 Brock Hills
                 name: East Wiza College
                 postcode: CF6 5BW
                 urn: '445001'
-                school_id:
       responses:
         '201':
           description: creates a new placement and returns a 201 (created) status
@@ -5382,6 +5393,7 @@ paths:
                     required:
                     - urn
                     - name
+                    - address
                     - postcode
                     - created_at
                     - updated_at
@@ -5392,6 +5404,7 @@ paths:
                 data:
                   urn: '445001'
                   name: East Wiza College
+                  address: URN 445001, New Kacey, CF6 5BW
                   postcode: CF6 5BW
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
@@ -6021,9 +6034,6 @@ paths:
                       description: |
                         The name of the object.
                         Required if School 'urn' does not exist in the system.
-                    address:
-                      nullable: true
-                      type: string
                     postcode:
                       nullable: true
                       type: string
@@ -6031,11 +6041,9 @@ paths:
               - data
             example:
               data:
-                address: 2146 Walker Mills
                 name: South Hackett University
                 postcode: GU1 1AA
                 urn: '642209'
-                school_id:
       responses:
         '200':
           description: partial update of an existing placement returns 200 (ok) status
@@ -6050,6 +6058,8 @@ paths:
                       urn:
                         type: string
                       name:
+                        type: string
+                      address:
                         type: string
                       postcode:
                         type: string
@@ -6072,6 +6082,7 @@ paths:
                 data:
                   urn: '808369'
                   name: Falconholt High
+                  address: "URN 808369, Zenobialand, WB1R 8NL"
                   postcode: WB1R 8NL
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'

--- a/public/openapi/v0.1.yaml
+++ b/public/openapi/v0.1.yaml
@@ -490,7 +490,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-782
+                  provider_trainee_id: 24/25-775
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -579,7 +579,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-784
+                  provider_trainee_id: 24/25-777
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -668,7 +668,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-767
+                  provider_trainee_id: 24/25-760
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -767,7 +767,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-770
+                  provider_trainee_id: 24/25-763
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -866,7 +866,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-773
+                  provider_trainee_id: 24/25-766
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -965,7 +965,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-776
+                  provider_trainee_id: 24/25-769
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -1064,7 +1064,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-761
+                  provider_trainee_id: 24/25-754
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -1163,7 +1163,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-752
+                  provider_trainee_id: 24/25-745
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -1262,7 +1262,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-755
+                  provider_trainee_id: 24/25-748
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -1361,7 +1361,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-758
+                  provider_trainee_id: 24/25-751
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -1460,7 +1460,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-764
+                  provider_trainee_id: 24/25-757
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -1559,7 +1559,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-779
+                  provider_trainee_id: 24/25-772
                   ukprn: '27390779'
                   ethnicity:
                   course_qualification: QTS
@@ -2142,7 +2142,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: ieVWq1Zq17FQZFvM1Z4tT9o1
+                    placement_id: pHYKdkeMGKmFNmNoF9g4M782
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -2158,9 +2158,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: s8cpTnRMEK2FXNLMMyZs2P8p
+                    degree_id: NT9np9CpqDGuC9dPAb5QHS26
                   state: submitted_for_trn
-                  trainee_id: hckBxfH9wjg7scvaJwmnfv8S
+                  trainee_id: PJKgFogjpxJKHjJMVzSJuzdW
                   disability1: '58'
                   disability2: '57'
                   lead_partner_not_applicable: false
@@ -3109,7 +3109,7 @@ paths:
                 withdraw_reasons_dfe_details:
                 slug_sent_to_dqt_at:
                 placement_detail:
-                provider_trainee_id: 24/25-22
+                provider_trainee_id: 24/25-15
                 ukprn: '29184653'
                 ethnicity:
                 course_qualification: QTS
@@ -3181,7 +3181,7 @@ paths:
         required: true
         schema:
           type: string
-        example: VVLf2JVNmpKQzYwrFxHSw3iU
+        example: uASxCQEqvaYnffKAg1WfRDvq
       responses:
         '200':
           description: updates the trainee
@@ -3640,7 +3640,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: wR7vSgxaUE3xZEtSvkroGSMC
+                    placement_id: mDM6Eey5v6xQzPmdgakYxFGt
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -3656,9 +3656,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: aVfuZoFiynQcUaCQuTJ8enFH
+                    degree_id: rtWG6ATrzUxUAL7WyyudUj7f
                   state: submitted_for_trn
-                  trainee_id: VVLf2JVNmpKQzYwrFxHSw3iU
+                  trainee_id: uASxCQEqvaYnffKAg1WfRDvq
                   application_id:
                   disability2: '57'
         '401':
@@ -4190,7 +4190,7 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-978
+                  provider_trainee_id: 24/25-971
                   ukprn: '21460768'
                   ethnicity:
                   course_qualification: QTS
@@ -4491,7 +4491,7 @@ paths:
                   uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                  degree_id: bVkpcXHAHqSCvtdbdqHuMgM7
+                  degree_id: uxQ1fsyjpVdKoCzaYAwi8WY8
         '404':
           description: does not create a new degree and returns a 404 status (not_found)
             status
@@ -4898,7 +4898,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-947
+                  provider_trainee_id: 24/25-940
                   ukprn: '74385610'
                   ethnicity:
                   course_qualification: QTS
@@ -5084,13 +5084,13 @@ paths:
         required: true
         schema:
           type: string
-        example: wjb6s47la1loaubihlgq1b2r
+        example: 5fqhko6rfl4cs8j5b8p2hkdb
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: og7mvlr2cbq7vwio1zuh5hgy
+        example: l7484bdq2q3odq1rud08whj2
       requestBody:
         content:
           application/json:
@@ -5199,7 +5199,7 @@ paths:
                   uk_degree_uuid: 3d6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 917f70f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                  degree_id: 2htbabe0u0pjojgv6u3e7jw2
+                  degree_id: yb9fhvmqxnomcnbemynw067j
         '404':
           description: does not update the degree and returns a 404 status (not_found)
           content:
@@ -5329,27 +5329,24 @@ paths:
                 data:
                   type: object
                   properties:
-                    address:
+                    urn:
                       nullable: true
                       type: string
+                      description: |
+                        The URN of the object.
+                        If School 'urn' does not exist in the system, 'name' is required.
                     name:
+                      nullable: true
+                      type: string
+                      description: |
+                        The name of the object.
+                        Required if School 'urn' does not exist in the system.
+                    address:
                       nullable: true
                       type: string
                     postcode:
                       nullable: true
                       type: string
-                    urn:
-                      nullable: true
-                      type: string
-                    school_id:
-                      type: integer
-                      nullable: true
-                  required:
-                  - address
-                  - name
-                  - postcode
-                  - urn
-                  - school_id
               required:
               - data
             example:
@@ -5398,7 +5395,7 @@ paths:
                   postcode: CF6 5BW
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: R2jRBgkbPcSw7n6p7Urkp8DT
+                  placement_id: va6N1fcKt2yrZ4BK7nDi2FXu
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -5823,7 +5820,7 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail: has_placement_detail
-                  provider_trainee_id: 24/25-957
+                  provider_trainee_id: 24/25-950
                   ukprn: '74112239'
                   ethnicity:
                   course_qualification: QTS
@@ -5996,13 +5993,13 @@ paths:
         required: true
         schema:
           type: string
-        example: 9y70s54wbyr5s2nych8iq5yk
+        example: 489jjf3zd8zfar0a1zjjanmv
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: p1kkbtxu3dhii5ka805vhp4d
+        example: mo4pkdffxts3ldicxrogl64m
       requestBody:
         content:
           application/json:
@@ -6012,31 +6009,32 @@ paths:
                 data:
                   type: object
                   properties:
-                    address:
+                    urn:
                       nullable: true
                       type: string
+                      description: |
+                        The URN of the object.
+                        If School 'urn' does not exist in the system, 'name' is required.
                     name:
+                      nullable: true
+                      type: string
+                      description: |
+                        The name of the object.
+                        Required if School 'urn' does not exist in the system.
+                    address:
                       nullable: true
                       type: string
                     postcode:
                       nullable: true
                       type: string
-                    urn:
-                      nullable: true
-                      type: string
-                    school_id:
-                      type: integer
-                      nullable: true
-                  required:
-                  - postcode
               required:
               - data
             example:
               data:
-                address: 413 Magnolia Light
-                name: Western Beahan Institute
+                address: 2146 Walker Mills
+                name: South Hackett University
                 postcode: GU1 1AA
-                urn: '424358'
+                urn: '642209'
                 school_id:
       responses:
         '200':
@@ -6072,12 +6070,12 @@ paths:
                 - data
               example:
                 data:
-                  urn: '749512'
-                  name: Ostbarrow High School
-                  postcode: SV0R 8XB
+                  urn: '808369'
+                  name: Falconholt High
+                  postcode: WB1R 8NL
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: q340ofyopo5lsruiqa5rzflq
+                  placement_id: 4qqly6kv0xm1z96c0j5bsxaa
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -6149,7 +6147,7 @@ paths:
         required: true
         schema:
           type: string
-        example: j70s7oduaxxjfbz3u7ho4gqa
+        example: qndp8wyi3zt351p7alki1hcl
       requestBody:
         content:
           application/json:
@@ -6510,7 +6508,7 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-1001
+                  provider_trainee_id: 24/25-994
                   ukprn: '11359462'
                   ethnicity:
                   course_qualification: QTS
@@ -6595,7 +6593,8 @@ paths:
               example:
                 errors:
                 - error: UnprocessableEntity
-                  message: QTS standards met date can't be blank
+                  message: Trainee degree information must be completed before QTS
+                    recommendation
   "/api/{api_version}/trainees/{trainee_id}/withdraw":
     post:
       summary: create
@@ -6613,7 +6612,7 @@ paths:
         required: true
         schema:
           type: string
-        example: qrni854imer75kgnh3k6f5ae
+        example: mbupq59yt76ztrrf2htbabe0
       requestBody:
         content:
           application/json:
@@ -6639,10 +6638,8 @@ paths:
               reasons:
               - unknown
               withdraw_date: 2024-09-15 12:34:56 UTC
-              withdraw_reasons_details: When I was a cop, this was my beat. I’m the
-                Black Dog and when I bite I don’t let go. I have no regrets about
-                her, but I’ll settle this score on my own turf.
-              withdraw_reasons_dfe_details: He said Mom was ugly, now go get him!
+              withdraw_reasons_details: Bang!
+              withdraw_reasons_dfe_details: A pig's gotta fly.
       responses:
         '200':
           description: uses the trainee serializer
@@ -6830,7 +6827,6 @@ paths:
                           properties:
                             uk_degree:
                               type: string
-                              nullable: true
                             non_uk_degree:
                               nullable: true
                             created_at:
@@ -6845,7 +6841,6 @@ paths:
                               type: integer
                             grade:
                               type: string
-                              nullable: true
                             country:
                               nullable: true
                             other_grade:
@@ -7025,20 +7020,20 @@ paths:
                   withdraw_reasons_details:
                   withdraw_reasons_dfe_details:
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  first_names: Wayne
-                  middle_names: Stamm
-                  last_name: Jenkins
-                  email: Wayne.Jenkins@example.com
+                  first_names: Sarita
+                  middle_names: Marks
+                  last_name: Heaney
+                  email: Sarita.Heaney@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '5493987'
+                  trn: '9685205'
                   region:
-                  hesa_id: '3188122025997'
+                  hesa_id: '8128168748368'
                   course_subject_one: mathematics
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '1993-01-21'
+                  date_of_birth: '1970-07-07'
                   created_at: '2024-09-15T12:34:56.000Z'
                   training_route: assessment_only
                   sex: prefer_not_to_say
@@ -7047,11 +7042,11 @@ paths:
                   disability_disclosure:
                   itt_start_date: '2024-08-13'
                   outcome_date:
-                  itt_end_date: '2026-07-01'
+                  itt_end_date: '2026-07-23'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-15'
+                  trainee_start_date: '2024-08-19'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -7073,29 +7068,29 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-1018
-                  ukprn: '22102968'
+                  provider_trainee_id: 24/25-1013
+                  ukprn: '86103843'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-08'
-                  course_age_range: '13914'
-                  expected_end_date: '2026-07-03'
+                  course_itt_start_date: '2024-08-21'
+                  course_age_range: '13913'
+                  expected_end_date: '2026-07-17'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
-                  fund_code: '2'
-                  bursary_level: '8'
-                  previous_last_name: Daugherty
+                  fund_code: '7'
+                  bursary_level: '9'
+                  previous_last_name: Sporer
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
                   pg_apprenticeship_start_date: '2024-09-15'
-                  funding_method: '8'
+                  funding_method: '9'
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
-                  itt_qualification_aim: '007'
+                  itt_qualification_aim: '028'
                   hesa_disabilities: {}
                   nationality: AL
                   withdraw_reasons:
@@ -7116,12 +7111,12 @@ paths:
                     uk_degree_uuid: 036a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 6b8770f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                    degree_id: gqrayxkohbzjt35c3rs5zzmj
+                    degree_id: ulinwqamhn8g74juhoq9q8ci
                   state: trn_received
-                  trainee_id: ajjni21na43nwxbnqampr9sz
+                  trainee_id: q3ld9w395bqf5m5cgqrayxko
                   application_id:
-                  id: 725
-                  dttp_id: dc8f3c3d-a327-4dba-b980-d05e71b48eeb
+                  id: 726
+                  dttp_id: 37b4165f-3066-4a28-a363-7b824e3cc3b6
                   progress:
                     personal_details: true
                     contact_details: true
@@ -7135,9 +7130,9 @@ paths:
                     schools: true
                     funding: true
                     iqts_country: false
-                  provider_id: 515
+                  provider_id: 516
                   placement_assignment_dttp_id:
-                  slug: crkeoy1fz1rrcmxuwpoq2zg2
+                  slug: f187ep282qh6si9ci90lsvoe
                   dttp_update_sha:
                   dormancy_dttp_id:
                   employing_school_id:

--- a/public/openapi/v1.0-pre.yaml
+++ b/public/openapi/v1.0-pre.yaml
@@ -1860,6 +1860,8 @@ paths:
                               type: string
                             name:
                               type: string
+                            address:
+                              type: string
                             postcode:
                               nullable: true
                             created_at:
@@ -1871,6 +1873,7 @@ paths:
                           required:
                           - urn
                           - name
+                          - address
                           - postcode
                           - created_at
                           - updated_at
@@ -2111,6 +2114,7 @@ paths:
                   placements:
                   - urn: '900020'
                     name: Establishment does not have a URN
+                    address: URN 900020
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
@@ -2629,12 +2633,21 @@ paths:
                       items:
                         type: object
                         properties:
-                          name:
-                            type: string
                           urn:
+                            nullable: true
                             type: string
-                        required:
-                        - urn
+                            description: |
+                              The URN of the object.
+                              If School 'urn' does not exist in the system, 'name' is required.
+                          name:
+                            nullable: true
+                            type: string
+                            description: |
+                              The name of the object.
+                              Required if School 'urn' does not exist in the system.
+                          postcode:
+                            nullable: true
+                            type: string
                     itt_aim:
                       type: integer
                     itt_qualification_aim:
@@ -3584,6 +3597,7 @@ paths:
                   placements:
                   - urn: '900020'
                     name: Establishment does not have a URN
+                    address: URN 900020
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
@@ -5279,9 +5293,6 @@ paths:
                       description: |
                         The name of the object.
                         Required if School 'urn' does not exist in the system.
-                    address:
-                      nullable: true
-                      type: string
                     postcode:
                       nullable: true
                       type: string
@@ -5289,11 +5300,9 @@ paths:
               - data
             example:
               data:
-                address: 893 Louvenia Stream
-                name: Hauck Academy
-                postcode: H5 0NA
-                urn: '605218'
-                school_id:
+                name: Kohler Academy
+                postcode: Z6D 8JB
+                urn: '650551'
       responses:
         '201':
           description: creates a new placement and returns a 201 (created) status
@@ -5309,6 +5318,8 @@ paths:
                         type: string
                       name:
                         type: string
+                      address:
+                        type: string
                       postcode:
                         type: string
                       created_at:
@@ -5320,6 +5331,7 @@ paths:
                     required:
                     - urn
                     - name
+                    - address
                     - postcode
                     - created_at
                     - updated_at
@@ -5328,9 +5340,10 @@ paths:
                 - data
               example:
                 data:
-                  urn: '605218'
-                  name: Hauck Academy
-                  postcode: H5 0NA
+                  urn: '650551'
+                  name: Kohler Academy
+                  address: URN 650551, New Kacey, Z6D 8JB
+                  postcode: Z6D 8JB
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   placement_id: CAUbbNT3NgLfpDovQzTimXTa
@@ -5865,6 +5878,8 @@ paths:
                         type: string
                       name:
                         type: string
+                      address:
+                        type: string
                       postcode:
                         type: string
                       created_at:
@@ -5876,6 +5891,7 @@ paths:
                     required:
                     - urn
                     - name
+                    - address
                     - postcode
                     - created_at
                     - updated_at
@@ -5884,9 +5900,10 @@ paths:
                 - data
               example:
                 data:
-                  urn: '252611'
-                  name: Ostbarrow High
-                  postcode: C7 4BE
+                  urn: '699410'
+                  name: Lakeacre High School
+                  address: URN 699410, New Kacey, R3 3JN
+                  postcode: R3 3JN
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   placement_id: 8xr5hbtl1baxj453o07iqmtq
@@ -5959,9 +5976,6 @@ paths:
                       description: |
                         The name of the object.
                         Required if School 'urn' does not exist in the system.
-                    address:
-                      nullable: true
-                      type: string
                     postcode:
                       nullable: true
                       type: string
@@ -5969,11 +5983,10 @@ paths:
               - data
             example:
               data:
-                address: 8934 Rosenbaum Spring
-                name: Rippin College
+                name: South Hackett University
                 postcode: GU1 1AA
-                urn: '177099'
-                school_id:
+                urn: '642209'
+                placement_id: '72LUDJ9yBxz5qKDfvrVtveRW'
       responses:
         '200':
           description: partial update of an existing placement returns 200 (ok) status
@@ -6000,6 +6013,7 @@ paths:
                     required:
                     - urn
                     - name
+                    - address
                     - postcode
                     - created_at
                     - updated_at
@@ -6008,9 +6022,10 @@ paths:
                 - data
               example:
                 data:
-                  urn: '912343'
-                  name: Iceborough Secondary College
-                  postcode: UB9 9JA
+                  urn: '808369'
+                  name: Falconholt High
+                  postcode: WB1R 8NL
+                  address: URN 808369, Zenobialand, WB1R 8NL
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   placement_id: juudytrc69p1kkbtxu3dhii5

--- a/public/openapi/v1.0-pre.yaml
+++ b/public/openapi/v1.0-pre.yaml
@@ -5267,27 +5267,24 @@ paths:
                 data:
                   type: object
                   properties:
-                    address:
+                    urn:
                       nullable: true
                       type: string
+                      description: |
+                        The URN of the object.
+                        If School 'urn' does not exist in the system, 'name' is required.
                     name:
+                      nullable: true
+                      type: string
+                      description: |
+                        The name of the object.
+                        Required if School 'urn' does not exist in the system.
+                    address:
                       nullable: true
                       type: string
                     postcode:
                       nullable: true
                       type: string
-                    urn:
-                      nullable: true
-                      type: string
-                    school_id:
-                      type: integer
-                      nullable: true
-                  required:
-                  - address
-                  - name
-                  - postcode
-                  - urn
-                  - school_id
               required:
               - data
             example:
@@ -5950,23 +5947,24 @@ paths:
                 data:
                   type: object
                   properties:
-                    address:
+                    urn:
                       nullable: true
                       type: string
+                      description: |
+                        The URN of the object.
+                        If School 'urn' does not exist in the system, 'name' is required.
                     name:
+                      nullable: true
+                      type: string
+                      description: |
+                        The name of the object.
+                        Required if School 'urn' does not exist in the system.
+                    address:
                       nullable: true
                       type: string
                     postcode:
                       nullable: true
                       type: string
-                    urn:
-                      nullable: true
-                      type: string
-                    school_id:
-                      type: integer
-                      nullable: true
-                  required:
-                  - postcode
               required:
               - data
             example:

--- a/spec/components/placements/view_spec.rb
+++ b/spec/components/placements/view_spec.rb
@@ -28,7 +28,7 @@ module Placements
     end
 
     context "with 2 placements" do
-      let(:placements) { create_list(:placement, 2, :manual) }
+      let(:placements) { create_list(:placement, 2) }
 
       it "shows the placement" do
         placements.each do |placement|

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -3,21 +3,23 @@
 FactoryBot.define do
   factory :placement do
     trainee
-
-    with_school
-
     slug { Faker::Alphanumeric.alphanumeric(number: Sluggable::SLUG_LENGTH) }
+
+    name { Faker::University.name }
+    address { Faker::Address.street_address }
+    postcode { Faker::Address.postcode }
+
+    school { nil }
+    urn { nil }
 
     trait :with_school do
       school
-    end
 
-    trait :manual do
-      school { nil }
-      urn { Faker::Number.unique.number(digits: 6) }
-      name { Faker::University.name }
-      address { Faker::Address.street_address }
-      postcode { Faker::Address.postcode }
+      after(:build) do |placement, evaluator|
+        placement.urn      = evaluator.school&.urn
+        placement.name     = evaluator.school&.name
+        placement.postcode = evaluator.school&.postcode
+      end
     end
 
     trait :not_applicable_school do

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -5,12 +5,12 @@ FactoryBot.define do
     trainee
     slug { Faker::Alphanumeric.alphanumeric(number: Sluggable::SLUG_LENGTH) }
 
+    urn { Faker::Number.unique.number(digits: 6) }
     name { Faker::University.name }
     address { Faker::Address.street_address }
     postcode { Faker::Address.postcode }
 
     school { nil }
-    urn { nil }
 
     trait :with_school do
       school

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     urn { Faker::Number.unique.number(digits: 6).to_s }
     name { Faker::University.name }
-    address { Faker::Address.street_address }
+    address { nil }
     postcode { Faker::Address.postcode }
 
     school { nil }

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     trainee
     slug { Faker::Alphanumeric.alphanumeric(number: Sluggable::SLUG_LENGTH) }
 
-    urn { Faker::Number.unique.number(digits: 6) }
+    urn { Faker::Number.unique.number(digits: 6).to_s }
     name { Faker::University.name }
     address { Faker::Address.street_address }
     postcode { Faker::Address.postcode }
@@ -14,6 +14,11 @@ FactoryBot.define do
 
     trait :with_school do
       school
+
+      urn { nil }
+      name { nil }
+      address { nil }
+      postcode { nil }
     end
 
     trait :not_applicable_school do

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -14,12 +14,6 @@ FactoryBot.define do
 
     trait :with_school do
       school
-
-      after(:build) do |placement, evaluator|
-        placement.urn      = evaluator.school&.urn
-        placement.name     = evaluator.school&.name
-        placement.postcode = evaluator.school&.postcode
-      end
     end
 
     trait :not_applicable_school do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -142,7 +142,7 @@ FactoryBot.define do
 
     trait :with_placements do
       has_placement_detail
-      placements { build_list(:placement, 2) }
+      placements { create_list(:placement, 2, :with_school) }
     end
 
     trait :submission_ready do

--- a/spec/features/form_sections/teacher_training_data/placements/deleting_trainee_placements_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/deleting_trainee_placements_spec.rb
@@ -65,7 +65,7 @@ private
 
   def and_a_trainee_exists_with_a_placement
     and_a_trainee_exists
-    @placement = create(:placement, trainee: @trainee)
+    @placement = create(:placement, :with_school, trainee: @trainee)
     @school ||= @placement.school
     FormStore.clear_all(@trainee.id)
   end

--- a/spec/forms/placement_form_spec.rb
+++ b/spec/forms/placement_form_spec.rb
@@ -163,7 +163,7 @@ describe PlacementForm, type: :model do
     end
 
     context "when there are placements" do
-      let(:trainee) { create(:trainee, placements: build_list(:placement, 1)) }
+      let(:trainee) { create(:trainee, placements: build_list(:placement, 1, :with_school)) }
       let(:placement) { trainee.placements.first }
 
       it "returns school name" do
@@ -174,7 +174,7 @@ describe PlacementForm, type: :model do
 
   describe "#update_placement" do
     context "using custom school data" do
-      let(:trainee) { create(:trainee, placements: build_list(:placement, 1)) }
+      let(:trainee) { create(:trainee, placements: build_list(:placement, 1, :with_school)) }
       let(:placement) { trainee.placements.first }
 
       let(:attributes) do
@@ -188,11 +188,11 @@ describe PlacementForm, type: :model do
         expect { subject.update_placement(attributes) }
           .to change { subject.school_id }.to(nil)
           .and change { subject.name }
-          .from(nil).to(attributes[:name])
+          .to(attributes[:name])
           .and change { subject.urn }
-          .from(nil).to(attributes[:urn])
+          .to(attributes[:urn])
           .and change { subject.postcode }
-          .from(nil).to(attributes[:postcode])
+          .to(attributes[:postcode])
       end
     end
 
@@ -212,7 +212,7 @@ describe PlacementForm, type: :model do
     end
 
     context "when there are placements" do
-      let(:trainee) { create(:trainee, placements: build_list(:placement, 1)) }
+      let(:trainee) { create(:trainee, placements: build_list(:placement, 1, :with_school)) }
       let(:placement) { trainee.placements.first }
 
       it "returns school name" do
@@ -236,7 +236,7 @@ describe PlacementForm, type: :model do
       end
 
       context "with duplicated urn" do
-        let(:trainee) { create(:trainee, placements: build_list(:placement, 1)) }
+        let(:trainee) { create(:trainee, placements: build_list(:placement, 1, :with_school)) }
 
         let(:placement) { Placement.new(name: "duplicated urn", urn: trainee.placements.first.school.urn) }
 
@@ -270,7 +270,7 @@ describe PlacementForm, type: :model do
     end
 
     describe "#urn_valid" do
-      let(:trainee_placement) { build(:placement) }
+      let(:trainee_placement) { build(:placement, :with_school) }
       let(:trainee) { create(:trainee, placements: [trainee_placement]) }
       let(:placement) { Placement.new(**placement_attributes) }
 
@@ -314,7 +314,7 @@ describe PlacementForm, type: :model do
     end
 
     describe "#school_urn_valid" do
-      let(:trainee_placement) { build(:placement) }
+      let(:trainee_placement) { build(:placement, :with_school) }
       let(:trainee) { create(:trainee, placements: [trainee_placement]) }
       let(:placement) { Placement.new(**placement_attributes) }
 

--- a/spec/forms/placement_form_spec.rb
+++ b/spec/forms/placement_form_spec.rb
@@ -114,8 +114,8 @@ describe PlacementForm, type: :model do
 
           expect(new_placement.school_id).to eq(school.id)
           expect(new_placement.name).to eq(school.name)
-          expect(new_placement.urn).to be_nil
-          expect(new_placement.postcode).to be_nil
+          expect(new_placement.urn).to eq(school.urn)
+          expect(new_placement.postcode).to eq(school.postcode)
         end
       end
 

--- a/spec/forms/placements_form_spec.rb
+++ b/spec/forms/placements_form_spec.rb
@@ -20,7 +20,7 @@ describe PlacementsForm, type: :model do
       end
 
       context "with placements" do
-        let(:placements) { build_list(:placement, 2) }
+        let(:placements) { build_list(:placement, 2, :with_school) }
 
         it { is_expected.to be_valid }
       end
@@ -47,7 +47,7 @@ describe PlacementsForm, type: :model do
   end
 
   describe "#build_placement_form" do
-    let(:template_placement) { build(:placement) }
+    let(:template_placement) { build(:placement, :with_school) }
 
     it "returns new PlacementForm instance" do
       placement_form = subject.build_placement_form(
@@ -62,8 +62,8 @@ describe PlacementsForm, type: :model do
   end
 
   describe "#find_placement_from_param" do
-    let(:placement1) { build(:placement, :manual, trainee:) }
-    let(:placement2) { build(:placement, :manual, trainee:) }
+    let(:placement1) { build(:placement, trainee:) }
+    let(:placement2) { build(:placement, trainee:) }
 
     before do
       allow(form_store).to receive(:get).and_return(nil)
@@ -102,8 +102,8 @@ describe PlacementsForm, type: :model do
   end
 
   describe "#placements" do
-    let(:placement1) { build(:placement, :manual, trainee:) }
-    let(:placement2) { build(:placement, :manual, trainee:) }
+    let(:placement1) { build(:placement, trainee:) }
+    let(:placement2) { build(:placement, trainee:) }
 
     before do
       allow(form_store).to receive(:get).and_return({

--- a/spec/models/api/v0_1/placement_attributes_spec.rb
+++ b/spec/models/api/v0_1/placement_attributes_spec.rb
@@ -3,43 +3,153 @@
 require "rails_helper"
 
 RSpec.describe Api::V01::PlacementAttributes do
-  context "when school_id is blank" do
-    before { subject.school_id = nil }
+  subject { described_class.new(params) }
 
-    it "validates presence of name" do
-      subject.name = nil
-      expect(subject).not_to be_valid
-      expect(subject.errors[:name]).to include("can't be blank")
+  let!(:school) { create(:school) }
+
+  describe "validations" do
+    context "when urn is present" do
+      context "with a valid urn" do
+        let(:params) do
+          {
+            urn: school.urn,
+          }
+        end
+
+        it "sets the attributes from the school" do
+          expect(subject).to be_valid
+          expect(subject.errors).to be_empty
+          expect(subject.school_id).to eq(school.id)
+          expect(subject.urn).to eq(school.urn)
+          expect(subject.name).to eq(school.name)
+          expect(subject.postcode).to eq(school.postcode)
+        end
+
+        context "with name, postcode, address specified" do
+          let(:name) { Faker::Educator.primary_school }
+          let(:postcode) { Faker::Address.postcode }
+          let(:address) { Faker::Address.street_address }
+
+          before do
+            params.merge!(
+              name:,
+              postcode:,
+              address:,
+            )
+          end
+
+          it "sets the attributes" do
+            expect(subject).to be_valid
+            expect(subject.name).to eq(name)
+            expect(subject.postcode).to eq(postcode)
+            expect(subject.address).to eq(address)
+          end
+        end
+      end
+
+      context "with an invalid urn" do
+        let(:params) do
+          {
+            urn: Faker::Number.number(digits: 5).to_s,
+          }
+        end
+
+        it "adds an error on urn" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:urn]).to contain_exactly("is invalid")
+        end
+      end
+    end
+
+    context "when urn is blank" do
+      let(:params) do
+        {
+          urn: "",
+        }
+      end
+
+      context "with a name" do
+        let(:name) { Faker::Educator.university }
+
+        before do
+          params.merge!(name:)
+        end
+
+        it "is valid" do
+          expect(subject).to be_valid
+          expect(subject.errors).to be_empty
+          expect(subject.name).to eq(name)
+        end
+      end
+
+      context "without a name" do
+        it "is invalid" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:name]).to contain_exactly("can't be blank")
+        end
+      end
+    end
+
+    context "when postcode is present" do
+      context "with a valid postcode" do
+        let(:params) do
+          {
+            name: Faker::Educator.university,
+            postcode: "SW1A 1AA",
+          }
+        end
+
+        it "is valid with a correct postcode" do
+          expect(subject).to be_valid
+          expect(subject.errors).to be_empty
+        end
+      end
+
+      context "with an invalid postcode" do
+        let(:params) do
+          {
+            name: Faker::Educator.university,
+            postcode: "invalid_postcode",
+          }
+        end
+
+        it "validates format of postcode" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:postcode]).to contain_exactly(
+            I18n.t("activemodel.errors.validators.postcode.invalid"),
+          )
+        end
+      end
     end
   end
 
-  context "when urn is present" do
-    it "validates format of urn" do
-      subject.urn = "invalid_urn"
-      expect(subject).not_to be_valid
-      expect(subject.errors[:urn]).to include("is invalid")
-    end
-  end
+  describe "attributes" do
+    describe "#address" do
+      let(:address) { Faker::Address.street_address }
+      let(:params) do
+        {
+          name: Faker::Educator.university,
+          address: address,
+        }
+      end
 
-  context "when subject, name, urn and postcode are missing" do
-    before { subject.attributes = { name: nil, urn: nil, postcode: nil, school_id: nil } }
-
-    it "adds an error on school_id" do
-      expect(subject).not_to be_valid
-      expect(subject.errors[:school_id]).to include("can't be blank")
-    end
-  end
-
-  context "when postcode is present" do
-    it "validates format of postcode" do
-      subject.postcode = "invalid_postcode"
-      expect(subject).not_to be_valid
-      expect(subject.errors[:postcode]).to include(I18n.t("activemodel.errors.validators.postcode.invalid"))
+      it "sets the address" do
+        expect(subject.address).to eq(address)
+      end
     end
 
-    it "is valid with a correct postcode" do
-      subject.postcode = "SW1A 1AA"
-      expect(subject.errors[:postcode]).not_to include(I18n.t("activemodel.errors.validators.postcode.invalid"))
+    describe "#school_id" do
+      let(:params) do
+        {
+          name: Faker::Educator.university,
+          school_id: school.id,
+        }
+      end
+
+      it "does not set it" do
+        expect(subject).to be_valid
+        expect(subject.school_id).to be_nil
+      end
     end
   end
 end

--- a/spec/models/api/v0_1/placement_attributes_spec.rb
+++ b/spec/models/api/v0_1/placement_attributes_spec.rb
@@ -5,27 +5,32 @@ require "rails_helper"
 RSpec.describe Api::V01::PlacementAttributes do
   subject { described_class.new(params) }
 
-  let!(:school) { create(:school) }
+  let(:school) { create(:school) }
 
   describe "validations" do
     context "when urn is present" do
       context "with a valid urn" do
         let(:params) do
           {
-            urn: school.urn,
+            urn:,
           }
         end
 
-        it "sets the attributes from the school" do
-          expect(subject).to be_valid
-          expect(subject.errors).to be_empty
-          expect(subject.school_id).to eq(school.id)
-          expect(subject.urn).to eq(school.urn)
-          expect(subject.name).to eq(school.name)
-          expect(subject.postcode).to eq(school.postcode)
+        context "with a School matching the urn" do
+          let(:urn) { school.urn }
+
+          it "sets the attributes from the school" do
+            expect(subject).to be_valid
+            expect(subject.errors).to be_empty
+            expect(subject.school_id).to eq(school.id)
+            expect(subject.urn).to be_nil
+            expect(subject.name).to be_nil
+            expect(subject.postcode).to be_nil
+          end
         end
 
         context "with name, postcode, address specified" do
+          let(:urn) { Faker::Number.unique.number(digits: 6).to_s }
           let(:name) { Faker::Educator.primary_school }
           let(:postcode) { Faker::Address.postcode }
           let(:address) { Faker::Address.street_address }
@@ -40,6 +45,7 @@ RSpec.describe Api::V01::PlacementAttributes do
 
           it "sets the attributes" do
             expect(subject).to be_valid
+            expect(subject.urn).to eq(urn)
             expect(subject.name).to eq(name)
             expect(subject.postcode).to eq(postcode)
             expect(subject.address).to eq(address)

--- a/spec/models/api/v0_1/placement_attributes_spec.rb
+++ b/spec/models/api/v0_1/placement_attributes_spec.rb
@@ -5,15 +5,15 @@ require "rails_helper"
 RSpec.describe Api::V01::PlacementAttributes do
   subject { described_class.new(params) }
 
-  let(:school) { create(:school) }
-
   describe "validations" do
+    let(:school) { create(:school) }
+
     context "when urn is present" do
       context "with a valid urn" do
         let(:params) do
           {
             urn:,
-          }
+          }.stringify_keys
         end
 
         context "with a School matching the urn" do
@@ -71,7 +71,7 @@ RSpec.describe Api::V01::PlacementAttributes do
       let(:params) do
         {
           urn: "",
-        }
+        }.stringify_keys
       end
 
       context "with a name" do
@@ -130,32 +130,20 @@ RSpec.describe Api::V01::PlacementAttributes do
   end
 
   describe "attributes" do
-    describe "#address" do
-      let(:address) { Faker::Address.street_address }
-      let(:params) do
-        {
-          name: Faker::Educator.university,
-          address: address,
-        }
-      end
+    let(:school) { create(:school) }
 
-      it "sets the address" do
-        expect(subject.address).to eq(address)
-      end
+    let(:params) do
+      {
+        urn: school.urn,
+        school_id: school.id,
+        name: school.name,
+        address: Faker::Address.street_address,
+        postcode: school.postcode,
+      }.stringify_keys
     end
 
-    describe "#school_id" do
-      let(:params) do
-        {
-          name: Faker::Educator.university,
-          school_id: school.id,
-        }
-      end
-
-      it "does not set it" do
-        expect(subject).to be_valid
-        expect(subject.school_id).to be_nil
-      end
+    it "sets the ATTRIBUTES and INTERNAL_ATTRIBUTES" do
+      expect(subject.attributes).to eq(params)
     end
   end
 end

--- a/spec/models/api/v0_1/placement_attributes_spec.rb
+++ b/spec/models/api/v0_1/placement_attributes_spec.rb
@@ -29,17 +29,15 @@ RSpec.describe Api::V01::PlacementAttributes do
           end
         end
 
-        context "with name, postcode, address specified" do
+        context "with name and postcode specified" do
           let(:urn) { Faker::Number.unique.number(digits: 6).to_s }
           let(:name) { Faker::Educator.primary_school }
           let(:postcode) { Faker::Address.postcode }
-          let(:address) { Faker::Address.street_address }
 
           before do
             params.merge!(
               name:,
               postcode:,
-              address:,
             )
           end
 
@@ -48,7 +46,6 @@ RSpec.describe Api::V01::PlacementAttributes do
             expect(subject.urn).to eq(urn)
             expect(subject.name).to eq(name)
             expect(subject.postcode).to eq(postcode)
-            expect(subject.address).to eq(address)
           end
         end
       end
@@ -137,7 +134,6 @@ RSpec.describe Api::V01::PlacementAttributes do
         urn: school.urn,
         school_id: school.id,
         name: school.name,
-        address: Faker::Address.street_address,
         postcode: school.postcode,
       }.stringify_keys
     end

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -175,6 +175,8 @@ RSpec.describe Placement do
   end
 
   describe "#full_address" do
+    let(:address) { Faker::Address.street_address }
+
     context "when a school record exists" do
       subject { create(:placement, :with_school) }
 
@@ -185,7 +187,7 @@ RSpec.describe Placement do
 
     context "when a school record does not exist and no urn is provided by user" do
       subject {
-        create(:placement, urn: nil)
+        create(:placement, address: address, urn: nil)
       }
 
       it "returns the user input address" do
@@ -195,7 +197,7 @@ RSpec.describe Placement do
 
     context "when a school record does not exist but urn is provided by user" do
       subject {
-        create(:placement, urn:)
+        create(:placement, address:, urn:)
       }
 
       let(:urn) { Faker::Number.number(digits: 6) }

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -72,8 +72,22 @@ RSpec.describe Placement do
     context "when a school record exists" do
       subject { create(:placement, :with_school) }
 
-      it "returns the school name" do
-        expect(subject.name).to eq(subject.school.name)
+      context "with name column value nil" do
+        it "returns the school name" do
+          expect(subject.name).to eq(subject.school.name)
+        end
+      end
+
+      context "with name column value present" do
+        let(:name) { Faker::Educator.primary_school }
+
+        before do
+          subject.update!(name:)
+        end
+
+        it "returns the column value" do
+          expect(subject.name).to eq(name)
+        end
       end
     end
 

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Placement do
           subject.update!(name:)
         end
 
-        it "returns the column value" do
-          expect(subject.name).to eq(name)
+        it "returns the school name" do
+          expect(subject.name).to eq(subject.school.name)
         end
       end
     end
@@ -102,7 +102,79 @@ RSpec.describe Placement do
     end
   end
 
-  describe "#address" do
+  describe "#urn" do
+    context "when a school record exists" do
+      subject { create(:placement, :with_school) }
+
+      context "with urn column value nil" do
+        it "returns the school urn" do
+          expect(subject.urn).to eq(subject.school.urn)
+        end
+      end
+
+      context "with urn column value present" do
+        let(:urn) { Faker::Number.unique.number(digits: 6).to_s }
+
+        before do
+          subject.update!(urn:)
+        end
+
+        it "returns the school urn" do
+          expect(subject.urn).to eq(subject.school.urn)
+        end
+      end
+    end
+
+    context "when a school record does not exist" do
+      subject {
+        create(:placement, urn:)
+      }
+
+      let(:urn) { Faker::Number.unique.number(digits: 6).to_s }
+
+      it "returns the urn column value" do
+        expect(subject.urn).to eq(urn)
+      end
+    end
+  end
+
+  describe "#postcode" do
+    context "when a school record exists" do
+      subject { create(:placement, :with_school) }
+
+      context "with postcode column value nil" do
+        it "returns the school name" do
+          expect(subject.postcode).to eq(subject.school.postcode)
+        end
+      end
+
+      context "with postcode column value present" do
+        let(:postcode) { Faker::Address.postcode }
+
+        before do
+          subject.update!(postcode:)
+        end
+
+        it "returns the school postcode" do
+          expect(subject.postcode).to eq(subject.school.postcode)
+        end
+      end
+    end
+
+    context "when a school record does not exist" do
+      subject {
+        create(:placement, postcode:)
+      }
+
+      let(:postcode) { Faker::Address.postcode }
+
+      it "returns the postcode column value" do
+        expect(subject.postcode).to eq(postcode)
+      end
+    end
+  end
+
+  describe "#full_address" do
     context "when a school record exists" do
       subject { create(:placement, :with_school) }
 
@@ -127,7 +199,7 @@ RSpec.describe Placement do
       }
 
       it "returns the user input address" do
-        expect(subject.full_address).to eq("URN #{subject.urn}, #{subject.address}, #{subject.postcode}")
+        expect(subject.full_address).to eq("#{subject.address}, #{subject.postcode}")
       end
     end
 

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Placement do
 
   describe "#name" do
     context "when a school record exists" do
-      subject { create(:placement) }
+      subject { create(:placement, :with_school) }
 
       it "returns the school name" do
         expect(subject.name).to eq(subject.school.name)
@@ -79,7 +79,7 @@ RSpec.describe Placement do
 
     context "when a school record does not exist" do
       subject {
-        create(:placement, :manual, name: "Some name")
+        create(:placement, name: "Some name")
       }
 
       it "returns the school name" do
@@ -90,7 +90,7 @@ RSpec.describe Placement do
 
   describe "#address" do
     context "when a school record exists" do
-      subject { create(:placement) }
+      subject { create(:placement, :with_school) }
 
       it "returns the school address" do
         expect(subject.full_address).to eq("URN #{subject.school.urn}, #{subject.school.town}, #{subject.school.postcode}")
@@ -99,7 +99,7 @@ RSpec.describe Placement do
 
     context "when a school record does not exist and no urn is provided by user" do
       subject {
-        create(:placement, :manual, urn: nil)
+        create(:placement, urn: nil)
       }
 
       it "returns the user input address" do
@@ -109,7 +109,7 @@ RSpec.describe Placement do
 
     context "when a school record does not exist but urn is provided by user" do
       subject {
-        create(:placement, :manual)
+        create(:placement, urn: Faker::Number.number(digits: 6))
       }
 
       it "returns the user input address" do
@@ -119,7 +119,7 @@ RSpec.describe Placement do
 
     context "when the school urn is among the Trainees::CreateFromHesa::NOT_APPLICABLE_SCHOOL_URNS" do
       subject {
-        create(:placement, :manual, urn: Trainees::CreateFromHesa::NOT_APPLICABLE_SCHOOL_URNS.sample)
+        create(:placement, urn: Trainees::CreateFromHesa::NOT_APPLICABLE_SCHOOL_URNS.sample)
       }
 
       it "returns no address" do

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -195,11 +195,13 @@ RSpec.describe Placement do
 
     context "when a school record does not exist but urn is provided by user" do
       subject {
-        create(:placement, urn: Faker::Number.number(digits: 6))
+        create(:placement, urn:)
       }
 
+      let(:urn) { Faker::Number.number(digits: 6) }
+
       it "returns the user input address" do
-        expect(subject.full_address).to eq("#{subject.address}, #{subject.postcode}")
+        expect(subject.full_address).to eq("URN #{urn}, #{subject.address}, #{subject.postcode}")
       end
     end
 

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -294,7 +294,7 @@ describe Reports::TraineeReport do
       context "when there are 2 placements" do
         let!(:placements) do
           Audited.audit_class.as_user(audit_user) do
-            create_list(:placement, 2, trainee:)
+            create_list(:placement, 2, :with_school, trainee:)
           end
         end
 
@@ -332,7 +332,7 @@ describe Reports::TraineeReport do
       end
 
       context "when there are over two placements" do
-        let!(:placements) { create_list(:placement, 4, trainee:) }
+        let!(:placements) { create_list(:placement, 4, :with_school, trainee:) }
 
         it "adds the rest of the placement school urns under other_placements" do
           expect(subject.other_placements).to eq("#{placements[2].school.urn}, #{placements[3].school.urn}")

--- a/spec/requests/api/v0_1/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_placement_spec.rb
@@ -11,7 +11,7 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
     let(:placement_attribute_keys) { Api::V01::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
 
     context "with a valid trainee and placement" do
-      context "create placement with urn" do
+      context "create placement with a school" do
         let(:school) { create(:school) }
         let(:params) do
           { data: { urn: school.urn } }.with_indifferent_access
@@ -25,7 +25,6 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
           }.from(0).to(1)
 
           expect(response).to have_http_status(:created)
-          expect(response.parsed_body["data"]).to be_present
           expect(response.parsed_body["data"]).to include(
             urn: school.urn,
             name: school.name,

--- a/spec/requests/api/v0_1/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_placement_spec.rb
@@ -57,10 +57,16 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
             trainee.placements.count
           }.from(0).to(1)
 
-          expect(response).to have_http_status(:created)
-          expect(response.parsed_body["data"]).to include(data)
-
           placement = trainee.reload.placements.take
+
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body["data"]).to include(
+            urn: data[:urn],
+            name: data[:name],
+            address: "URN #{data[:urn]}, #{data[:address]}, #{data[:postcode]}",
+            postcode: data[:postcode],
+            placement_id: placement.slug,
+          )
 
           expect(placement.school_id).to be_nil
           expect(placement.urn).to eq(data[:urn])

--- a/spec/requests/api/v0_1/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_placement_spec.rb
@@ -63,7 +63,7 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
           expect(response.parsed_body["data"]).to include(
             urn: data[:urn],
             name: data[:name],
-            address: "URN #{data[:urn]}, #{data[:address]}, #{data[:postcode]}",
+            address: "URN #{data[:urn]}, #{data[:postcode]}",
             postcode: data[:postcode],
             placement_id: placement.slug,
           )

--- a/spec/requests/api/v0_1/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/put_placement_spec.rb
@@ -29,16 +29,16 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
               trainee.placements.count
             }
 
+            placement.reload
+
             expect(response).to have_http_status(:ok)
             expect(response.parsed_body["data"]).to include(
               placement_id: slug,
               urn: school.urn,
               name: school.name,
               postcode: school.postcode,
-              address: "URN #{school.urn}, #{school.town}, #{school.postcode}",
+              address: placement.full_address,
             )
-
-            placement.reload
 
             expect(placement.school_id).to eq(school.id)
             expect(placement.urn).to eq(school.urn)
@@ -100,18 +100,18 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
 
           expect(response).to have_http_status(:ok)
 
+          placement.reload
+
           expect(response.parsed_body["data"]).to include(
             "placement_id" => slug,
-            "address" => "URN #{placement.urn}, #{placement.address}, #{placement.postcode}",
+            "address" => placement.full_address,
             "name" => params.dig(:data, :name),
             "postcode" => params.dig(:data, :postcode),
             "urn" => placement.urn,
           )
 
-          placement.reload
-
           expect(placement.school_id).to be_nil
-          expect(placement.address).to eq(params.dig(:data, :address))
+          expect(placement.address).to be_nil
           expect(placement.name).to eq(params.dig(:data, :name))
           expect(placement.postcode).to eq(params.dig(:data, :postcode))
           expect(placement.urn).not_to be_blank

--- a/spec/requests/api/v0_1/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/put_placement_spec.rb
@@ -6,42 +6,85 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
   context "with a valid authentication token" do
     let(:provider) { trainee.provider }
     let(:token) { AuthenticationToken.create_with_random_token(provider:) }
+    let(:trainee) { create(:trainee) }
     let(:trainee_slug) { trainee.slug }
-    let(:trainee) { create(:trainee, :with_placements) }
-    let(:placement) { trainee.placements.first }
     let(:slug) { placement.slug }
     let(:placement_attribute_keys) { Api::V01::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
 
     context "with a valid trainee and placement" do
-      context "update placement with a school" do
+      describe "update placement with a school" do
+        let!(:placement) { create(:placement, :with_school, trainee:, school:) }
+
         let(:school) { create(:school) }
-        let(:params) do
-          { data: { urn: school.urn } }.with_indifferent_access
+
+        context "when the params include the school urn" do
+          let(:params) do
+            { data: { urn: school.urn } }.with_indifferent_access
+          end
+
+          it "updates an existing placement and returns a 200 (ok) status" do
+            expect {
+              put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+            }.not_to change {
+              trainee.placements.count
+            }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body["data"]).to include(
+              placement_id: slug,
+              urn: school.urn,
+              name: school.name,
+              postcode: school.postcode,
+              address: nil,
+            )
+
+            placement.reload
+
+            expect(placement.school_id).to eq(school.id)
+            expect(placement.urn).to eq(school.urn)
+            expect(placement.name).to eq(school.name)
+            expect(placement.postcode).to eq(school.postcode)
+            expect(placement.address).to be_blank
+          end
         end
 
-        it "updates an existing placement and returns a 200 (ok) status" do
-          expect {
-            put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
-          }.not_to change {
-            trainee.placements.count
-          }
+        context "when the params do not include the school urn" do
+          let(:params) do
+            { data: { urn: Faker::Number.unique.number(digits: 6).to_s, name: Faker::University.name } }.with_indifferent_access
+          end
 
-          expect(response).to have_http_status(:ok)
-          expect(response.parsed_body["data"]["placement_id"]).to eql(slug)
+          it "updates an existing placement and returns a 200 (ok) status" do
+            expect {
+              put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+            }.not_to change {
+              trainee.placements.count
+            }
 
-          placement.reload
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body["data"]).to include(
+              placement_id: slug,
+              urn: params.dig(:data, :urn),
+              name: params.dig(:data, :name),
+              postcode: nil,
+              address: nil,
+            )
 
-          expect(placement.school_id).to eq(school.id)
-          expect(placement.urn).to eq(school.urn)
-          expect(placement.address).not_to be_blank
-          expect(placement.name).to eq(school.name)
-          expect(placement.postcode).to eq(school.postcode)
+            placement.reload
+
+            expect(placement.urn).to eq(params.dig(:data, :urn))
+            expect(placement.name).to eq(params.dig(:data, :name))
+            expect(placement.school_id).to be_nil
+            expect(placement.postcode).to be_nil
+            expect(placement.address).to be_nil
+          end
         end
       end
 
-      context "updates an existing placement without a school" do
+      describe "updates an existing placement without a school" do
+        let!(:placement) { create(:placement, trainee:) }
+
         let(:params) do
-          { data: build(:placement).attributes.slice(*placement_attribute_keys) }.with_indifferent_access
+          { data: placement.attributes.except("urn").slice(*placement_attribute_keys) }.with_indifferent_access
         end
 
         let(:params_to_update_postcode) do
@@ -56,20 +99,22 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
           }
 
           expect(response).to have_http_status(:ok)
+
           expect(response.parsed_body["data"]).to include(
             "placement_id" => slug,
             "address" => params.dig(:data, :address),
             "name" => params.dig(:data, :name),
             "postcode" => params.dig(:data, :postcode),
-            "urn" => params.dig(:data, :urn),
+            "urn" => placement.urn,
           )
+
           placement.reload
 
+          expect(placement.school_id).to be_nil
           expect(placement.address).to eq(params.dig(:data, :address))
           expect(placement.name).to eq(params.dig(:data, :name))
           expect(placement.postcode).to eq(params.dig(:data, :postcode))
-          expect(placement.urn).to eq(params.dig(:data, :urn))
-          expect(placement.school_id).to be_nil
+          expect(placement.urn).not_to be_blank
         end
 
         it "partial update of an existing placement returns 200 (ok) status" do
@@ -92,32 +137,36 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
           end
 
           it "does not create a new placement and returns a 422 status (unprocessable_entity) status" do
-            put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
-
-            expect(response).to have_http_status(:not_found)
-            expect(trainee.reload.placements.count).to eq(2)
-          end
-        end
-
-        context "with invalid placement attributes" do
-          let(:params) do
-            { data: Api::V01::PlacementAttributes::ATTRIBUTES.index_with { |_| nil } }
-          end
-
-          it "does not create a new placements and returns a 422 status (unprocessable_entity) status" do
             expect {
               put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
             }.not_to change {
               trainee.placements.count
             }
 
-            expect(response).to have_http_status(:unprocessable_entity)
-            expect(response.parsed_body["errors"]).to contain_exactly(
-              "error" => "UnprocessableEntity",
-              "message" => "Name can't be blank",
-            )
+            expect(response).to have_http_status(:not_found)
           end
         end
+      end
+    end
+
+    context "with an invalid placement attributes" do
+      let!(:placement) { create(:placement, trainee:) }
+      let(:params) do
+        { data: Api::V01::PlacementAttributes::ATTRIBUTES.index_with { |_| nil } }
+      end
+
+      it "does not create a new placements and returns a 422 status (unprocessable_entity) status" do
+        expect {
+          put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+        }.not_to change {
+          trainee.placements.count
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          "error" => "UnprocessableEntity",
+          "message" => "Name can't be blank",
+        )
       end
     end
   end

--- a/spec/requests/api/v0_1/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/put_placement_spec.rb
@@ -56,22 +56,19 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
           }
 
           expect(response).to have_http_status(:ok)
-
           expect(response.parsed_body["data"]).to include(
             "placement_id" => slug,
             "address" => params.dig(:data, :address),
             "name" => params.dig(:data, :name),
             "postcode" => params.dig(:data, :postcode),
             "urn" => params.dig(:data, :urn),
-            "urn" => nil,
           )
-
           placement.reload
 
           expect(placement.address).to eq(params.dig(:data, :address))
           expect(placement.name).to eq(params.dig(:data, :name))
           expect(placement.postcode).to eq(params.dig(:data, :postcode))
-          expect(placement.urn).to be_nil
+          expect(placement.urn).to eq(params.dig(:data, :urn))
           expect(placement.school_id).to be_nil
         end
 

--- a/spec/requests/api/v0_1/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/put_placement_spec.rb
@@ -35,7 +35,7 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
               urn: school.urn,
               name: school.name,
               postcode: school.postcode,
-              address: nil,
+              address: "URN #{school.urn}, #{school.town}, #{school.postcode}",
             )
 
             placement.reload
@@ -66,7 +66,7 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
               urn: params.dig(:data, :urn),
               name: params.dig(:data, :name),
               postcode: nil,
-              address: nil,
+              address: "URN #{params.dig(:data, :urn)}",
             )
 
             placement.reload
@@ -102,7 +102,7 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
 
           expect(response.parsed_body["data"]).to include(
             "placement_id" => slug,
-            "address" => params.dig(:data, :address),
+            "address" => "URN #{placement.urn}, #{placement.address}, #{placement.postcode}",
             "name" => params.dig(:data, :name),
             "postcode" => params.dig(:data, :postcode),
             "urn" => placement.urn,

--- a/spec/requests/api/v0_1/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/put_placement_spec.rb
@@ -13,7 +13,7 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
     let(:placement_attribute_keys) { Api::V01::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
 
     context "with a valid trainee and placement" do
-      context "update placement with urn" do
+      context "update placement with a school" do
         let(:school) { create(:school) }
         let(:params) do
           { data: { urn: school.urn } }.with_indifferent_access
@@ -39,9 +39,9 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
         end
       end
 
-      context "updates an existing placement without urn" do
+      context "updates an existing placement without a school" do
         let(:params) do
-          { data: build(:placement).attributes.except("urn").slice(*placement_attribute_keys) }.with_indifferent_access
+          { data: build(:placement).attributes.slice(*placement_attribute_keys) }.with_indifferent_access
         end
 
         let(:params_to_update_postcode) do
@@ -62,7 +62,8 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
             "address" => params.dig(:data, :address),
             "name" => params.dig(:data, :name),
             "postcode" => params.dig(:data, :postcode),
-            "urn" => placement.urn,
+            "urn" => params.dig(:data, :urn),
+            "urn" => nil,
           )
 
           placement.reload
@@ -70,7 +71,8 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
           expect(placement.address).to eq(params.dig(:data, :address))
           expect(placement.name).to eq(params.dig(:data, :name))
           expect(placement.postcode).to eq(params.dig(:data, :postcode))
-          expect(placement.urn).to eq(placement.school.urn)
+          expect(placement.urn).to be_nil
+          expect(placement.school_id).to be_nil
         end
 
         it "partial update of an existing placement returns 200 (ok) status" do

--- a/spec/requests/api/v0_1/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/put_placement_spec.rb
@@ -67,7 +67,6 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
 
           placement.reload
 
-          expect(placement.school_id).to eq(placement.school.id)
           expect(placement.address).to eq(params.dig(:data, :address))
           expect(placement.name).to eq(params.dig(:data, :name))
           expect(placement.postcode).to eq(params.dig(:data, :postcode))

--- a/spec/requests/api/v0_1/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/put_placement_spec.rb
@@ -13,56 +13,76 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
     let(:placement_attribute_keys) { Api::V01::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
 
     context "with a valid trainee and placement" do
-      context "update placement with school_id" do
+      context "update placement with urn" do
+        let(:school) { create(:school) }
         let(:params) do
-          { data: create(:placement).attributes.slice(*placement_attribute_keys) }.with_indifferent_access
+          { data: { urn: school.urn } }.with_indifferent_access
         end
 
         it "updates an existing placement and returns a 200 (ok) status" do
-          put "/api/v0.1//trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+          expect {
+            put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+          }.not_to change {
+            trainee.placements.count
+          }
 
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body["data"]["placement_id"]).to eql(slug)
-          expect(trainee.reload.placements.count).to eq(2)
 
-          expect(placement.reload.school_id).to eq(params.dig(:data, :school_id))
-          expect(placement.reload.address).to be_blank
-          expect(placement.reload.name).to eq(School.find(params.dig(:data, :school_id)).name)
-          expect(placement.reload.postcode).to be_blank
-          expect(placement.reload.urn).to be_blank
+          placement.reload
+
+          expect(placement.school_id).to eq(school.id)
+          expect(placement.urn).to eq(school.urn)
+          expect(placement.address).not_to be_blank
+          expect(placement.name).to eq(school.name)
+          expect(placement.postcode).to eq(school.postcode)
         end
       end
 
-      context "updates an existing placement without school_id" do
+      context "updates an existing placement without urn" do
         let(:params) do
-          { data: create(:placement, :manual).attributes.slice(*placement_attribute_keys) }.with_indifferent_access
+          { data: build(:placement).attributes.except("urn").slice(*placement_attribute_keys) }.with_indifferent_access
         end
 
         let(:params_to_update_postcode) do
           { data: { postcode: "GU1 1AA" }.with_indifferent_access }
         end
 
-        it "creates a new placement and returns a 200 (ok) status" do
-          put "/api/v0.1//trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+        it "updates the placement and returns a 200 (ok) status" do
+          expect {
+            put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+          }.not_to change {
+            trainee.placements.count
+          }
 
           expect(response).to have_http_status(:ok)
-          expect(response.parsed_body["data"]["placement_id"]).to eql(slug)
-          expect(trainee.reload.placements.count).to eq(2)
 
-          expect(placement.reload.school_id).to be_blank
-          expect(placement.reload.address).to eq(params.dig(:data, :address))
-          expect(placement.reload.name).to eq(params.dig(:data, :name))
-          expect(placement.reload.postcode).to eq(params.dig(:data, :postcode))
-          expect(placement.reload.urn).to eq(params.dig(:data, :urn))
+          expect(response.parsed_body["data"]).to include(
+            "placement_id" => slug,
+            "address" => params.dig(:data, :address),
+            "name" => params.dig(:data, :name),
+            "postcode" => params.dig(:data, :postcode),
+            "urn" => placement.urn,
+          )
+
+          placement.reload
+
+          expect(placement.school_id).to eq(placement.school.id)
+          expect(placement.address).to eq(params.dig(:data, :address))
+          expect(placement.name).to eq(params.dig(:data, :name))
+          expect(placement.postcode).to eq(params.dig(:data, :postcode))
+          expect(placement.urn).to eq(placement.school.urn)
         end
 
         it "partial update of an existing placement returns 200 (ok) status" do
-          put "/api/v0.1//trainees/#{trainee_slug}/placements/#{slug}", params: params_to_update_postcode.to_json, headers: { Authorization: token, **json_headers }
+          expect {
+            put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params_to_update_postcode.to_json, headers: { Authorization: token, **json_headers }
+          }.not_to change {
+            trainee.placements.count
+          }
 
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body["data"]["placement_id"]).to eql(slug)
-          expect(trainee.reload.placements.count).to eq(2)
-
           expect(placement.reload.postcode).to eq("GU1 1AA")
         end
 
@@ -74,24 +94,30 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
           end
 
           it "does not create a new placement and returns a 422 status (unprocessable_entity) status" do
-            put "/api/v0.1//trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+            put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
 
             expect(response).to have_http_status(:not_found)
             expect(trainee.reload.placements.count).to eq(2)
           end
         end
 
-        context "with an invalid placement attributes" do
+        context "with invalid placement attributes" do
           let(:params) do
             { data: Api::V01::PlacementAttributes::ATTRIBUTES.index_with { |_| nil } }
           end
 
           it "does not create a new placements and returns a 422 status (unprocessable_entity) status" do
-            put "/api/v0.1//trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+            expect {
+              put "/api/v0.1/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+            }.not_to change {
+              trainee.placements.count
+            }
 
             expect(response).to have_http_status(:unprocessable_entity)
-            expect(response.parsed_body["errors"].count).to eq(2)
-            expect(trainee.reload.placements.count).to eq(2)
+            expect(response.parsed_body["errors"]).to contain_exactly(
+              "error" => "UnprocessableEntity",
+              "message" => "Name can't be blank",
+            )
           end
         end
       end

--- a/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
@@ -11,53 +11,34 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
     let(:placement_attribute_keys) { Api::V10Pre::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
 
     context "with a valid trainee and placement" do
-      context "create placement with school_id" do
+      context "create placement with a urn" do
+        let(:school) { create(:school) }
         let(:params) do
-          { data: create(:placement).attributes.slice(*placement_attribute_keys) }.with_indifferent_access
+          { data: { urn: school.urn } }.with_indifferent_access
         end
 
         it "creates a new placement and returns a 201 (created) status" do
-          post "/api/v1.0-pre//trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
+          expect {
+            post "/api/v1.0-pre/trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
+          }.to change {
+            trainee.placements.count
+          }.from(0).to(1)
 
           expect(response).to have_http_status(:created)
           expect(response.parsed_body["data"]).to be_present
-          expect(trainee.reload.placements.count).to eq(1)
+          expect(response.parsed_body["data"]).to include(
+            urn: school.urn,
+            name: school.name,
+            postcode: school.postcode,
+          )
 
-          expect(trainee.reload.placements.first.school_id).to eq(params.dig(:data, :school_id))
-          expect(trainee.reload.placements.first.address).to be_blank
-          expect(trainee.reload.placements.first.name).to eq(School.find(params.dig(:data, :school_id)).name)
-          expect(trainee.reload.placements.first.postcode).to be_blank
-          expect(trainee.reload.placements.first.urn).to be_blank
-        end
+          placement = trainee.placements.take
 
-        it "updates the progress attribute on the trainee" do
-          post "/api/v1.0-pre//trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
-
-          expect(trainee.reload.progress[:placements]).to be(true)
-        end
-      end
-
-      context "create placement without school_id" do
-        let(:placement) { create(:placement, :manual) }
-        let(:params) do
-          { data: placement.attributes.slice(*placement_attribute_keys) }.with_indifferent_access
-        end
-
-        it "creates a new placement and returns a 201 (created) status" do
-          post "/api/v1.0-pre//trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
-
-          expect(response).to have_http_status(:created)
-          expect(response.parsed_body["data"]).to be_present
-
-          expect(trainee.reload.placements.count).to eq(1)
-          expect(trainee.reload.placements.first.school_id).to be_blank
-          expect(trainee.reload.placements.first.address).to eq(params.dig(:data, :address))
-          expect(trainee.reload.placements.first.name).to eq(params.dig(:data, :name))
-          expect(trainee.reload.placements.first.postcode).to eq(params.dig(:data, :postcode))
-          expect(trainee.reload.placements.first.urn).to eq(params.dig(:data, :urn))
-
-          expect(response.parsed_body["data"]["urn"]).to eq(placement.urn)
-          expect(response.parsed_body["data"]["name"]).to eq(placement.name)
+          expect(placement.urn).to eq(school.urn)
+          expect(placement.school_id).to eq(school.id)
+          expect(placement.address).to be_nil
+          expect(placement.name).to eq(school.name)
+          expect(placement.postcode).to eq(school.postcode)
         end
 
         context "with different trainee" do
@@ -68,10 +49,13 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
           end
 
           it "does not create a new placement and returns a 422 status (unprocessable_entity) status" do
-            post "/api/v1.0-pre//trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
+            expect {
+              post "/api/v1.0-pre//trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
+            }.not_to change {
+              trainee.placements.count
+            }
 
             expect(response).to have_http_status(:not_found)
-            expect(trainee.reload.placements.count).to eq(0)
           end
         end
 
@@ -81,12 +65,50 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
           end
 
           it "does not create a new placements and returns a 422 status (unprocessable_entity) status" do
-            post "/api/v1.0-pre//trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
+            expect {
+              post "/api/v1.0-pre/trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
+            }.not_to change {
+              trainee.placements.count
+            }
 
             expect(response).to have_http_status(:unprocessable_entity)
-            expect(response.parsed_body["errors"].count).to eq(2)
-            expect(trainee.reload.placements.count).to eq(0)
+            expect(response.parsed_body["errors"]).to contain_exactly(
+              "error" => "UnprocessableEntity",
+              "message" => "Name can't be blank",
+            )
           end
+        end
+      end
+
+      context "create placement without a urn" do
+        let(:placement_attributes) { build(:placement).attributes.except("urn").slice(*placement_attribute_keys) }
+        let(:params) do
+          { data: placement_attributes }.with_indifferent_access
+        end
+
+        it "creates a new placement and returns a 201 (created) status" do
+          expect {
+            post "/api/v1.0-pre//trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
+          }.to change {
+            trainee.placements.count
+          }.from(0).to(1)
+
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body["data"]).to include(placement_attributes)
+
+          placement = trainee.placements.take
+
+          expect(placement.school_id).to be_nil
+          expect(placement.urn).to be_nil
+          expect(placement.address).to eq(placement_attributes["address"])
+          expect(placement.name).to eq(placement_attributes["name"])
+          expect(placement.postcode).to eq(placement_attributes["postcode"])
+        end
+
+        it "updates the progress attribute on the trainee" do
+          post "/api/v1.0-pre//trainees/#{trainee_slug}/placements", params: params.to_json, headers: { Authorization: token, **json_headers }
+
+          expect(trainee.reload.progress[:placements]).to be(true)
         end
       end
     end

--- a/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
@@ -8,7 +8,7 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
     let(:token) { AuthenticationToken.create_with_random_token(provider:) }
     let(:trainee_slug) { trainee.slug }
     let(:trainee) { create(:trainee) }
-    let(:placement_attribute_keys) { Api::V10Pre::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
+    let(:placement_attribute_keys) { Api::V10Pre::PlacementAttributes::ATTRIBUTES }
 
     context "with a valid trainee and placement" do
       context "create placement with a urn" do
@@ -81,9 +81,9 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
       end
 
       context "create placement without a urn" do
-        let(:placement_attributes) { build(:placement).attributes.except("urn").slice(*placement_attribute_keys) }
+        let(:data) { attributes_for(:placement).except(:urn).slice(*placement_attribute_keys) }
         let(:params) do
-          { data: placement_attributes }.with_indifferent_access
+          { data: }.with_indifferent_access
         end
 
         it "creates a new placement and returns a 201 (created) status" do
@@ -94,15 +94,15 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
           }.from(0).to(1)
 
           expect(response).to have_http_status(:created)
-          expect(response.parsed_body["data"]).to include(placement_attributes)
+          expect(response.parsed_body[:data]).to include(data)
 
           placement = trainee.placements.take
 
           expect(placement.school_id).to be_nil
           expect(placement.urn).to be_nil
-          expect(placement.address).to eq(placement_attributes["address"])
-          expect(placement.name).to eq(placement_attributes["name"])
-          expect(placement.postcode).to eq(placement_attributes["postcode"])
+          expect(placement.address).to eq(data[:address])
+          expect(placement.name).to eq(data[:name])
+          expect(placement.postcode).to eq(data[:postcode])
         end
 
         it "updates the progress attribute on the trainee" do

--- a/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
@@ -11,7 +11,7 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
     let(:placement_attribute_keys) { Api::V10Pre::PlacementAttributes::ATTRIBUTES }
 
     context "with a valid trainee and placement" do
-      context "create placement with a urn" do
+      context "create placement with a school" do
         let(:school) { create(:school) }
         let(:params) do
           { data: { urn: school.urn } }.with_indifferent_access
@@ -80,7 +80,7 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
         end
       end
 
-      context "create placement without a urn" do
+      context "create placement without a school" do
         let(:data) { attributes_for(:placement).except(:urn).slice(*placement_attribute_keys) }
         let(:params) do
           { data: }.with_indifferent_access

--- a/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
@@ -93,10 +93,16 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
             trainee.placements.count
           }.from(0).to(1)
 
-          expect(response).to have_http_status(:created)
-          expect(response.parsed_body[:data]).to include(data)
-
           placement = trainee.placements.take
+
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body[:data]).to include(
+            urn: nil,
+            name: data[:name],
+            address: "#{data[:address]}, #{data[:postcode]}",
+            postcode: data[:postcode],
+            placement_id: placement.slug,
+          )
 
           expect(placement.school_id).to be_nil
           expect(placement.urn).to be_nil

--- a/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
@@ -99,14 +99,14 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
           expect(response.parsed_body[:data]).to include(
             urn: nil,
             name: data[:name],
-            address: "#{data[:address]}, #{data[:postcode]}",
+            address: placement.full_address,
             postcode: data[:postcode],
             placement_id: placement.slug,
           )
 
           expect(placement.school_id).to be_nil
           expect(placement.urn).to be_nil
-          expect(placement.address).to eq(data[:address])
+          expect(placement.address).to be_nil
           expect(placement.name).to eq(data[:name])
           expect(placement.postcode).to eq(data[:postcode])
         end

--- a/spec/requests/api/v1_0_pre/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/put_placement_spec.rb
@@ -6,42 +6,85 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
   context "with a valid authentication token" do
     let(:provider) { trainee.provider }
     let(:token) { AuthenticationToken.create_with_random_token(provider:) }
+    let(:trainee) { create(:trainee) }
     let(:trainee_slug) { trainee.slug }
-    let(:trainee) { create(:trainee, :with_placements) }
-    let(:placement) { trainee.placements.first }
     let(:slug) { placement.slug }
     let(:placement_attribute_keys) { Api::V10Pre::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
 
     context "with a valid trainee and placement" do
-      context "update placement with urn" do
+      describe "update placement with a school" do
+        let!(:placement) { create(:placement, :with_school, trainee:, school:) }
+
         let(:school) { create(:school) }
-        let(:params) do
-          { data: { urn: school.urn } }.with_indifferent_access
+
+        context "when the params include the school urn" do
+          let(:params) do
+            { data: { urn: school.urn } }.with_indifferent_access
+          end
+
+          it "updates an existing placement and returns a 200 (ok) status" do
+            expect {
+              put "/api/v1.0-pre/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+            }.not_to change {
+              trainee.placements.count
+            }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body["data"]).to include(
+              placement_id: slug,
+              urn: school.urn,
+              name: school.name,
+              postcode: school.postcode,
+              address: nil,
+            )
+
+            placement.reload
+
+            expect(placement.school_id).to eq(school.id)
+            expect(placement.urn).to eq(school.urn)
+            expect(placement.name).to eq(school.name)
+            expect(placement.postcode).to eq(school.postcode)
+            expect(placement.address).to be_blank
+          end
         end
 
-        it "updates an existing placement and returns a 200 (ok) status" do
-          expect {
-            put "/api/v1.0-pre/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
-          }.not_to change {
-            trainee.placements.count
-          }
+        context "when the params do not include the school urn" do
+          let(:params) do
+            { data: { urn: Faker::Number.unique.number(digits: 6).to_s, name: Faker::University.name } }.with_indifferent_access
+          end
 
-          expect(response).to have_http_status(:ok)
-          expect(response.parsed_body["data"]["placement_id"]).to eql(slug)
+          it "updates an existing placement and returns a 200 (ok) status" do
+            expect {
+              put "/api/v1.0-pre/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+            }.not_to change {
+              trainee.placements.count
+            }
 
-          placement.reload
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body["data"]).to include(
+              placement_id: slug,
+              urn: params.dig(:data, :urn),
+              name: params.dig(:data, :name),
+              postcode: nil,
+              address: nil,
+            )
 
-          expect(placement.school_id).to eq(school.id)
-          expect(placement.urn).to eq(school.urn)
-          expect(placement.address).not_to be_blank
-          expect(placement.name).to eq(school.name)
-          expect(placement.postcode).to eq(school.postcode)
+            placement.reload
+
+            expect(placement.urn).to eq(params.dig(:data, :urn))
+            expect(placement.name).to eq(params.dig(:data, :name))
+            expect(placement.school_id).to be_nil
+            expect(placement.postcode).to be_nil
+            expect(placement.address).to be_nil
+          end
         end
       end
 
-      context "updates an existing placement without urn" do
+      describe "updates an existing placement without a school" do
+        let!(:placement) { create(:placement, trainee:) }
+
         let(:params) do
-          { data: create(:placement).attributes.except("urn").slice(*placement_attribute_keys) }.with_indifferent_access
+          { data: placement.attributes.except("urn").slice(*placement_attribute_keys) }.with_indifferent_access
         end
 
         let(:params_to_update_postcode) do
@@ -67,11 +110,11 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
 
           placement.reload
 
-          expect(placement.school_id).to eq(placement.school.id)
+          expect(placement.school_id).to be_nil
           expect(placement.address).to eq(params.dig(:data, :address))
           expect(placement.name).to eq(params.dig(:data, :name))
           expect(placement.postcode).to eq(params.dig(:data, :postcode))
-          expect(placement.urn).to eq(placement.school.urn)
+          expect(placement.urn).not_to be_blank
         end
 
         it "partial update of an existing placement returns 200 (ok) status" do
@@ -103,26 +146,27 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
             expect(response).to have_http_status(:not_found)
           end
         end
+      end
+    end
 
-        context "with an invalid placement attributes" do
-          let(:params) do
-            { data: Api::V10Pre::PlacementAttributes::ATTRIBUTES.index_with { |_| nil } }
-          end
+    context "with an invalid placement attributes" do
+      let!(:placement) { create(:placement, trainee:) }
+      let(:params) do
+        { data: Api::V10Pre::PlacementAttributes::ATTRIBUTES.index_with { |_| nil } }
+      end
 
-          it "does not create a new placements and returns a 422 status (unprocessable_entity) status" do
-            expect {
-              put "/api/v1.0-pre/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
-            }.not_to change {
-              trainee.placements.count
-            }
+      it "does not create a new placements and returns a 422 status (unprocessable_entity) status" do
+        expect {
+          put "/api/v1.0-pre/trainees/#{trainee_slug}/placements/#{slug}", params: params.to_json, headers: { Authorization: token, **json_headers }
+        }.not_to change {
+          trainee.placements.count
+        }
 
-            expect(response).to have_http_status(:unprocessable_entity)
-            expect(response.parsed_body["errors"]).to contain_exactly(
-              "error" => "UnprocessableEntity",
-              "message" => "Name can't be blank",
-            )
-          end
-        end
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          "error" => "UnprocessableEntity",
+          "message" => "Name can't be blank",
+        )
       end
     end
   end

--- a/spec/requests/api/v1_0_pre/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/put_placement_spec.rb
@@ -35,7 +35,7 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
               urn: school.urn,
               name: school.name,
               postcode: school.postcode,
-              address: nil,
+              address: "URN #{school.urn}, #{school.town}, #{school.postcode}",
             )
 
             placement.reload
@@ -61,12 +61,13 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
             }
 
             expect(response).to have_http_status(:ok)
+
             expect(response.parsed_body["data"]).to include(
               placement_id: slug,
               urn: params.dig(:data, :urn),
               name: params.dig(:data, :name),
               postcode: nil,
-              address: nil,
+              address: "URN #{params.dig(:data, :urn)}",
             )
 
             placement.reload
@@ -101,11 +102,11 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
           expect(response).to have_http_status(:ok)
 
           expect(response.parsed_body["data"]).to include(
-            "placement_id" => slug,
-            "address" => params.dig(:data, :address),
-            "name" => params.dig(:data, :name),
-            "postcode" => params.dig(:data, :postcode),
-            "urn" => placement.urn,
+            placement_id: slug,
+            address: "URN #{placement.urn}, #{params.dig(:data, :address)}, #{params.dig(:data, :postcode)}",
+            name: params.dig(:data, :name),
+            postcode: params.dig(:data, :postcode),
+            urn: placement.urn,
           )
 
           placement.reload

--- a/spec/requests/api/v1_0_pre/trainees/put_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/put_placement_spec.rb
@@ -101,18 +101,18 @@ describe "`PUT /trainees/:trainee_slug/placements/:slug` endpoint" do
 
           expect(response).to have_http_status(:ok)
 
+          placement.reload
+
           expect(response.parsed_body["data"]).to include(
             placement_id: slug,
-            address: "URN #{placement.urn}, #{params.dig(:data, :address)}, #{params.dig(:data, :postcode)}",
+            address: placement.full_address,
             name: params.dig(:data, :name),
             postcode: params.dig(:data, :postcode),
             urn: placement.urn,
           )
 
-          placement.reload
-
           expect(placement.school_id).to be_nil
-          expect(placement.address).to eq(params.dig(:data, :address))
+          expect(placement.address).to be_nil
           expect(placement.name).to eq(params.dig(:data, :name))
           expect(placement.postcode).to eq(params.dig(:data, :postcode))
           expect(placement.urn).not_to be_blank

--- a/spec/serializers/api/v0_1/placement_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/placement_serializer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::V01::PlacementSerializer do
       placement_id
       urn
       name
+      address
       postcode
       created_at
       updated_at
@@ -23,7 +24,6 @@ RSpec.describe Api::V01::PlacementSerializer do
       slug
       trainee_id
       school_id
-      address
     ].each do |field|
       it "`#{field}` is not present in the output" do
         expect(json.keys).not_to include(field)

--- a/spec/serializers/api/v0_1/placement_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/placement_serializer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::V01::PlacementSerializer do
     let(:json) { described_class.new(placement).as_hash.with_indifferent_access }
 
     context "for a placement that is not associated with a school" do
-      let(:placement) { create(:placement, :manual) }
+      let(:placement) { create(:placement) }
 
       it_behaves_like "a placement serialiser"
     end

--- a/spec/services/api/trainees/save_placement_response_spec.rb
+++ b/spec/services/api/trainees/save_placement_response_spec.rb
@@ -24,12 +24,16 @@ describe Api::Trainees::SavePlacementResponse do
 
       it "returns status created with data" do
         expect(subject[:status]).to be(:created)
+        expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(
+          "urn" => params[:urn],
+          "name" => params[:name],
+          "address" => "URN #{params[:urn]}, #{params[:address]}, #{params[:postcode]}",
+          "postcode" => params[:postcode]
+        )
 
-        expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(params.except(:school_id))
-
-        expect(placement.reload.id).to be_present
+        expect(placement.id).to be_present
         expect(placement.slug).to be_present
-        expect(placement.school_id).to eq(params[:school_id])
+        expect(placement.school_id).to be_nil
       end
 
       it "uses the serializer" do
@@ -70,7 +74,12 @@ describe Api::Trainees::SavePlacementResponse do
 
       it "returns status ok with data" do
         expect(subject[:status]).to be(:ok)
-        expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(params.except(:school_id))
+        expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(
+          "urn" => params[:urn],
+          "name" => params[:name],
+          "address" => "URN #{params[:urn]}, #{params[:address]}, #{params[:postcode]}",
+          "postcode" => params[:postcode]
+        )
 
         expect(placement.reload.id).to be_present
         expect(placement.slug).to be_present

--- a/spec/services/api/trainees/save_placement_response_spec.rb
+++ b/spec/services/api/trainees/save_placement_response_spec.rb
@@ -16,7 +16,7 @@ describe Api::Trainees::SavePlacementResponse do
     let(:placement) { trainee.placements.new }
 
     context "with valid params" do
-      let(:placement_attribute_keys) { Api::V01::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
+      let(:placement_attribute_keys) { Api::V01::PlacementAttributes::ATTRIBUTES.map(&:to_s).push("address") }
 
       let(:params) do
         create(:placement).attributes.slice(*placement_attribute_keys).with_indifferent_access
@@ -27,7 +27,7 @@ describe Api::Trainees::SavePlacementResponse do
         expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(
           "urn" => params[:urn],
           "name" => params[:name],
-          "address" => "URN #{params[:urn]}, #{params[:address]}, #{params[:postcode]}",
+          "address" => "URN #{params[:urn]}, #{params[:postcode]}",
           "postcode" => params[:postcode],
         )
 
@@ -66,7 +66,7 @@ describe Api::Trainees::SavePlacementResponse do
     let(:placement) { trainee.placements.first }
 
     context "with valid params" do
-      let(:placement_attribute_keys) { Api::V01::PlacementAttributes::ATTRIBUTES.map(&:to_s) }
+      let(:placement_attribute_keys) { Api::V01::PlacementAttributes::ATTRIBUTES.map(&:to_s).push("address") }
 
       let(:params) do
         create(:placement).attributes.slice(*placement_attribute_keys).with_indifferent_access
@@ -77,7 +77,7 @@ describe Api::Trainees::SavePlacementResponse do
         expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(
           "urn" => params[:urn],
           "name" => params[:name],
-          "address" => "URN #{params[:urn]}, #{params[:address]}, #{params[:postcode]}",
+          "address" => "URN #{params[:urn]}, #{params[:postcode]}",
           "postcode" => params[:postcode],
         )
 
@@ -130,18 +130,6 @@ describe Api::Trainees::SavePlacementResponse do
         expect(subject[:json][:data]).to be_blank
         expect(subject[:json][:errors]).to include(
           { error: "Conflict", message: "Urn has already been taken" },
-        )
-      end
-    end
-
-    context "with same address and postcode" do
-      let(:existing_placement) { create(:placement, address: "1 Hogwarts drive", postcode: "BN1 1AA") }
-
-      it "returns status unprocessable entity with error response" do
-        expect(subject[:status]).to be(:conflict)
-        expect(subject[:json][:data]).to be_blank
-        expect(subject[:json][:errors]).to include(
-          { error: "Conflict", message: "Address has already been taken" },
         )
       end
     end

--- a/spec/services/api/trainees/save_placement_response_spec.rb
+++ b/spec/services/api/trainees/save_placement_response_spec.rb
@@ -116,7 +116,7 @@ describe Api::Trainees::SavePlacementResponse do
     end
 
     context "with same name" do
-      let(:existing_placement) { create(:placement, :manual, name: "existing placement") }
+      let(:existing_placement) { create(:placement, name: "existing placement") }
 
       it "returns status unprocessable entity with error response" do
         expect(subject[:status]).to be(:conflict)
@@ -128,7 +128,7 @@ describe Api::Trainees::SavePlacementResponse do
     end
 
     context "with same address and postcode" do
-      let(:existing_placement) { create(:placement, :manual, address: "1 Hogwarts drive", postcode: "BN1 1AA") }
+      let(:existing_placement) { create(:placement, address: "1 Hogwarts drive", postcode: "BN1 1AA") }
 
       it "returns status unprocessable entity with error response" do
         expect(subject[:status]).to be(:conflict)

--- a/spec/services/api/trainees/save_placement_response_spec.rb
+++ b/spec/services/api/trainees/save_placement_response_spec.rb
@@ -25,7 +25,7 @@ describe Api::Trainees::SavePlacementResponse do
       it "returns status created with data" do
         expect(subject[:status]).to be(:created)
 
-        expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(params.except(:school_id, :address))
+        expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(params.except(:school_id))
 
         expect(placement.reload.id).to be_present
         expect(placement.slug).to be_present
@@ -53,7 +53,6 @@ describe Api::Trainees::SavePlacementResponse do
         expect(subject[:json][:data]).to be_blank
         expect(subject[:json][:errors]).to contain_exactly(
           { error: "UnprocessableEntity", message: "Name can't be blank" },
-          { error: "UnprocessableEntity", message: "School can't be blank" },
         )
       end
     end
@@ -71,7 +70,7 @@ describe Api::Trainees::SavePlacementResponse do
 
       it "returns status ok with data" do
         expect(subject[:status]).to be(:ok)
-        expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(params.except(:school_id, :address))
+        expect(subject[:json][:data].slice(*placement_attribute_keys)).to match(params.except(:school_id))
 
         expect(placement.reload.id).to be_present
         expect(placement.slug).to be_present
@@ -99,7 +98,6 @@ describe Api::Trainees::SavePlacementResponse do
         expect(subject[:json][:data]).to be_blank
         expect(subject[:json][:errors]).to contain_exactly(
           { error: "UnprocessableEntity", message: "Name can't be blank" },
-          { error: "UnprocessableEntity", message: "School can't be blank" },
         )
       end
     end

--- a/spec/services/api/trainees/save_placement_response_spec.rb
+++ b/spec/services/api/trainees/save_placement_response_spec.rb
@@ -28,7 +28,7 @@ describe Api::Trainees::SavePlacementResponse do
           "urn" => params[:urn],
           "name" => params[:name],
           "address" => "URN #{params[:urn]}, #{params[:address]}, #{params[:postcode]}",
-          "postcode" => params[:postcode]
+          "postcode" => params[:postcode],
         )
 
         expect(placement.id).to be_present
@@ -78,7 +78,7 @@ describe Api::Trainees::SavePlacementResponse do
           "urn" => params[:urn],
           "name" => params[:name],
           "address" => "URN #{params[:urn]}, #{params[:address]}, #{params[:postcode]}",
-          "postcode" => params[:postcode]
+          "postcode" => params[:postcode],
         )
 
         expect(placement.reload.id).to be_present

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -229,7 +229,7 @@ module Trainees
         end
 
         context "for an update action" do
-          let(:placement) { create(:placement, :manual, trainee:) }
+          let(:placement) { create(:placement, trainee:) }
           let(:associated_audit) do
             trainee.own_and_associated_audits.where(auditable_type: "Placement", action: :update).last
           end

--- a/spec/services/trainees/get_placement_name_from_audit_spec.rb
+++ b/spec/services/trainees/get_placement_name_from_audit_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Trainees
   describe GetPlacementNameFromAudit do
     let(:trainee) { create(:trainee) }
-    let(:placement) { create(:placement, trainee:) }
+    let(:placement) { create(:placement, :with_school, trainee:) }
 
     context "when the placement is associated with a school record" do
       it "returns the correct names for a create audit" do
@@ -32,7 +32,7 @@ module Trainees
     end
 
     context "when the placement is NOT associated with a school record" do
-      let(:placement) { create(:placement, :manual, trainee:) }
+      let(:placement) { create(:placement, trainee:) }
 
       it "returns the correct names for a create audit" do
         placement


### PR DESCRIPTION
### Context

[7602-update-api-documentation-for-placements](https://trello.com/c/oKK5xr0C/[7602-update-api-documentation-for-placements)

Refactor and update documentation for placements endpoints to ensure parity with the frontend implementation

### Changes proposed in this pull request

- Make `name` required if school record cannot be found by `urn`
- Don't allow the `school_id` to be set by the request body
- Don't allow `address` to be set by the request body. Instead return the `Placement#full_address`
- Delegate `urn`, `postcode` to School
- Update OpenApi docs

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
