### PR TITLE
Track Graduation Year Value in Error Message

### DIFF
--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -75,7 +75,7 @@ class Degree < ApplicationRecord
 
   def graduation_year_valid
     errors.add(:graduation_year, :future) if graduation_year > next_year
-    errors.add(:graduation_year, :invalid) unless graduation_year.between?(next_year - MAX_GRAD_YEARS, next_year)
+    errors.add(:graduation_year, :invalid, value: graduation_year) unless graduation_year.between?(next_year - MAX_GRAD_YEARS, next_year)
   end
 
   def non_uk_degree_non_enic?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1398,7 +1398,7 @@ en:
             graduation_year:
               blank: Enter a graduation year
               future: Enter a graduation year that is in the past, for example 2014
-              invalid: Enter a valid graduation year
+              invalid: Graduation year %{value} is invalid
             country:
               blank: Select the country where the degree was obtained
         provider:

--- a/spec/models/degree_spec.rb
+++ b/spec/models/degree_spec.rb
@@ -48,8 +48,9 @@ describe Degree do
         it "validates" do
           expect { degree.save! }.to raise_error(ActiveRecord::RecordInvalid)
           expect(degree.errors.messages[:graduation_year]).to include(I18n.t(
-                                                                        "activerecord.errors.models.degree.attributes.graduation_year.invalid",
-                                                                      ))
+            "activerecord.errors.models.degree.attributes.graduation_year.invalid",
+            value: degree.graduation_year
+          ))
         end
       end
 

--- a/spec/models/degree_spec.rb
+++ b/spec/models/degree_spec.rb
@@ -48,9 +48,9 @@ describe Degree do
         it "validates" do
           expect { degree.save! }.to raise_error(ActiveRecord::RecordInvalid)
           expect(degree.errors.messages[:graduation_year]).to include(I18n.t(
-            "activerecord.errors.models.degree.attributes.graduation_year.invalid",
-            value: degree.graduation_year
-          ))
+                                                                        "activerecord.errors.models.degree.attributes.graduation_year.invalid",
+                                                                        value: degree.graduation_year,
+                                                                      ))
         end
       end
 


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/oItGWarf)

We're seeing an error in Sentry, which suggests that the graduation year being provided for a degree is invalid. It's unclear if the value is actually invalid or if there's a validation issue with our code. So I've updated the error message to include the graduation year. This should give us some more insight into what's going on.  

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
