### PR TITLE
[7610] Spike investigate potential integration with qualtrics api

### DIFF
--- a/app/lib/qualtrics_api/client.rb
+++ b/app/lib/qualtrics_api/client.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module QualtricsApi
+  class Client
+    class Request
+      include HTTParty
+      base_uri Settings.qualtrics.base_url
+      headers "X-API-TOKEN" => Settings.qualtrics.api_token,
+              "Content-Type" => "application/json"
+    end
+
+    class HttpError < StandardError; end
+
+    def self.post(...)
+      response = Request.post(...)
+
+      raise(HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}") unless response.success?
+
+      response
+    end
+  end
+end

--- a/app/services/survey/withdraw.rb
+++ b/app/services/survey/withdraw.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Survey
+  class Withdraw
+    include ServicePattern
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      create_contact_in_mailing_list_body = create_contact_in_mailing_list_response.body
+      contact_lookup_id = JSON.parse(create_contact_in_mailing_list_body)["result"]["contactLookupId"]
+      create_distribution_response(contact_lookup_id)
+    end
+
+  private
+
+    attr_reader :trainee
+
+    delegate :first_names, :last_name, :email, :withdraw_date, :training_route, to: :trainee
+
+    def create_contact_in_mailing_list_response
+      @create_contact_in_mailing_list_response ||= QualtricsApi::Client::Request.post("/directories/#{directory_id}/mailinglists/#{mailing_list_id}/contacts", body: create_contact_in_mailing_list_body)
+    end
+
+    def create_contact_in_mailing_list_body
+      {
+        "email" => email,
+        "firstName" => first_names,
+        "lastName" => last_name,
+
+        embeddedData: {
+          "withdraw_date" => withdraw_date,
+          "training_route" => training_route,
+        },
+      }.to_json
+    end
+
+    def create_distribution_body(contact_lookup_id)
+      {
+        message: {
+          libraryId: library_id,
+          messageId: message_id,
+        },
+        recipients: {
+          mailingListId: mailing_list_id,
+          contactId: contact_lookup_id,
+        },
+        header: {
+          fromEmail: Settings.data_email,
+          fromName: "Bat Support",
+          subject: "BAT Chocolate Withdraw",
+          replyToEmail: Settings.data_email,
+        },
+        surveyLink: {
+          surveyId: survey_id,
+          expirationDate: expiration_date,
+          type: "Individual",
+        },
+        sendDate: send_date,
+        embeddedData: {
+          important: "support really needs chocolate",
+          no_clue: "guessing this can be used in email template",
+        },
+      }.to_json
+    end
+
+    def create_distribution_response(contact_lookup_id)
+      @create_distribution_response ||= QualtricsApi::Client::Request.post("/distributions", body: create_distribution_body(contact_lookup_id))
+    end
+
+    def send_date
+      5.minutes.from_now.utc.iso8601
+    end
+
+    def expiration_date
+      5.days.from_now.utc.iso8601
+    end
+
+    def survey_id
+      Settings.qualtrics.withdraw.survey_id
+    end
+
+    def mailing_list_id
+      Settings.qualtrics.withdraw.mailing_list_id
+    end
+
+    def message_id
+      Settings.qualtrics.withdraw.message_id
+    end
+
+    def directory_id
+      Settings.qualtrics.directory_id
+    end
+
+    def library_id
+      Settings.qualtrics.library_id
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -186,3 +186,13 @@ api:
     ip: []
   allowed_versions: [v0.1, v1.0-pre]
   current_version: v0.1
+
+qualtrics:
+  api_token: please_change_me
+  directory_id: POOL_please_change_me
+  base_url: https://{{data_centre_id}}.qualtrics.com/API/v3/
+  library_id: UR_please_change_me
+  withdraw:
+    survey_id: SV_please_change_me
+    mailing_list_id: CG_please_change_me
+    message_id: MS_please_change_me


### PR DESCRIPTION
### Context

Spike investigate potential integration with qualtrics api

### Changes proposed in this pull request

Just a proof of concept

### Guidance to review

**requires settings**

To send survey
 
```ruby
trainee = Trainee.new(first_names: "first_name", last_name: "last_name", email: "email", withdraw_date: 1.month.ago, training_route: :pg_teaching_apprenticeship)
Survey::Withdraw.call(trainee:)
```

A email will sent using [this message template](https://dferesearch.eu.qualtrics.com/app/library#libraryID=UR_ekCHK2MXhZN2XH0&page=1)

![image](https://github.com/user-attachments/assets/4888fad4-9616-4ad2-909b-2e3d8cd15356)

The trainee will be added to [this contact list/mailing list](https://dferesearch.eu.qualtrics.com/iq-directory/#/POOL_03wzmFoShC0dJRP/groups/lists/CG_1Lkud59ClAAJxGl)

The invite will be [this  survey](https://dferesearch.eu.qualtrics.com/survey-builder/SV_6WGVq1rUe8gamwK/edit)

The distributions will be [added here](https://dferesearch.eu.qualtrics.com/Q/DistributeSection?ContextSurveyID=SV_6WGVq1rUe8gamwK)

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
