### PR TITLE
[7648] MalwareScanJob failing silently

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ gem "faraday"
 gem "csv-safe"
 gem "progress_bar" # useful to track progress of long running data migrations using scripts or rake tasks
 
-gem 'azure-blob', git: 'https://github.com/d-a-v-e/azure-blob', branch: 'master'
+gem "azure-blob", git: "https://github.com/d-a-v-e/azure-blob", branch: "master"
 gem "cssbundling-rails"
 gem "jsbundling-rails"
 gem "rack-attack"

--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ gem "faraday"
 gem "csv-safe"
 gem "progress_bar" # useful to track progress of long running data migrations using scripts or rake tasks
 
-gem "azure-blob"
+gem 'azure-blob', git: 'https://github.com/d-a-v-e/azure-blob', branch: 'master'
 gem "cssbundling-rails"
 gem "jsbundling-rails"
 gem "rack-attack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: https://github.com/d-a-v-e/azure-blob
-  revision: 1649f48b72fb98b6079d3ca2ae2a12da9d5904da
+  revision: b2971e3dda367641536cabce2d40d6e42fbcc562
   branch: master
   specs:
     azure-blob (0.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,14 @@ GIT
       activesupport
       tzinfo
 
+GIT
+  remote: https://github.com/d-a-v-e/azure-blob
+  revision: 1649f48b72fb98b6079d3ca2ae2a12da9d5904da
+  branch: master
+  specs:
+    azure-blob (0.5.2)
+      rexml
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -115,8 +123,6 @@ GEM
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
     awesome_print (1.9.2)
-    azure-blob (0.5.2)
-      rexml
     base32 (0.3.4)
     base64 (0.2.0)
     benchmark-malloc (0.2.0)
@@ -766,7 +772,7 @@ DEPENDENCIES
   audited (~> 5.7)
   auto_strip_attributes
   awesome_print
-  azure-blob
+  azure-blob!
   base32
   benchmark-memory
   blazer

--- a/app/lib/malware_scan.rb
+++ b/app/lib/malware_scan.rb
@@ -26,8 +26,9 @@ class MalwareScan
       # so we'll treat any other content for the SCAN_RESULT_TAG_KEY as suspect
       upload.scan_result_suspect!
     end
-  rescue AzureBlob::Http::Error, Net::HTTPClientError
+  rescue StandardError => e
     upload.scan_result_error!
+    raise(e)
   end
 
 private

--- a/app/lib/malware_scan.rb
+++ b/app/lib/malware_scan.rb
@@ -8,22 +8,21 @@ class MalwareScan
   SCAN_RESULT_TAG_KEY = "Malware Scanning scan result"
   SCAN_RESULT_TAG_VALUE_CLEAN = "no threats found"
   SCAN_RESULT_TAG_VALUE_ERROR = /scan failed/
+  SCAN_RESULT_TAG_VALUE_SUSPECT = /malicious/
 
   def initialize(upload:)
     @upload = upload
   end
 
   def call
-    return if upload.file.blank? || upload.scan_result_clean?
+    return unless relevant?
 
     case malware_tag
     when SCAN_RESULT_TAG_VALUE_CLEAN
       upload.scan_result_clean!
     when SCAN_RESULT_TAG_VALUE_ERROR
       upload.scan_result_error!
-    else
-      # there is no clear guidance for a scan result of "suspect"
-      # so we'll treat any other content for the SCAN_RESULT_TAG_KEY as suspect
+    when SCAN_RESULT_TAG_VALUE_SUSPECT
       upload.scan_result_suspect!
     end
   rescue StandardError => e
@@ -50,5 +49,9 @@ private
 
   def malware_tag
     @malware_tag ||= blob_tags&.dig(SCAN_RESULT_TAG_KEY)&.downcase
+  end
+
+  def relevant?
+    upload.file.present? && (upload.scan_result_pending? || upload.scan_result_error?)
   end
 end

--- a/app/lib/malware_scan.rb
+++ b/app/lib/malware_scan.rb
@@ -5,29 +5,29 @@ require "azure_blob"
 class MalwareScan
   include ServicePattern
 
-  SCAN_RESULT_TAG_KEY = /Malware Scanning scan result/
-  SCAN_RESULT_TAG_VALUE_CLEAN = /No threats found/
+  SCAN_RESULT_TAG_KEY = "Malware Scanning scan result"
+  SCAN_RESULT_TAG_VALUE_CLEAN = "no threats found"
+  SCAN_RESULT_TAG_VALUE_ERROR = /scan failed/
 
   def initialize(upload:)
     @upload = upload
   end
 
   def call
-    return unless upload.scan_result_pending?
-    return if upload.file.blank?
+    return if upload.file.blank? || upload.scan_result_clean?
 
-    response = fetch_scan_result
-
-    if response =~ SCAN_RESULT_TAG_KEY
-      upload.update!(
-        malware_scan_result: malware_scan_result_from_response(response),
-      )
-      if upload.scan_result_suspect?
-        upload.destroy
-      end
+    case malware_tag
+    when SCAN_RESULT_TAG_VALUE_CLEAN
+      upload.scan_result_clean!
+    when SCAN_RESULT_TAG_VALUE_ERROR
+      upload.scan_result_error!
+    else
+      # there is no clear guidance for a scan result of "suspect"
+      # so we'll treat any other content for the SCAN_RESULT_TAG_KEY as suspect
+      upload.scan_result_suspect!
     end
   rescue AzureBlob::Http::Error, Net::HTTPClientError
-    upload.update!(malware_scan_result: "error")
+    upload.scan_result_error!
   end
 
 private
@@ -43,11 +43,11 @@ private
       )
   end
 
