### PR TITLE
[7728] Error with Dead Jobs

### DIFF
--- a/app/services/concerns/hashable.rb
+++ b/app/services/concerns/hashable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hashable
+  # Search for a specific key in a Hash and return its value
+  #
+  def deep_dig(obj, key)
+    stack   = [obj]
+    visited = Set.new
+
+    until stack.empty?
+      current = stack.pop
+
+      next if visited.include?(current)
+
+      visited.add(current)
+
+      if current.is_a?(Hash)
+        return current[key] if current.key?(key)
+
+        stack.push(*current.values)
+      elsif current.is_a?(Array)
+        stack.push(*current)
+      end
+    end
+  end
+end

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -224,9 +224,12 @@ default_queue.map { _1["wrapped"] }.tally
 #### Dead jobs
 
 ```ruby
+include Hashable
+
 ds = Sidekiq::DeadSet.new
+
 # unique user ids
-ds.map { _1.args[0]["arguments"][0]["_aj_globalid"].split("/").last }.uniq.count
+ds.map { deep_dig(_1.args[0]["arguments"][0], "_aj_globalid").split("/").last }.uniq.count
 # eg count 405 errors
 ds.select { _1.item["error_message"].starts_with? "status: 405" }.count
 # retry

--- a/spec/concerns/hashable_spec.rb
+++ b/spec/concerns/hashable_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Hashable do
+  let(:klass) do
+    Class.new do
+      include Hashable
+    end
+  end
+
+  let(:first_name) { Faker::Name.first_name }
+  let(:last_name) { Faker::Name.last_name }
+  let(:school_name) { Faker::Educator.primary_school }
+  let(:city) { Faker::Address.city }
+  let(:languages) { [Faker::Nation.language] }
+
+  let(:hash) do
+    {
+      first_name: first_name,
+      last_name: last_name,
+      attributes: { school: { name: school_name } },
+      metadata: { location: { city: } },
+      interests: [{ id: 1 }, { basket: true }],
+      languages: languages,
+    }
+  end
+
+  describe "#deep_dig" do
+    context "when the key value is a not a Hash or an Array" do
+      it "returns the value of the key" do
+        expect(klass.new.deep_dig(hash, :last_name)).to eq(last_name)
+      end
+    end
+
+    context "when the key value is a Hash" do
+      it "returns the value of the key" do
+        expect(klass.new.deep_dig(hash, :name)).to eq(school_name)
+        expect(klass.new.deep_dig(hash, :city)).to eq(city)
+      end
+    end
+
+    context "when the key value is an Array" do
+      it "returns the value of the key" do
+        expect(klass.new.deep_dig(hash, :languages)).to eq(languages)
+        expect(klass.new.deep_dig(hash, :basket)).to be(true)
+      end
+    end
+
+    context "when the key does not exists" do
+      it "returns nil" do
+        expect(klass.new.deep_dig(hash, :age)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/features/system_admin/dead_jobs/sorting_dead_jobs_spec.rb
+++ b/spec/features/system_admin/dead_jobs/sorting_dead_jobs_spec.rb
@@ -29,7 +29,7 @@ feature "Sorting sidekiq dead jobs" do
           [
             {
               arguments: [
-                { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee_two.id}" },
+                { trainee: { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee_two.id}" } },
               ],
             },
           ],

--- a/spec/features/system_admin/dead_jobs/viewing_dead_jobs_spec.rb
+++ b/spec/features/system_admin/dead_jobs/viewing_dead_jobs_spec.rb
@@ -23,6 +23,22 @@ feature "Viewing sidekiq dead jobs" do
           enqueued_at: 73.hours.ago.to_i,
         }.with_indifferent_access,
       ),
+      OpenStruct.new(
+        item: {
+          wrapped: "Dqt::UpdateTraineeJob",
+          args:
+          [
+            {
+              arguments: [
+                { trainee: { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee.id}" } },
+              ],
+            },
+          ],
+          error_message: 'status: 400, body: {"title":"Teacher has no incomplete ITT record","status":400,"errorCode":10005}, headers: ',
+          jid: "1234",
+          enqueued_at: 73.hours.ago.to_i,
+        }.with_indifferent_access,
+      ),
     ]
   end
 

--- a/spec/services/sidekiq/remove_dead_duplicates_spec.rb
+++ b/spec/services/sidekiq/remove_dead_duplicates_spec.rb
@@ -6,9 +6,10 @@ module Sidekiq
   describe RemoveDeadDuplicates do
     let(:dead_set) { double }
     let(:args) { [{ "arguments" => [{ "_aj_globalid" => "gid://register-trainee-teachers/Trainee/12345" }] }] }
+    let(:args2) { [{ "arguments" => [{ "trainee" => { "_aj_globalid" => "gid://register-trainee-teachers/Trainee/12345" } }] }] }
     let(:item) { { "error_message" => "status 404" } }
     let(:job1) { double(args: args, item: item, display_class: "Dqt::UpdateTraineeJob") }
-    let(:job2) { double(args: args, item: item, display_class: "Dqt::UpdateTraineeJob") }
+    let(:job2) { double(args: args2, item: item, display_class: "Dqt::UpdateTraineeJob") }
     let(:job3) { double(args: args, item: { "error_message" => "status 429" }, display_class: "Dqt::WithdrawTraineeJob") }
     let(:dead_set_jobs) { [job1, job2, job3] }
 

--- a/spec/support/shared_examples/dead_jobs.rb
+++ b/spec/support/shared_examples/dead_jobs.rb
@@ -17,7 +17,7 @@ RSpec.shared_examples "Dead jobs" do |dead_jobs_klass, name|
           args: [
             {
               arguments: [
-                { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee.id}" },
+                { trainee_id: { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee.id}" } },
               ],
             },
           ],


### PR DESCRIPTION
### Context

[Error with Dead Jobs](7728-error-with-dead-jobs)

Some jobs had the global id nested inside a Hash which resulted in the reported error.

ex.

`{"trainee"=>{"_aj_globalid"=>"gid://register-trainee-teachers/Trainee/:trainee_id"}`

### Changes proposed in this pull request

* Account for keyword arguments when accessing `_aj_globalid`


### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
