### PR TITLE
[7672] Data migration to correct Lead Partner for HESA trainees

### DIFF
--- a/db/data/20241021090400_fix_data_for_wrong_lead_partner_from_hesa_import.rb
+++ b/db/data/20241021090400_fix_data_for_wrong_lead_partner_from_hesa_import.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class FixDataForWrongLeadPartnerFromHesaImport < ActiveRecord::Migration[7.2]
+  def up
+    # This migration is to fix the data for the records that were imported from HESA (created or updated) and were incorrectly assigned the lead_partner_id of 1335
+    Trainee.where(lead_partner_id: 1335, record_source: %w[hesa_collection hesa_trn_data]).update_all(lead_partner_id: nil, lead_partner_not_applicable: true)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/0VkhyWjz)

[A bug](https://github.com/DFE-Digital/register-trainee-teachers/pull/4733) has caused an incorrect lead partner to be set for trainees that have been imported from HESA. We need to update these trainee records with the intended data which was a blank lead partner URN.

We have considered the following:

1. Are there any circumstances under which lead partner `1335` should be set?
   * No, we don't think there are, because we know of no partnerships with any HEIs for `1335` for 2024, and for previous years this lead partner could not have been a lead school.
3. New trainees from HESA and updates to existing trainees from HESA
   * We want to update both these scenarios which have been affected.
4. Trainee records which have `hesa_editable = true`
   * If the lead partner is still set to `1335` then this is still incorrect (see point 1) and should be updated.
5. Updating timestamps and running callbacks
   * We don't think we want to update timestamps or run callbacks when correcting this data.


### Changes proposed in this pull request

* Data migration to update HESA trainees with the incorrect lead partner to no lead partner

### Guidance to review

* Are there any other things we need to consider?
* Could there be unintended consequences of running this?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
