### PR TITLE
[7700] Investigate duplicate fields being returned from GET /trainees/{trainee_id}

### DIFF
--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -30,6 +30,7 @@ module Api
 
     def show
       trainee = current_provider.trainees.find_by!(slug: params[:slug])
+
       render(json: serializer_klass.new(trainee).as_hash)
     end
 

--- a/app/serializers/api/v0_1/degree_serializer.rb
+++ b/app/serializers/api/v0_1/degree_serializer.rb
@@ -16,14 +16,16 @@ module Api
       end
 
       def as_hash
-        @degree.attributes.except(*EXCLUDED_ATTRIBUTES).merge({
-          degree_id:,
-          subject:,
-          institution:,
-          country:,
-          uk_degree:,
-          grade:,
-        })
+        @degree.attributes
+          .except(*EXCLUDED_ATTRIBUTES)
+          .with_indifferent_access.merge({
+            degree_id:,
+            subject:,
+            institution:,
+            country:,
+            uk_degree:,
+            grade:,
+          })
       end
 
       def degree_id

--- a/app/serializers/api/v0_1/trainee_serializer.rb
+++ b/app/serializers/api/v0_1/trainee_serializer.rb
@@ -32,29 +32,31 @@ module Api
       end
 
       def as_hash
-        @trainee.attributes.except(*EXCLUDED_ATTRIBUTES).merge(
-          provider_attributes,
-          diversity_attributes,
-          course_attributes,
-          school_attributes,
-          funding_attributes,
-          hesa_trainee_attributes,
-          sex: sex,
-          study_mode: course_study_mode,
-          course_subject_one: course_subject_one,
-          course_subject_two: course_subject_two,
-          course_subject_three: course_subject_three,
-          training_route: training_route,
-          nationality: nationality,
-          training_initiative: training_initiative,
-          withdraw_reasons: withdraw_reasons,
-          placements: placements,
-          degrees: degrees,
-          state: @trainee.state,
-          trainee_id: @trainee.slug,
-          recommended_for_award_at: recommended_for_award_at,
-          application_id: @trainee.application_choice_id,
-        )
+        @trainee.attributes
+          .except(*EXCLUDED_ATTRIBUTES)
+          .with_indifferent_access.merge(
+            provider_attributes,
+            diversity_attributes,
+            course_attributes,
+            school_attributes,
+            funding_attributes,
+            hesa_trainee_attributes,
+            sex: sex,
+            study_mode: course_study_mode,
+            course_subject_one: course_subject_one,
+            course_subject_two: course_subject_two,
+            course_subject_three: course_subject_three,
+            training_route: training_route,
+            nationality: nationality,
+            training_initiative: training_initiative,
+            withdraw_reasons: withdraw_reasons,
+            placements: placements,
+            degrees: degrees,
+            state: @trainee.state,
+            trainee_id: @trainee.slug,
+            recommended_for_award_at: recommended_for_award_at,
+            application_id: @trainee.application_choice_id,
+          )
       end
 
       def degrees

--- a/spec/requests/api/v0_1/get_trainee_spec.rb
+++ b/spec/requests/api/v0_1/get_trainee_spec.rb
@@ -19,6 +19,7 @@ describe "`GET /api/v0.1/trainees/:id` endpoint" do
 
     it "returns the trainee" do
       parsed_trainee = JSON.parse(Api::GetVersionedItem.for_serializer(model: :trainee, version: "v0.1").new(trainee).as_hash.to_json)
+
       expect(response.parsed_body).to eq(parsed_trainee)
     end
 

--- a/spec/serializers/api/v0_1/degree_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/degree_serializer_spec.rb
@@ -4,10 +4,10 @@ require "rails_helper"
 
 RSpec.describe Api::V01::DegreeSerializer do
   let(:degree) { create(:degree) }
-  let(:json) { described_class.new(degree).as_hash.with_indifferent_access }
+  let(:json) { described_class.new(degree).as_hash }
 
   describe "serialization" do
