### PR TITLE
[7544] - disable productiondata deploy/backup

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -227,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [sandbox, productiondata]
+        environment: [sandbox]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -92,11 +92,11 @@ jobs:
         --connection-string '${{ env.STORAGE_CONN_STR }}'
         rm ${BACKUP_FILE_NAME}.tar.gz
 
-    - name: Restore backup to aks productiondata database
-      if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.restoreToProductionDataEnv == 'true') }}
-      shell: bash
-      run: |
-        bin/konduit.sh -i ${{ env.BACKUP_FILE_NAME }}.sql -t 7200 register-productiondata -- psql
+    # - name: Restore backup to aks productiondata database
+    #   if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.restoreToProductionDataEnv == 'true') }}
+    #   shell: bash
+    #   run: |
+    #     bin/konduit.sh -i ${{ env.BACKUP_FILE_NAME }}.sql -t 7200 register-productiondata -- psql
 
     - name: Restore backup to aks analysis database
       if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.restoreToProductionAnalysisEnv == 'true') }}


### PR DESCRIPTION
### Context

relates to #4693 Disables production data auto-deploys and backup whilst checking Ambition and TeachFirst data