### PR TITLE
[7708] - increase timeout on retrieve trn job during October

### DIFF
--- a/app/jobs/dqt/retrieve_trn_job.rb
+++ b/app/jobs/dqt/retrieve_trn_job.rb
@@ -49,7 +49,7 @@ module Dqt
     end
 
     def timeout
-      return (Settings.jobs.max_poll_duration_days + 6).days if Time.Zone.now.month == 10 # Increase timeout for jobs during October to deal with increased registrations
+      return (Settings.jobs.max_poll_duration_days + 6).days if Time.zone.now.month == 10 # Increase timeout for jobs during October to deal with increased registrations
 
       Settings.jobs.max_poll_duration_days.days
     end

--- a/app/jobs/dqt/retrieve_trn_job.rb
+++ b/app/jobs/dqt/retrieve_trn_job.rb
@@ -16,7 +16,7 @@ module Dqt
       @trainee = trn_request.trainee
 
       if @timeout_after.nil?
-        self.class.perform_later(trn_request, trainee.submitted_for_trn_at + Settings.jobs.max_poll_duration_days.days)
+        self.class.perform_later(trn_request, trainee.submitted_for_trn_at + timeout)
         return
       end
 
@@ -46,6 +46,12 @@ module Dqt
 
     def requeue
       self.class.set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trn_request, timeout_after)
+    end
+
+    def timeout
+      return (Settings.jobs.max_poll_duration_days + 6).days if Time.Zone.now.month == 10 # Increase timeout for jobs during October to deal with increased registrations
+
+      Settings.jobs.max_poll_duration_days.days
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/rCDEPvXl/7708-retrieve-trn-job-is-timing-out

### Changes proposed in this pull request

October is a busy month for DQT which means there are a substantial amount of potential duplicates who can't be assigned TRNs. This is causing a large number of timeout errors for the `RetrieveTRN` job on Register. Increasing the timeout during the busy period should reduce the amount of noisy error messages that come through to the Support channel on slack during this period.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