-    it "includes all expected fields" do
+    let(:fields) do
       %w[
         degree_id
         uk_degree
@@ -24,21 +24,11 @@ RSpec.describe Api::V01::DegreeSerializer do
         uk_degree_uuid
         subject_uuid
         grade_uuid
-      ].each do |field|
-        expect(json.keys).to include(field)
-      end
+      ]
     end
 
-    it "does not include excluded fields" do
-      %w[
-        id
-        trainee_id
-        slug
-        dttp_id
-        locale_code
-      ].each do |field|
-        expect(json.keys).not_to include(field)
-      end
+    it "matches the fields" do
+      expect(json.keys).to match_array(fields)
     end
   end
 end

--- a/spec/serializers/api/v0_1/placement_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/placement_serializer_spec.rb
@@ -4,30 +4,20 @@ require "rails_helper"
 
 RSpec.describe Api::V01::PlacementSerializer do
   shared_examples_for "a placement serialiser" do
-    %w[
-      placement_id
-      urn
-      name
-      address
-      postcode
-      created_at
-      updated_at
-    ].each do |field|
-      it "`#{field}` is present in the output and has a value" do
-        expect(json.keys).to include(field)
-        expect(json[field]).to be_present
-      end
+    let(:fields) do
+      %w[
+        placement_id
+        urn
+        name
+        address
+        postcode
+        created_at
+        updated_at
+      ]
     end
 
-    %w[
-      id
-      slug
-      trainee_id
-      school_id
-    ].each do |field|
-      it "`#{field}` is not present in the output" do
-        expect(json.keys).not_to include(field)
-      end
+    it "matches the fields" do
+      expect(json.keys).to match_array(fields)
     end
   end
 

--- a/spec/serializers/api/v0_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/trainee_serializer_spec.rb
@@ -4,10 +4,10 @@ require "rails_helper"
 
 RSpec.describe Api::V01::TraineeSerializer do
   let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :with_diversity_information, :in_progress, :with_placements, :with_french_nationality) }
-  let(:json) { described_class.new(trainee).as_hash.with_indifferent_access }
+  let(:json) { described_class.new(trainee).as_hash }
 
   describe "serialization" do
-    it "includes all the expected fields" do
+    let(:fields) do
       %w[
         trainee_id
         provider_trainee_id
@@ -86,41 +86,24 @@ RSpec.describe Api::V01::TraineeSerializer do
         degrees
         disability1
         application_id
-      ].each do |field|
-        expect(json.keys).to include(field)
-      end
+        ethnic_background
+        additional_ethnic_background
+        created_from_dttp
+        created_from_hesa
+        bursary_level
+        funding_method
+        itt_qualification_aim
+        state
+      ]
+    end
+
+    it "matches the fields" do
+      expect(json.keys).to match_array(fields)
     end
 
     it "includes the correct disability values" do
       expect(json["disability1"]).not_to be_nil
       expect(json["disability1"]).to eq(trainee.hesa_trainee_detail.hesa_disabilities["disability1"])
-    end
-
-    it "does not include excluded fields" do
-      %w[
-        id
-        slug
-        progress
-        provider_id
-        dttp_id
-        placement_assignment_dttp_id
-        dttp_update_sha
-        dormancy_dttp_id
-        lead_partner_id
-        employing_school_id
-        course_allocation_subject_id
-        start_academic_cycle_id
-        end_academic_cycle_id
-        hesa_trn_submission_id
-        application_choice_id
-        apply_application_id
-        applying_for_bursary
-        applying_for_grant
-        applying_for_scholarship
-        bursary_tier
-      ].each do |field|
-        expect(json.keys).not_to include(field)
-      end
     end
 
     describe "placements" do


### PR DESCRIPTION
### Context

[Investigate duplicate fields being returned from GET /trainees/{trainee_id}](https://trello.com/c/x4ueTgbj/7700-stub-investigate-duplicate-fields-being-returned-from-get-trainees-traineeid)

### Changes proposed in this pull request

* Use `#with_indifferent_access` to allow for the keys to be merged to the String keys of the attributes

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
