### PR TITLE
[7740] Filter existing duplicates in trainee duplicate checks

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -356,6 +356,7 @@ class Trainee < ApplicationRecord
         start_academic_cycle_id: trainee.start_academic_cycle_id,
       )
   }
+  scope :not_marked_as_duplicate, -> { where.not(id: PotentialDuplicateTrainee.select(:trainee_id)) }
 
   audited associated_with: :provider
   has_associated_audits

--- a/app/services/trainees/find_duplicates_of_hesa_trainee.rb
+++ b/app/services/trainees/find_duplicates_of_hesa_trainee.rb
@@ -17,7 +17,7 @@ module Trainees
     attr_reader :trainee
 
     def potential_duplicates
-      Trainee.potential_duplicates_of(trainee)
+      Trainee.potential_duplicates_of(trainee).not_marked_as_duplicate
     end
 
     def confirmed_duplicate?(duplicate_trainee)


### PR DESCRIPTION
### Context
We have introduced trainee duplicate checking at the point of import from HESA and a new 'HESA duplicate trainees' page in sysadmin. There is a bug. Duplicate groups are repeated on the 'HESA duplicate trainees' page.

### Changes proposed in this pull request
- Filter out pre-existing duplicates when checking for duplicates at the point of import from HESA
- Amend tests to reflect these changes

### Guidance to review
We will need a follow up to clean up repeated records in the DB. This can probably be done manually once the code fix is deployed.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