-  def fetch_scan_result
-    blob_client.get_blob(upload.file.key)
+  def blob_tags
+    @blob_tags ||= blob_client.get_blob_tags(upload.file.key)
   end
 
-  def malware_scan_result_from_response(response)
-    response =~ SCAN_RESULT_TAG_VALUE_CLEAN ? "clean" : "suspect"
+  def malware_tag
+    @malware_tag ||= blob_tags&.dig(SCAN_RESULT_TAG_KEY)&.downcase
   end
 end

--- a/spec/lib/malware_scan_spec.rb
+++ b/spec/lib/malware_scan_spec.rb
@@ -5,60 +5,72 @@ require "rails_helper"
 RSpec.describe MalwareScan do
   describe "#call" do
     let(:upload) { create(:upload) }
-    let(:tags_url) { "https://example.com/tempdata/xyz123?comp=tags" }
-    let(:response_success) { true }
-    let(:scan_result) { "No threats found" }
-    let(:response_body) { <<-XML.squish }
-      <Tags>
-        <Tag>
-          <Key>Malware Scanning scan result</Key>
-          <Value>#{scan_result}</Value>
-        </Tag>
-      </Tags>
-    XML
+    let(:blob_client) { instance_double(AzureBlob::Client) }
+    let(:scan_result) { "no threats found" }
+    let(:tags) { { "Malware Scanning scan result" => scan_result } }
 
-    let(:stubbed_blob_client) do
-      instance_double(AzureBlob::Client, generate_uri: tags_url)
-    end
-
-    subject(:malware_scan) { described_class.call(upload:) }
+    subject(:call_malware_scan) { described_class.call(upload:) }
 
     before do
-      allow(AzureBlob::Client).to receive(:new).and_return(
-        stubbed_blob_client,
-      )
-      allow(stubbed_blob_client).to receive(:get_blob).and_return(response_body)
+      allow(AzureBlob::Client).to receive(:new).and_return(blob_client)
+      allow(blob_client).to receive(:get_blob_tags).and_return(tags)
     end
 
     it "calls the Azure Storage REST API for the scan result" do
-      expect(stubbed_blob_client).to receive(:get_blob).with(upload.file.key)
-      malware_scan
+      expect(blob_client).to receive(:get_blob_tags).with(upload.file.key)
+      call_malware_scan
     end
 
-    context "with a successful scan result" do
-      it "saves the result" do
-        malware_scan
+    context "when the upload file is blank" do
+      before { allow(upload).to receive(:file).and_return(nil) }
+
+      it "does not perform a scan" do
+        expect(blob_client).not_to receive(:get_blob_tags)
+        call_malware_scan
+      end
+    end
+
+    context "when the upload already has a clean scan result" do
+      before { upload.scan_result_clean! }
+
+      it "does not perform a scan" do
+        expect(blob_client).not_to receive(:get_blob_tags)
+        call_malware_scan
+      end
+    end
+
+    context "with a clean scan result" do
+      it "saves the result as clean" do
+        call_malware_scan
         expect(upload.malware_scan_result).to eq("clean")
       end
     end
 
