### PR TITLE
Make smoke test sign-in step resilient to button text changes

### DIFF
--- a/spec/smoke/login_spec.rb
+++ b/spec/smoke/login_spec.rb
@@ -40,7 +40,7 @@ private
 
   def login_with_username
     fill_in "username", with: ENV.fetch("SMOKE_TEST_USERNAME", nil)
-    find_button("Continue").click
+    first(:css, "button[type='submit']").click
   end
 
   def login_with_password


### PR DESCRIPTION
### Context

[DfE Sign-In pages have been changed slightly](https://ukgovernmentdfe.slack.com/archives/C5S500XB6/p1727856661948639) on `pre-prod` so our smoke tests are failing on `staging` which is preventing deploys to `production`.

### Changes proposed in this pull request

* Update smoke test sign-in flow to click button based on the type of button, rather than button text, so future button text changes will not affect our smoke test.
* This should tolerate differences in button text between the different environments too.

### Guidance to review


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
