### PR TITLE
[7727] - Handle visiting lead partners / employing schools edit page by url

### DIFF
--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -2,6 +2,7 @@
 
 module Trainees
   class EmployingSchoolsController < BaseController
+    before_action :employing_school_applicable
     before_action :load_schools
 
     helper_method :query
@@ -50,6 +51,12 @@ module Trainees
 
     def index_or_edit_page
       @employing_school_form.search_results_found? || @employing_school_form.no_results_searching_again? ? :index : :edit
+    end
+
+    def employing_school_applicable
+      if trainee.employing_school_not_applicable?
+        redirect_to(edit_trainee_employing_schools_details_path(trainee))
+      end
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/lead_partners_controller.rb
+++ b/app/controllers/trainees/lead_partners_controller.rb
@@ -2,6 +2,7 @@
 
 module Trainees
   class LeadPartnersController < BaseController
+    before_action :lead_partner_applicable
     before_action :validate_form_completeness
 
     helper_method :query
@@ -48,6 +49,12 @@ module Trainees
 
     def index_or_edit_page
       @lead_partner_form.search_results_found? || @lead_partner_form.no_results_searching_again? ? :index : :edit
+    end
+
+    def lead_partner_applicable
+      if trainee.lead_partner_not_applicable?
+        redirect_to(edit_trainee_lead_partners_details_path(trainee))
+      end
     end
 
     def authorize_trainee

--- a/app/forms/schools/form.rb
+++ b/app/forms/schools/form.rb
@@ -12,8 +12,6 @@ module Schools
 
     attr_accessor(*NON_TRAINEE_FIELDS)
 
-    validate :both_fields_are_not_selected
-
     validates :query,
               presence: true,
               length: {
@@ -106,12 +104,6 @@ module Schools
 
     def school_validation_required?
       school_applicable? && (non_search_validation? || (search_results_found? && results_search_again_query.blank?))
-    end
-
-    def both_fields_are_not_selected
-      if params[:query].present? && school_not_applicable?
-        errors.add(:query, :both_fields_are_present)
-      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1884,7 +1884,6 @@ en:
           attributes:
             query:
               blank: Enter a school unique reference number (URN), name or postcode
-              both_fields_are_present: Select an employing school or select employing school not applicable
             employing_school_id:
               blank: Select an employing school or search again
             results_search_again_query:
@@ -1901,7 +1900,6 @@ en:
           attributes:
             query:
               blank: Enter a partner unique reference number (URN), name or postcode
-              both_fields_are_present: Select a lead school or select lead school not applicable
             lead_partner_id:
               blank: Select a lead partner or search again
             results_search_again_query:

--- a/spec/features/trainee_actions/add_lead_partner_and_employing_school_spec.rb
+++ b/spec/features/trainee_actions/add_lead_partner_and_employing_school_spec.rb
@@ -65,6 +65,10 @@ feature "add lead partner and employing school" do
     and_i_see_the_not_applicable_employing_school_radio_option(false)
     and_i_choose_the_not_applicable_employing_school_option(true)
     and_i_click_on_continue
+    when_i_try_to_visit_the_edit_employing_school_page_by_url
+    then_i_see_the_edit_employing_school_details_page
+    and_i_see_the_not_applicable_employing_school_radio_option(true)
+    and_i_click_on_continue
     then_i_see_the_confirm_my_details_page
     when_i_confirm_my_details
     then_the_lead_and_employing_schools_section_is_marked_completed
@@ -81,6 +85,10 @@ feature "add lead partner and employing school" do
     and_i_choose_the_not_applicable_lead_partner_option(true)
     and_i_click_on_continue
     then_i_see_the_edit_employing_school_details_page
+    when_i_try_to_visit_the_lead_partner_edit_page_by_url
+    then_i_see_the_edit_lead_partner_details_page
+    and_i_choose_the_not_applicable_lead_partner_option(true)
+    and_i_click_on_continue
     and_i_see_the_not_applicable_employing_school_radio_option(false)
     and_i_choose_the_not_applicable_employing_school_option(false)
     and_i_click_on_continue
@@ -229,4 +237,14 @@ feature "add lead partner and employing school" do
   def when_i_click_on_change_lead_partner
     confirm_details_page.change.click
   end
+
+  def when_i_try_to_visit_the_edit_employing_school_page_by_url
+    employing_schools_search_page.load(trainee_id: trainee.slug)
+  end
+
+  def when_i_try_to_visit_the_lead_partner_edit_page_by_url
+    edit_lead_partner_page.load(trainee_id: trainee.slug)
+  end
+
+  alias_method :then_i_see_the_edit_lead_partner_details_page, :and_i_see_the_edit_lead_partner_details_page
 end

--- a/spec/forms/partners/lead_partner_form_spec.rb
+++ b/spec/forms/partners/lead_partner_form_spec.rb
@@ -43,26 +43,6 @@ module Partners
       end
     end
 
-    context "school chosen but also marked as not applicable" do
-      let(:params) { { "lead_partner_id" => "1", "lead_partner_not_applicable" => "1", query: "school" } }
-
-      it "returns an error" do
-        expect(subject.errors[:query]).to include(
-          I18n.t("activemodel.errors.models.partners/lead_partner_form.attributes.query.both_fields_are_present"),
-        )
-      end
-    end
-
-    context "school not chosen, but query present and also marked as not applicable" do
-      let(:params) { { "lead_partner_not_applicable" => "1", query: "school" } }
-
-      it "returns an error" do
-        expect(subject.errors[:query]).to include(
-          I18n.t("activemodel.errors.models.partners/lead_partner_form.attributes.query.both_fields_are_present"),
-        )
-      end
-    end
-
     describe "#stash" do
       it "uses FormStore to temporarily save the fields under a key combination of trainee ID and lead_partner" do
         expect(form_store).to receive(:set).with(trainee.id, :lead_partner, subject.fields)

--- a/spec/forms/schools/employing_school_form_spec.rb
+++ b/spec/forms/schools/employing_school_form_spec.rb
@@ -63,27 +63,5 @@ module Schools
         )
       end
     end
-
-    context "school chosen but also marked as not applicable" do
-      let(:form_name) { school_id_key.sub("id", "form") }
-      let(:params) { { school_id_key => "1", not_applicable => "1", query: "school" } }
-
-      it "returns an error" do
-        expect(subject.errors[:query]).to include(
-          I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.query.both_fields_are_present"),
-        )
-      end
-    end
-
-    context "school not chosen, but query present and also marked as not applicable" do
-      let(:form_name) { school_id_key.sub("id", "form") }
-      let(:params) { { not_applicable => "1", query: "school" } }
-
-      it "returns an error" do
-        expect(subject.errors[:query]).to include(
-          I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.query.both_fields_are_present"),
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
### Context

[Handle visiting lead partners / employing schools edit page by url](https://trello.com/c/EUdJZd8J/7727-handle-visiting-lead-partners-employing-schools-edit-page-by-url)

### Changes proposed in this pull request

- Redirect to `trainees/:trainee_id/lead-partners/details/edit` If a user attempts to visit `trainees/:trainee_id/lead-partners/edit` and `lead_partner_not_applicable` is set to `true` 
- Redirect to `trainees/:trainee_id/employing-schools/details/edit` If a user attempts to visit `trainees/:trainee_id/employing-schools/edit` and `employing_school_not_applicable` is set to `true` 
- Remove `both_fields_are_not_selected` validation

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