-    context "with a failed scan result" do
+    context "with a suspect scan result" do
       let(:scan_result) { "Malicious" }
 
-      it "delete the upload" do
-        malware_scan
-        expect(Upload.find_by_id(upload.id)).to be_nil
+      it "saves the result as suspect" do
+        call_malware_scan
+        expect(upload.malware_scan_result).to eq("suspect")
       end
     end
 
-    context "with an unsuccessful response" do
+    context "with an error scan result" do
+      let(:scan_result) { "scan failed" }
+
+      it "saves the result as error" do
+        call_malware_scan
+        expect(upload.malware_scan_result).to eq("error")
+      end
+    end
+
+    context "when an AzureBlob::Http::Error occurs" do
       before do
-        allow(AzureBlob::Client).to receive(:new).and_return(stubbed_blob_client)
-        allow(stubbed_blob_client).to receive(:get_blob).and_raise(AzureBlob::Http::Error)
+        allow(blob_client).to receive(:get_blob_tags).and_raise(AzureBlob::Http::Error)
       end
 
-      it "saves an error result" do
-        malware_scan
+      it "saves an error result and re-raises the error" do
+        expect { call_malware_scan }.to raise_error(AzureBlob::Http::Error)
         expect(upload.malware_scan_result).to eq("error")
       end
     end

--- a/spec/lib/malware_scan_spec.rb
+++ b/spec/lib/malware_scan_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe MalwareScan do
   describe "#call" do
-    let(:upload) { create(:upload) }
+    let(:malware_scan_result) { :pending }
+    let(:upload) { create(:upload, malware_scan_result:) }
     let(:blob_client) { instance_double(AzureBlob::Client) }
     let(:scan_result) { "no threats found" }
     let(:tags) { { "Malware Scanning scan result" => scan_result } }
@@ -30,8 +31,8 @@ RSpec.describe MalwareScan do
       end
     end
 
-    context "when the upload already has a clean scan result" do
-      before { upload.scan_result_clean! }
+    context "when the upload is already marked as clean" do
+      let(:malware_scan_result) { :clean }
 
       it "does not perform a scan" do
         expect(blob_client).not_to receive(:get_blob_tags)
@@ -39,7 +40,25 @@ RSpec.describe MalwareScan do
       end
     end
 
-    context "with a clean scan result" do
+    context "when the upload is already marked as suspect" do
+      let(:malware_scan_result) { :suspect }
+
+      it "does not perform a scan" do
+        expect(blob_client).not_to receive(:get_blob_tags)
+        call_malware_scan
+      end
+    end
+
+    context "with a clean scan result whilst pending" do
+      it "saves the result as clean" do
+        call_malware_scan
+        expect(upload.malware_scan_result).to eq("clean")
+      end
+    end
+
+    context "with a clean scan result when previously marked as error" do
+      let(:malware_scan_result) { :error }
+
       it "saves the result as clean" do
         call_malware_scan
         expect(upload.malware_scan_result).to eq("clean")
@@ -47,7 +66,7 @@ RSpec.describe MalwareScan do
     end
 
     context "with a suspect scan result" do
-      let(:scan_result) { "Malicious" }
+      let(:scan_result) { "malicious file detected" }
 
       it "saves the result as suspect" do
         call_malware_scan


### PR DESCRIPTION
### Context

* Uploaded files are scanned by Azure to mark them safe or suspect.
* The current service has a bug and is just looking for the expected "safe" tag in the actual uploaded file content
* NOTE: there are two parts to this, this PR and the [forked gem changes](https://github.com/d-a-v-e/azure-blob/pull/1/files)

### Changes proposed in this pull request

* This points the azure-blob gem to a forked version with [these changes I made ](https://github.com/testdouble/azure-blob/pull/5/files)
* refactors the actual service to make use of the new endpoint
* refactors the specs

### Guidance to review

* these specs are incredibly "dumb" They have to stub a lot
* The `azure-blob` gem is pretty small in scope as it stands, and seems to have a single maintainer, not sure how quickly the suggested change will go in
* I need to write some specs for the actual gem update but I'm really confused by the contribution guidance around `devenv` and how testing is actually verified in the repo (there's no CI as far as I can tell). [I've opened a PR here](https://github.com/testdouble/azure-blob/pull/5)