### PR TITLE
Remove Unnecessary Yabeda Tests

### DIFF
--- a/spec/support/shared_examples/register_api_endpoint.rb
+++ b/spec/support/shared_examples/register_api_endpoint.rb
@@ -17,16 +17,6 @@ RSpec.shared_examples "a register API endpoint", openapi: false do |url, api_tok
       expect(response).to have_http_status(:ok)
     end
 
-    it "increments the requests_total counter", openapi: do
-      expect { get url, headers: { Authorization: token } }
-        .to change { Yabeda.register_api.requests_total.values.values.sum }
-        .by(1)
-    end
-
-    it "measures the request_duration histogram", openapi: openapi, time_sensitive: true do
-      expect(Yabeda.register_api.request_duration.values.values.sum).to be > 0
-    end
-
     context "when the register_api feature flag is off", feature_register_api: false do
       it "returns status code 404", openapi: do
         expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
### Context
When adding some documentation for Grafana, I removed some metrics that Yabeda was giving us by default. There were still some tests around this that were failing.

### Changes proposed in this pull request
This just removes those tests as they're no longer necessary. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
