### PR TITLE
[7664] Remove PII from logs sent to logit.io

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,9 @@ gem "stackprof"
 
 # Logging
 gem "amazing_print", "~> 1.6"
-gem "rails_semantic_logger", "4.17.0"
+
+# There seems to be an issue with 4.17.0 where the workers log the sql
+gem "rails_semantic_logger", "4.16.0"
 
 # Thread-safe global state
 gem "request_store", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,10 +515,10 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    rails_semantic_logger (4.17.0)
+    rails_semantic_logger (4.16.0)
       rack
       railties (>= 5.1)
-      semantic_logger (~> 4.16)
+      semantic_logger (~> 4.13)
     railties (7.2.0)
       actionpack (= 7.2.0)
       activesupport (= 7.2.0)
@@ -630,7 +630,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    semantic_logger (4.16.0)
+    semantic_logger (4.16.1)
       concurrent-ruby (~> 1.0)
     sentry-rails (5.21.0)
       railties (>= 5.0)
@@ -825,7 +825,7 @@ DEPENDENCIES
   rails (~> 7.2)
   rails-controller-testing
   rails-erd
-  rails_semantic_logger (= 4.17.0)
+  rails_semantic_logger (= 4.16.0)
   request_store (~> 1.7)
   rotp
   rspec-benchmark


### PR DESCRIPTION
### Context

[7664-remove-pii-from-logs-sent-to-logitio](https://trello.com/c/hqiak3Al/7664-remove-pii-from-logs-sent-to-logitio)

The app is currently logging sql queries in the Sidekiq workers. 

`rails_semantic_logger` `4.17.0` implements changes to their Sidekiq logging mechanism https://github.com/reidmorrison/rails_semantic_logger/compare/v4.16.0...v4.17.0

By locking the gem to `4.16.0` seems to resolve the issue.

### Changes proposed in this pull request

* Lock `rails_semantic_logger` to `4.16.0`

### Guidance to review

Can be tested locally by commenting out the `unless` statement at [semantic_logger.rb#L66](https://github.com/DFE-Digital/register-trainee-teachers/blob/main/config/initializers/semantic_logger.rb#L66)

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
