### PR TITLE
[7744] Create upload summary page part 2

### DIFF
--- a/app/controllers/bulk_update/trainees/submissions_controller.rb
+++ b/app/controllers/bulk_update/trainees/submissions_controller.rb
@@ -7,9 +7,7 @@ module BulkUpdate
       before_action { require_feature_flag(:bulk_add_trainees) }
 
       def show
-        @bulk_update_trainee_upload = organisation.bulk_update_trainee_uploads.find_by(id: params[:id])
-
-        redirect_to(not_found_path) unless @bulk_update_trainee_upload
+        @bulk_update_trainee_upload = organisation.bulk_update_trainee_uploads.find(params[:id])
       end
 
       def create
@@ -18,10 +16,7 @@ module BulkUpdate
         @bulk_add_trainee_submit_form.save
 
         # TODO: Handle failures/errors when saving
-
         redirect_to(bulk_update_trainees_submission_path(@bulk_update_trainee_upload))
-      rescue ActiveRecord::RecordNotFound
-        redirect_to(not_found_path)
       end
 
     private

--- a/app/controllers/bulk_update/trainees/submissions_controller.rb
+++ b/app/controllers/bulk_update/trainees/submissions_controller.rb
@@ -23,7 +23,7 @@ module BulkUpdate
         @bulk_add_trainee_submit_form.save
 
         # TODO: Handle failures/errors when saving
-        redirect_to(bulk_update_trainees_submission_path(@bulk_update_trainee_upload))
+        redirect_to(bulk_update_trainees_submission_path(bulk_update_trainee_upload))
       end
 
     private

--- a/app/controllers/bulk_update/trainees/submissions_controller.rb
+++ b/app/controllers/bulk_update/trainees/submissions_controller.rb
@@ -7,12 +7,14 @@ module BulkUpdate
       before_action { require_feature_flag(:bulk_add_trainees) }
 
       def show
-        @bulk_update_trainee_upload = organisation.bulk_update_trainee_uploads.find(params[:id])
+        authorize(bulk_update_trainee_upload)
       end
 
       def create
-        @bulk_update_trainee_upload = organisation.bulk_update_trainee_uploads.find(params[:id])
-        @bulk_add_trainee_submit_form = BulkUpdate::BulkAddTraineesSubmitForm.new(upload: @bulk_update_trainee_upload)
+        @bulk_add_trainee_submit_form = BulkUpdate::BulkAddTraineesSubmitForm.new(
+          upload: authorize(bulk_update_trainee_upload),
+        )
+
         @bulk_add_trainee_submit_form.save
 
         # TODO: Handle failures/errors when saving
@@ -20,6 +22,10 @@ module BulkUpdate
       end
 
     private
+
+      def bulk_update_trainee_upload
+        @bulk_update_trainee_upload ||= policy_scope(BulkUpdate::TraineeUpload).find(params[:id])
+      end
 
       def organisation
         @organisation ||= current_user.organisation

--- a/app/controllers/bulk_update/trainees/submissions_controller.rb
+++ b/app/controllers/bulk_update/trainees/submissions_controller.rb
@@ -3,16 +3,21 @@
 module BulkUpdate
   module Trainees
     class SubmissionsController < ApplicationController
-      before_action { check_for_provider }
       before_action { require_feature_flag(:bulk_add_trainees) }
 
       def show
-        authorize(bulk_update_trainee_upload)
+        authorize(
+          bulk_update_trainee_upload,
+          policy_class: BulkUpdate::Submissions::TraineeUploadPolicy,
+        )
       end
 
       def create
         @bulk_add_trainee_submit_form = BulkUpdate::BulkAddTraineesSubmitForm.new(
-          upload: authorize(bulk_update_trainee_upload),
+          upload: authorize(
+            bulk_update_trainee_upload,
+            policy_class: BulkUpdate::Submissions::TraineeUploadPolicy,
+          ),
         )
 
         @bulk_add_trainee_submit_form.save
@@ -25,14 +30,6 @@ module BulkUpdate
 
       def bulk_update_trainee_upload
         @bulk_update_trainee_upload ||= policy_scope(BulkUpdate::TraineeUpload).find(params[:id])
-      end
-
-      def organisation
-        @organisation ||= current_user.organisation
-      end
-
-      def check_for_provider
-        redirect_to(root_path) unless organisation.is_a?(Provider)
       end
     end
   end

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -7,10 +7,8 @@ module BulkUpdate
       before_action { require_feature_flag(:bulk_add_trainees) }
 
       def show
-        @bulk_update_trainee_upload = organisation
-          .bulk_update_trainee_uploads
-          .includes(:row_errors)
-          .find(params[:id])
+        @bulk_update_trainee_upload = policy_scope(BulkUpdate::TraineeUpload)
+          .includes(:row_errors).find(params[:id])
       end
 
       def new

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -7,7 +7,10 @@ module BulkUpdate
       before_action { require_feature_flag(:bulk_add_trainees) }
 
       def show
-        @bulk_update_trainee_upload = organisation.bulk_update_trainee_uploads.find(params[:id])
+        @bulk_update_trainee_upload = organisation
+          .bulk_update_trainee_uploads
+          .includes(:row_errors)
+          .find(params[:id])
       end
 
       def new

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -7,9 +7,7 @@ module BulkUpdate
       before_action { require_feature_flag(:bulk_add_trainees) }
 
       def show
-        @bulk_update_trainee_upload = organisation.bulk_update_trainee_uploads.find_by(id: params[:id])
-
-        redirect_to(not_found_path) unless @bulk_update_trainee_upload
+        @bulk_update_trainee_upload = organisation.bulk_update_trainee_uploads.find(params[:id])
       end
 
       def new
@@ -27,6 +25,7 @@ module BulkUpdate
         if @bulk_add_trainee_upload_form.valid?
           # TODO: Dry run method
           upload = @bulk_add_trainee_upload_form.save
+
           redirect_to(bulk_update_trainees_upload_path(upload))
         else
           render(:new)
@@ -36,11 +35,7 @@ module BulkUpdate
     private
 
       def file
-        @file ||= create_params["file"]
-      end
-
-      def create_params
-        params.require(:bulk_update_bulk_add_trainees_upload_form).permit(:file)
+        @file ||= params.dig(:bulk_update_bulk_add_trainees_upload_form, :file)
       end
 
       def organisation

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -41,7 +41,11 @@ module BulkUpdate
     private
 
       def file
-        @file ||= params.dig(:bulk_update_bulk_add_trainees_upload_form, :file)
+        @file ||= create_params["file"]
+      end
+
+      def create_params
+        params.fetch(:bulk_update_bulk_add_trainees_upload_form, {}).permit(:file)
       end
     end
   end

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -23,7 +23,7 @@ module BulkUpdate
       def create
         @bulk_add_trainee_upload_form = BulkUpdate::BulkAddTraineesUploadForm.new(
           provider: current_user.organisation,
-          file: file,
+          file: upload_params[:file],
         )
 
         authorize(@bulk_add_trainee_upload_form.upload)
@@ -40,11 +40,7 @@ module BulkUpdate
 
     private
 
-      def file
-        @file ||= create_params["file"]
-      end
-
-      def create_params
+      def upload_params
         params.fetch(:bulk_update_bulk_add_trainees_upload_form, {}).permit(:file)
       end
     end

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -3,25 +3,30 @@
 module BulkUpdate
   module Trainees
     class UploadsController < ApplicationController
-      before_action { check_for_provider }
       before_action { require_feature_flag(:bulk_add_trainees) }
 
       def show
         @bulk_update_trainee_upload = policy_scope(BulkUpdate::TraineeUpload)
           .includes(:row_errors).find(params[:id])
+
+        authorize(@bulk_update_trainee_upload)
       end
 
       def new
         @bulk_add_trainee_upload_form = BulkUpdate::BulkAddTraineesUploadForm.new(
-          provider: organisation,
+          provider: current_user.organisation,
         )
+
+        authorize(@bulk_add_trainee_upload_form.upload)
       end
 
       def create
         @bulk_add_trainee_upload_form = BulkUpdate::BulkAddTraineesUploadForm.new(
-          provider: organisation,
+          provider: current_user.organisation,
           file: file,
         )
+
+        authorize(@bulk_add_trainee_upload_form.upload)
 
         if @bulk_add_trainee_upload_form.valid?
           # TODO: Dry run method
@@ -37,14 +42,6 @@ module BulkUpdate
 
       def file
         @file ||= params.dig(:bulk_update_bulk_add_trainees_upload_form, :file)
-      end
-
-      def organisation
-        @organisation ||= current_user.organisation
-      end
-
-      def check_for_provider
-        redirect_to(root_path) unless current_user.hei_provider?
       end
     end
   end

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -29,7 +29,7 @@ module BulkUpdate
           # TODO: Dry run method
           upload = @bulk_add_trainee_upload_form.save
 
-          redirect_to(bulk_update_trainees_upload_path(upload))
+          redirect_to(bulk_update_trainees_upload_path(upload), flash: { success: t(".success") })
         else
           render(:new)
         end

--- a/app/forms/bulk_update/bulk_add_trainees_submit_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_submit_form.rb
@@ -15,8 +15,9 @@ module BulkUpdate
     def save
       return false unless valid? && upload.validated?
 
-      BulkUpdate::AddTrainees::ImportRowsJob.perform_later(upload)
       upload.in_progress!
+
+      BulkUpdate::AddTrainees::ImportRowsJob.perform_later(upload)
     end
   end
 end

--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -23,9 +23,7 @@ module BulkUpdate
     def save
       return false unless valid?
 
-      upload.provider           = provider
-      upload.file               = file
-      upload.number_of_trainees = csv&.count
+      upload.attributes = upload_attributes
       upload.save!
 
       BulkUpdate::AddTrainees::ImportRowsJob.perform_later(id: upload.id)
@@ -42,6 +40,15 @@ module BulkUpdate
     end
 
   private
+
+    def upload_attributes
+      {
+        provider: provider,
+        file: file,
+        number_of_trainees: csv&.count,
+        status: :pending,
+      }
+    end
 
     def build_upload
       BulkUpdate::TraineeUpload.new(

--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -46,7 +46,6 @@ module BulkUpdate
         provider: provider,
         file: file,
         number_of_trainees: csv&.count,
-        status: :pending,
       }
     end
 

--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -20,8 +20,7 @@ module BulkUpdate
       @upload   = build_upload
 
       if file
-        @upload.file      = File.read(file)
-        @upload.file_name = file.original_filename
+        @upload.file = file
       end
     end
 

--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -23,6 +23,7 @@ module BulkUpdate
     def save
       return false unless valid?
 
+      upload.provider           = provider
       upload.file               = file
       upload.number_of_trainees = csv&.count
       upload.save!
@@ -45,7 +46,6 @@ module BulkUpdate
     def build_upload
       BulkUpdate::TraineeUpload.new(
         status: :pending,
-        provider:,
       )
     end
 

--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -26,7 +26,7 @@ module BulkUpdate
       upload.attributes = upload_attributes
       upload.save!
 
-      BulkUpdate::AddTrainees::ImportRowsJob.perform_later(id: upload.id)
+      BulkUpdate::AddTrainees::ImportRowsJob.perform_later(upload)
 
       upload
     end

--- a/app/models/bulk_update/row_error.rb
+++ b/app/models/bulk_update/row_error.rb
@@ -14,4 +14,9 @@
 #
 class BulkUpdate::RowError < ApplicationRecord
   belongs_to :errored_on, polymorphic: true
+
+  enum :error_type, {
+    duplicate: "duplicate",
+    validation: "validation",
+  }
 end

--- a/app/models/bulk_update/row_error.rb
+++ b/app/models/bulk_update/row_error.rb
@@ -12,6 +12,10 @@
 #  updated_at      :datetime         not null
 #  errored_on_id   :bigint
 #
+# Indexes
+#
+#  index_bulk_update_row_errors_on_error_type  (error_type)
+#
 class BulkUpdate::RowError < ApplicationRecord
   belongs_to :errored_on, polymorphic: true
 

--- a/app/models/bulk_update/row_error.rb
+++ b/app/models/bulk_update/row_error.rb
@@ -5,6 +5,7 @@
 # Table name: bulk_update_row_errors
 #
 #  id              :bigint           not null, primary key
+#  error_type      :string           default("validation"), not null
 #  errored_on_type :string
 #  message         :string
 #  created_at      :datetime         not null

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -34,5 +34,8 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
            class_name: "BulkUpdate::TraineeUploadRow",
            foreign_key: :bulk_update_trainee_upload_id,
            inverse_of: :trainee_upload,
+           dependent: :destroy
+
+  has_many :row_errors, through: :trainee_upload_rows
   has_one_attached :file
 end

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -30,11 +30,9 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
   }
 
   belongs_to :provider
-  has_many :bulk_update_trainee_upload_rows,
+  has_many :trainee_upload_rows,
            class_name: "BulkUpdate::TraineeUploadRow",
            foreign_key: :bulk_update_trainee_upload_id,
-           inverse_of: :bulk_update_trainee_upload,
-           dependent: :destroy
-
+           inverse_of: :trainee_upload,
   has_one_attached :file
 end

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -38,4 +38,6 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
 
   has_many :row_errors, through: :trainee_upload_rows
   has_one_attached :file
+
+  delegate :filename, :download, :attach, to: :file
 end

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -21,6 +21,14 @@
 #
 
 class BulkUpdate::TraineeUpload < ApplicationRecord
+  enum :status, {
+    pending: "pending",
+    validated: "validated",
+    in_progress: "in_progress",
+    succeeded: "succeeded",
+    failed: "failed",
+  }
+
   belongs_to :provider
   has_many :bulk_update_trainee_upload_rows,
            class_name: "BulkUpdate::TraineeUploadRow",
@@ -29,12 +37,4 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
            dependent: :destroy
 
   has_one_attached :file
-
-  enum :status, {
-    pending: "pending",
-    validated: "validated",
-    in_progress: "in_progress",
-    succeeded: "succeeded",
-    failed: "failed",
-  }
 end

--- a/app/models/bulk_update/trainee_upload_row.rb
+++ b/app/models/bulk_update/trainee_upload_row.rb
@@ -30,4 +30,6 @@ class BulkUpdate::TraineeUploadRow < ApplicationRecord
 
   validates :row_number, presence: true
   validates :data, presence: true
+
+  scope :without_errors, -> { left_joins(:row_errors).where(row_errors: { errored_on_id: nil }) }
 end

--- a/app/models/bulk_update/trainee_upload_row.rb
+++ b/app/models/bulk_update/trainee_upload_row.rb
@@ -21,7 +21,9 @@
 #  fk_rails_...  (bulk_update_trainee_upload_id => bulk_update_trainee_uploads.id)
 #
 class BulkUpdate::TraineeUploadRow < ApplicationRecord
-  belongs_to :bulk_update_trainee_upload, class_name: "BulkUpdate::TraineeUpload"
+  belongs_to :trainee_upload,
+             class_name: "BulkUpdate::TraineeUpload",
+             foreign_key: :bulk_update_trainee_upload_id
 
   has_many :row_errors, as: :errored_on, class_name: "BulkUpdate::RowError", dependent: :destroy
 

--- a/app/models/bulk_update/trainee_upload_row.rb
+++ b/app/models/bulk_update/trainee_upload_row.rb
@@ -23,7 +23,8 @@
 class BulkUpdate::TraineeUploadRow < ApplicationRecord
   belongs_to :trainee_upload,
              class_name: "BulkUpdate::TraineeUpload",
-             foreign_key: :bulk_update_trainee_upload_id
+             foreign_key: :bulk_update_trainee_upload_id,
+             inverse_of: :trainee_upload_rows
 
   has_many :row_errors, as: :errored_on, class_name: "BulkUpdate::RowError", dependent: :destroy
 

--- a/app/policies/bulk_update/submissions/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/submissions/trainee_upload_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module Submissions
+    class TraineeUploadPolicy < BulkUpdate::TraineeUploadPolicy
+      def show?
+        super && (trainee_upload.submitted? || trainee_upload.succeeded?)
+      end
+
+      def create?
+        super && trainee_upload.validated?
+      end
+    end
+  end
+end

--- a/app/policies/bulk_update/submissions/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/submissions/trainee_upload_policy.rb
@@ -4,7 +4,7 @@ module BulkUpdate
   module Submissions
     class TraineeUploadPolicy < BulkUpdate::TraineeUploadPolicy
       def show?
-        super && (trainee_upload.submitted? || trainee_upload.succeeded?)
+        super && (trainee_upload.in_progress? || trainee_upload.succeeded?)
       end
 
       def create?

--- a/app/policies/bulk_update/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/trainee_upload_policy.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  class TraineeUploadPolicy
+    class Scope
+      attr_reader :user, :scope
+
+      def initialize(user, scope)
+        @user  = user
+        @scope = scope
+      end
+
+      def resolve
+        scope.where(provider: user.organisation)
+      end
+    end
+
+    attr_reader :user, :trainee_upload
+
+    def initialize(user, trainee_upload)
+      @user           = user
+      @trainee_upload = trainee_upload
+    end
+
+    def show?
+      trainee_upload.submitted? || trainee_upload.succeeded?
+    end
+
+    def create?
+      trainee_upload.validated?
+    end
+  end
+end

--- a/app/policies/bulk_update/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/trainee_upload_policy.rb
@@ -22,12 +22,11 @@ module BulkUpdate
       @trainee_upload = trainee_upload
     end
 
-    def show?
-      trainee_upload.submitted? || trainee_upload.succeeded?
+    def new?
+      user.provider?
     end
 
-    def create?
-      trainee_upload.validated?
-    end
+    alias_method :show?, :new?
+    alias_method :create?, :new?
   end
 end

--- a/app/policies/bulk_update/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/trainee_upload_policy.rb
@@ -23,7 +23,7 @@ module BulkUpdate
     end
 
     def new?
-      user.provider?
+      user.hei_provider?
     end
 
     alias_method :show?, :new?

--- a/app/services/bulk_update/add_trainees/import_rows.rb
+++ b/app/services/bulk_update/add_trainees/import_rows.rb
@@ -87,20 +87,20 @@ module BulkUpdate
             end
           end
 
-          ActiveRecord::Base.transaction do |_transaction|
+          ActiveRecord::Base.transaction(requires_new: true) do
             results = trainee_upload.trainee_upload_rows.map do |upload_row|
               BulkUpdate::AddTrainees::ImportRow.call(row: upload_row.data, current_provider: current_provider)
             end
 
             # Commit or rollback the transaction depending on whether all rows were error free
-            if all_succeeded?(results)
+            if results.all?(&:success)
               trainee_upload.succeeded! unless dry_run
             else
               # TODO: copy any errors into `trainee_upload`
               success = false
-              raise(ActiveRecord::Rollback)
             end
-            raise(ActiveRecord::Rollback) if dry_run
+
+            raise(ActiveRecord::Rollback) if dry_run || !success
           end
 
           trainee_upload.validated! if dry_run && success
@@ -114,14 +114,10 @@ module BulkUpdate
         raise
       end
 
-      def current_provider
-        @current_provider ||= trainee_upload.provider
-      end
-
     private
 
-      def all_succeeded?(results)
-        results.all?
+      def current_provider
+        @current_provider ||= trainee_upload.provider
       end
     end
   end

--- a/app/services/bulk_update/add_trainees/import_rows.rb
+++ b/app/services/bulk_update/add_trainees/import_rows.rb
@@ -80,7 +80,7 @@ module BulkUpdate
           if dry_run
             CSV.parse(trainee_upload.file.download, headers: true).map.with_index do |row, index|
               BulkUpdate::TraineeUploadRow.create!(
-                bulk_update_trainee_upload: trainee_upload,
+                trainee_upload: trainee_upload,
                 data: row.to_h,
                 row_number: index + 1,
               )

--- a/app/services/bulk_update/add_trainees/import_rows.rb
+++ b/app/services/bulk_update/add_trainees/import_rows.rb
@@ -88,7 +88,7 @@ module BulkUpdate
           end
 
           ActiveRecord::Base.transaction do |_transaction|
-            results = trainee_upload.bulk_update_trainee_upload_rows.map do |upload_row|
+            results = trainee_upload.trainee_upload_rows.map do |upload_row|
               BulkUpdate::AddTrainees::ImportRow.call(row: upload_row.data, current_provider: current_provider)
             end
 

--- a/app/services/bulk_update/add_trainees/validate_file.rb
+++ b/app/services/bulk_update/add_trainees/validate_file.rb
@@ -55,7 +55,7 @@ module BulkUpdate
         file.tempfile.rewind
         CSVSafe.new(file.tempfile, **BulkUpdate::BulkAddTraineesUploadForm::CSV_ARGS).read
         true
-      rescue StandardError
+      rescue CSV::MalformedCSVError
         record.errors.add(:file, :is_not_csv)
         false
       end

--- a/app/services/bulk_update/recommendations_uploads/validate_trainee.rb
+++ b/app/services/bulk_update/recommendations_uploads/validate_trainee.rb
@@ -79,7 +79,7 @@ module BulkUpdate
       end
 
       def missing_data_validator
-        @missing_data_validator ||= Submissions::MissingDataValidator.new(trainee:)
+        @missing_data_validator ||= ::Submissions::MissingDataValidator.new(trainee:)
       end
 
       def found_with

--- a/app/views/bulk_update/bulk_updates/index.html.erb
+++ b/app/views/bulk_update/bulk_updates/index.html.erb
@@ -11,7 +11,7 @@
       Bulk updates
     </h1>
 
-    <% if FeatureService.enabled?(:bulk_add_trainees) && current_user.hei_provider? %>
+    <% if FeatureService.enabled?(:bulk_add_trainees) && policy(BulkUpdate::TraineeUpload).new? %>
       <p class="govuk-body">
         Make changes to multiple trainee records at the same time. You can:
       </p>

--- a/app/views/bulk_update/trainees/uploads/new.html.erb
+++ b/app/views/bulk_update/trainees/uploads/new.html.erb
@@ -76,6 +76,7 @@
       </div>
 
       <%= f.govuk_file_field(:file, label: { hidden: true }, accept: ".csv") %>
+
       <%= f.govuk_submit("Upload records") %>
     <% end %>
   </div>

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -11,31 +11,44 @@
       Upload Summary
     </h1>
 
-    <% if @bulk_update_trainee_upload.failed? %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          The upload failed because:
-        </h2>
-      </div>
-    <% else %>
-      <p class="govuk-body">
+    <p class="govuk-body">
       You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.number_of_trainees, "trainee") %>.
-      </p>
+    </p>
 
-      <p class="govuk-body">
-        It included:
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
+    <p class="govuk-body">
+      It included:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <% if @bulk_update_trainee_upload.trainee_upload_rows.without_errors.present? %>
         <li>
-          <%= pluralize(@bulk_update_trainee_upload.number_of_trainees, "trainee") %> who can be added
+          <%= pluralize(@bulk_update_trainee_upload.trainee_upload_rows.without_errors.size, "trainee") %> who can be added
         </li>
-      </ul>
-      <%= register_form_with(
-        model: @bulk_add_trainee_form,
-        url: bulk_update_trainees_submissions_path(id: @bulk_update_trainee_upload.id),
-      ) do |f| %>
-        <%= f.govuk_submit("Submit") %>
       <% end %>
+
+      <% if @bulk_update_trainee_upload.row_errors.duplicate.present? %>
+        <li>
+          <%= pluralize(@bulk_update_trainee_upload.row_errors.duplicate.size, "trainee") %>
+          who will not be added, as they already exist in Register
+        </li>
+      <% end %>
+
+      <% if @bulk_update_trainee_upload.row_errors.validation.present? %>
+        <li>
+          <%= pluralize(@bulk_update_trainee_upload.row_errors.validation.size, "trainee") %>
+          with errors in their details
+        </li>
+      <% end %>
+
+    </ul>
+
+    <p class="govuk-body">You need to review the errors before you can add new trainees</p>
+
+    <%= register_form_with(
+      model: @bulk_add_trainee_form,
+      url: bulk_update_trainees_submissions_path(id: @bulk_update_trainee_upload.id),
+    ) do |f| %>
+      <%= f.govuk_submit("Submit") %>
     <% end %>
   </div>
 </div>

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -6,49 +6,79 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-xl"><%= organisation_name %></span>
-      Upload Summary
-    </h1>
+    <% if @bulk_update_trainee_upload.pending? %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl"><%= organisation_name %></span>
+        Your file is being processed
+      </h1>
 
-    <p class="govuk-body">
-      You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.number_of_trainees, "trainee") %>.
-    </p>
+      <p class="govuk-body">
+        We're currently processing <%= @bulk_update_trainee_upload.file_name %>.
+      </p>
 
-    <p class="govuk-body">
-      It included:
-    </p>
+      <p class="govuk-body">
+        This is taking longer than usual
+      </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <% if @bulk_update_trainee_upload.trainee_upload_rows.without_errors.present? %>
-        <li>
-          <%= pluralize(@bulk_update_trainee_upload.trainee_upload_rows.without_errors.size, "trainee") %> who can be added
-        </li>
-      <% end %>
+      <p class="govuk-body">
+        You'll receive and email to tell you when this is complete.
+      </p>
 
-      <% if @bulk_update_trainee_upload.row_errors.duplicate.present? %>
-        <li>
-          <%= pluralize(@bulk_update_trainee_upload.row_errors.duplicate.size, "trainee") %>
-          who will not be added, as they already exist in Register
-        </li>
-      <% end %>
+      <p class="govuk-body">
+        You can also check the <%= link_to "status of new trainee files" %>.
+      </p>
 
-      <% if @bulk_update_trainee_upload.row_errors.validation.present? %>
-        <li>
-          <%= pluralize(@bulk_update_trainee_upload.row_errors.validation.size, "trainee") %>
-          with errors in their details
-        </li>
-      <% end %>
+      <p class="govuk-body">
+        <%= link_to "Back to bulk updates page" %>
+      </p>
+    <% else %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl"><%= organisation_name %></span>
+        Upload Summary
+      </h1>
 
-    </ul>
+      <p class="govuk-body">
+        You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.number_of_trainees, "trainee") %>.
+      </p>
 
-    <p class="govuk-body">You need to review the errors before you can add new trainees</p>
+      <p class="govuk-body">
+        It included:
+      </p>
 
-    <%= register_form_with(
-      model: @bulk_add_trainee_form,
-      url: bulk_update_trainees_submissions_path(id: @bulk_update_trainee_upload.id),
-    ) do |f| %>
-      <%= f.govuk_submit("Submit") %>
+      <ul class="govuk-list govuk-list--bullet">
+        <% if @bulk_update_trainee_upload.trainee_upload_rows.without_errors.present? %>
+          <li>
+            <%= pluralize(@bulk_update_trainee_upload.trainee_upload_rows.without_errors.size, "trainee") %> who can be added
+          </li>
+        <% end %>
+
+        <% if @bulk_update_trainee_upload.row_errors.duplicate.present? %>
+          <li>
+            <%= pluralize(@bulk_update_trainee_upload.row_errors.duplicate.size, "trainee") %>
+            who will not be added, as they already exist in Register
+          </li>
+        <% end %>
+
+        <% if @bulk_update_trainee_upload.row_errors.validation.present? %>
+          <li>
+            <%= pluralize(@bulk_update_trainee_upload.row_errors.validation.size, "trainee") %>
+            with errors in their details
+          </li>
+        <% end %>
+      </ul>
+
+      <% if @bulk_update_trainee_upload.row_errors.present? %>
+        <p class="govuk-body">You need to review the errors before you can add new trainees</p>
+
+        <%= govuk_link_to("Review errors", class: "govuk-button") %>
+      <% else %>
+        <%= register_form_with(
+          model: @bulk_add_trainee_form,
+          url: bulk_update_trainees_submissions_path(id: @bulk_update_trainee_upload.id),
+        ) do |f| %>
+          <%= f.govuk_submit("Submit") %>
+        <% end %>
     <% end %>
+  <% end %>
   </div>
 </div>

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -13,7 +13,7 @@
       </h1>
 
       <p class="govuk-body">
-        We're currently processing <%= @bulk_update_trainee_upload.file_name %>.
+        We're currently processing <%= @bulk_update_trainee_upload.filename %>.
       </p>
 
       <p class="govuk-body">

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -29,7 +29,7 @@
       </p>
 
       <p class="govuk-body">
-        <%= link_to "Back to bulk updates page" %>
+        <%= link_to "Back to bulk updates page", bulk_update_path %>
       </p>
     <% else %>
       <h1 class="govuk-heading-l">
@@ -79,6 +79,9 @@
           <%= f.govuk_submit("Submit") %>
         <% end %>
     <% end %>
+      <p class="govuk-body">
+        <%= link_to "Cancel bulk updates to records", bulk_update_path %>
+      </p>
   <% end %>
   </div>
 </div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -298,6 +298,7 @@ shared:
     - updated_at
     - errored_on_id
     - errored_on_type
+    - error_type
     - message
   :placements:
     - id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1988,6 +1988,12 @@ en:
     index:
       heading: News and updates
       contents: Contents
+
+  bulk_update:
+    trainees:
+      uploads:
+        create:
+          success: File uploaded
   system_admin:
     users:
       create:

--- a/db/migrate/20241101133718_add_error_type_to_bulk_update_row_error.rb
+++ b/db/migrate/20241101133718_add_error_type_to_bulk_update_row_error.rb
@@ -1,0 +1,7 @@
+class AddErrorTypeToBulkUpdateRowError < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :bulk_update_row_errors, :error_type, :string, default: "validation", null: false
+  end
+end

--- a/db/migrate/20241101133718_add_error_type_to_bulk_update_row_error.rb
+++ b/db/migrate/20241101133718_add_error_type_to_bulk_update_row_error.rb
@@ -3,5 +3,7 @@ class AddErrorTypeToBulkUpdateRowError < ActiveRecord::Migration[7.2]
 
   def change
     add_column :bulk_update_row_errors, :error_type, :string, default: "validation", null: false
+
+    add_index :bulk_update_row_errors, :error_type, algorithm: :concurrently
   end
 end

--- a/db/migrate/20241101133718_add_error_type_to_bulk_update_row_error.rb
+++ b/db/migrate/20241101133718_add_error_type_to_bulk_update_row_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddErrorTypeToBulkUpdateRowError < ActiveRecord::Migration[7.2]
   disable_ddl_transaction!
 

--- a/db/migrate/20241114153414_add_index_errored_on_id_errored_on_type_to_bulk_update_errors.rb
+++ b/db/migrate/20241114153414_add_index_errored_on_id_errored_on_type_to_bulk_update_errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexErroredOnIdErroredOnTypeToBulkUpdateErrors < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :bulk_update_row_errors, %i[errored_on_id errored_on_type], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -243,6 +243,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_01_133718) do
     t.string "errored_on_type"
     t.string "message"
     t.string "error_type", default: "validation", null: false
+    t.index ["error_type"], name: "index_bulk_update_row_errors_on_error_type"
   end
 
   create_table "bulk_update_trainee_upload_rows", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_01_133718) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_14_153414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -244,6 +244,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_01_133718) do
     t.string "message"
     t.string "error_type", default: "validation", null: false
     t.index ["error_type"], name: "index_bulk_update_row_errors_on_error_type"
+    t.index ["errored_on_id", "errored_on_type"], name: "idx_on_errored_on_id_errored_on_type_492045ed60"
   end
 
   create_table "bulk_update_trainee_upload_rows", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_30_160457) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_01_133718) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -242,6 +242,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_30_160457) do
     t.bigint "errored_on_id"
     t.string "errored_on_type"
     t.string "message"
+    t.string "error_type", default: "validation", null: false
   end
 
   create_table "bulk_update_trainee_upload_rows", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -666,10 +666,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_30_160457) do
     t.string "surname16"
     t.string "ttcid"
     t.string "hesa_committed_at"
-    t.string "previous_hesa_id"
     t.string "application_choice_id"
     t.string "itt_start_date"
     t.string "trainee_start_date"
+    t.string "previous_hesa_id"
     t.string "provider_trainee_id"
     t.string "lead_partner_urn"
     t.index ["hesa_id", "rec_id"], name: "index_hesa_students_on_hesa_id_and_rec_id", unique: true

--- a/spec/factories/bulk_update/trainee_upload_rows.rb
+++ b/spec/factories/bulk_update/trainee_upload_rows.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :bulk_update_trainee_upload_row, class: "BulkUpdate::TraineeUploadRow" do
-    association :trainee_upload, factory: :bulk_update_trainee_upload
+    trainee_upload factory: %i[bulk_update_trainee_upload]
 
     sequence(:row_number) { |n| n }
 
@@ -18,7 +18,7 @@ FactoryBot.define do
           :bulk_update_row_error,
           error_type: evaluator.error_type,
           errored_on: bulk_update_trainee_upload_row,
-          message: "An error has occured"
+          message: "An error has occured",
         )
       end
     end

--- a/spec/factories/bulk_update/trainee_upload_rows.rb
+++ b/spec/factories/bulk_update/trainee_upload_rows.rb
@@ -2,6 +2,25 @@
 
 FactoryBot.define do
   factory :bulk_update_trainee_upload_row, class: "BulkUpdate::TraineeUploadRow" do
-    bulk_update_trainee_upload { nil }
+    association :trainee_upload, factory: :bulk_update_trainee_upload
+
+    sequence(:row_number) { |n| n }
+
+    data { {}.to_json }
+
+    transient do
+      error_type { "validation" }
+    end
+
+    trait :with_errors do
+      after(:build) do |bulk_update_trainee_upload_row, evaluator|
+        create(
+          :bulk_update_row_error,
+          error_type: evaluator.error_type,
+          errored_on: bulk_update_trainee_upload_row,
+          message: "An error has occured"
+        )
+      end
+    end
   end
 end

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -36,8 +36,8 @@ FactoryBot.define do
       status { "validated" }
     end
 
-    trait :submitted do
-      status { "submitted" }
+    trait :in_progress do
+      status { "in_progress" }
     end
 
     trait :succeeded do

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -5,8 +5,9 @@ FactoryBot.define do
     provider
     status { nil }
     number_of_trainees { 5 }
-    after(:build) do |upload|
-      upload.file.attach(
+
+    after(:build) do |bulk_update_trainee_upload|
+      bulk_update_trainee_upload.attach(
         io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees.csv").open,
         filename: "five_trainees.csv",
       )
@@ -16,7 +17,7 @@ FactoryBot.define do
       validated
 
       after(:create) do |upload|
-        CSV.parse(upload.file.download, headers: true).map.with_index do |row, index|
+        CSV.parse(upload.download, headers: true).map.with_index do |row, index|
           create(
             :bulk_update_trainee_upload_row,
             trainee_upload: upload,
@@ -46,11 +47,15 @@ FactoryBot.define do
     trait :failed do
       status { "failed" }
 
-      file_name { "five_trainees_with_two_errors" }
-      file { Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").read }
-
       after(:build) do |bulk_update_trainee_upload|
-        CSV.parse(bulk_update_trainee_upload.file, headers: true).each_with_index do |row, index|
+        bulk_update_trainee_upload.attach(
+          io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open,
+          filename: "five_trainees_with_two_errors.csv",
+        )
+      end
+
+      after(:create) do |bulk_update_trainee_upload|
+        CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|
           if index < 3
             create(
               :bulk_update_trainee_upload_row,
@@ -76,11 +81,15 @@ FactoryBot.define do
     trait :failed_with_validation_errors do
       status { "failed" }
 
-      file_name { "five_trainees_with_two_errors" }
-      file { Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").read }
-
       after(:build) do |bulk_update_trainee_upload|
-        CSV.parse(bulk_update_trainee_upload.file, headers: true).each_with_index do |row, index|
+        bulk_update_trainee_upload.attach(
+          io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open,
+          filename: "five_trainees_with_two_errors.csv",
+        )
+      end
+
+      after(:create) do |bulk_update_trainee_upload|
+        CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|
           if index < 3
             create(
               :bulk_update_trainee_upload_row,
@@ -104,11 +113,15 @@ FactoryBot.define do
     trait :failed_with_duplicate_errors do
       status { "failed" }
 
-      file_name { "five_trainees_with_two_errors" }
-      file { Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").read }
-
       after(:build) do |bulk_update_trainee_upload|
-        CSV.parse(bulk_update_trainee_upload.file, headers: true).each_with_index do |row, index|
+        bulk_update_trainee_upload.attach(
+          io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open,
+          filename: "five_trainees_with_two_errors.csv",
+        )
+      end
+
+      after(:create) do |bulk_update_trainee_upload|
+        CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|
           if index < 3
             create(
               :bulk_update_trainee_upload_row,

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
         CSV.parse(upload.file.download, headers: true).map.with_index do |row, index|
           create(
             :bulk_update_trainee_upload_row,
-            bulk_update_trainee_upload: upload,
+            trainee_upload: upload,
             data: row.to_h,
             row_number: index + 1,
           )

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -22,6 +22,94 @@ FactoryBot.define do
             row_number: index + 1,
           )
         end
+
+      end
+    end
+
+    trait :failed do
+      status { "failed" }
+
+      file_name { "five_trainees_with_two_errors" }
+      file { Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").read }
+
+      after(:build) do |bulk_update_trainee_upload|
+        CSV.parse(bulk_update_trainee_upload.file, headers: true).each_with_index do |row, index|
+          if index < 3
+            create(
+              :bulk_update_trainee_upload_row,
+              :with_errors,
+              error_type: :duplicate,
+              trainee_upload: bulk_update_trainee_upload,
+              data: row.to_h,
+              row_number: index + 1
+            )
+          else
+            create(
+              :bulk_update_trainee_upload_row,
+              :with_errors,
+              trainee_upload: bulk_update_trainee_upload,
+              data: row.to_h,
+              row_number: index + 1
+            )
+          end
+        end
+      end
+    end
+
+    trait :failed_with_validation_errors do
+      status { "failed" }
+
+      file_name { "five_trainees_with_two_errors" }
+      file { Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").read }
+
+      after(:build) do |bulk_update_trainee_upload|
+        CSV.parse(bulk_update_trainee_upload.file, headers: true).each_with_index do |row, index|
+          if index < 3
+            create(
+              :bulk_update_trainee_upload_row,
+              trainee_upload: bulk_update_trainee_upload,
+              data: row.to_h,
+              row_number: index + 1
+            )
+          else
+            create(
+              :bulk_update_trainee_upload_row,
+              :with_errors,
+              trainee_upload: bulk_update_trainee_upload,
+              data: row.to_h,
+              row_number: index + 1
+            )
+          end
+        end
+      end
+    end
+
+    trait :failed_with_duplicate_errors do
+      status { "failed" }
+
+      file_name { "five_trainees_with_two_errors" }
+      file { Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").read }
+
+      after(:build) do |bulk_update_trainee_upload|
+        CSV.parse(bulk_update_trainee_upload.file, headers: true).each_with_index do |row, index|
+          if index < 3
+            create(
+              :bulk_update_trainee_upload_row,
+              trainee_upload: bulk_update_trainee_upload,
+              data: row.to_h,
+              row_number: index + 1
+            )
+          else
+            create(
+              :bulk_update_trainee_upload_row,
+              :with_errors,
+              error_type: :duplicate,
+              trainee_upload: bulk_update_trainee_upload,
+              data: row.to_h,
+              row_number: index + 1
+            )
+          end
+        end
       end
     end
   end

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -13,16 +13,24 @@ FactoryBot.define do
       )
     end
 
+    trait(:with_errors) do
+      after(:build) do |bulk_update_trainee_upload|
+        bulk_update_trainee_upload.attach(
+          io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open,
+          filename: "five_trainees_with_two_errors.csv",
+        )
+      end
+    end
+
     trait :with_rows do
       validated
 
       after(:create) do |upload|
-        CSV.parse(upload.download, headers: true).map.with_index do |row, index|
+        CSV.parse(upload.download, headers: true).each do |row|
           create(
             :bulk_update_trainee_upload_row,
             trainee_upload: upload,
             data: row.to_h,
-            row_number: index + 1,
           )
         end
       end
@@ -47,13 +55,6 @@ FactoryBot.define do
     trait :failed do
       status { "failed" }
 
-      after(:build) do |bulk_update_trainee_upload|
-        bulk_update_trainee_upload.attach(
-          io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open,
-          filename: "five_trainees_with_two_errors.csv",
-        )
-      end
-
       after(:create) do |bulk_update_trainee_upload|
         CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|
           if index < 3
@@ -63,7 +64,6 @@ FactoryBot.define do
               error_type: :duplicate,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1,
             )
           else
             create(
@@ -71,7 +71,6 @@ FactoryBot.define do
               :with_errors,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1,
             )
           end
         end
@@ -81,13 +80,6 @@ FactoryBot.define do
     trait :failed_with_validation_errors do
       status { "failed" }
 
-      after(:build) do |bulk_update_trainee_upload|
-        bulk_update_trainee_upload.attach(
-          io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open,
-          filename: "five_trainees_with_two_errors.csv",
-        )
-      end
-
       after(:create) do |bulk_update_trainee_upload|
         CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|
           if index < 3
@@ -95,7 +87,6 @@ FactoryBot.define do
               :bulk_update_trainee_upload_row,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1,
             )
           else
             create(
@@ -103,7 +94,6 @@ FactoryBot.define do
               :with_errors,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1,
             )
           end
         end
@@ -113,13 +103,6 @@ FactoryBot.define do
     trait :failed_with_duplicate_errors do
       status { "failed" }
 
-      after(:build) do |bulk_update_trainee_upload|
-        bulk_update_trainee_upload.attach(
-          io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open,
-          filename: "five_trainees_with_two_errors.csv",
-        )
-      end
-
       after(:create) do |bulk_update_trainee_upload|
         CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|
           if index < 3
@@ -127,7 +110,6 @@ FactoryBot.define do
               :bulk_update_trainee_upload_row,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1,
             )
           else
             create(
@@ -136,7 +118,6 @@ FactoryBot.define do
               error_type: :duplicate,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1,
             )
           end
         end

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :bulk_update_trainee_upload, class: "BulkUpdate::TraineeUpload" do
     provider
-    status { "pending" }
+    status { nil }
     number_of_trainees { 5 }
     after(:build) do |upload|
       upload.file.attach(
@@ -13,6 +13,8 @@ FactoryBot.define do
     end
 
     trait :with_rows do
+      validated
+
       after(:create) do |upload|
         CSV.parse(upload.file.download, headers: true).map.with_index do |row, index|
           create(
@@ -23,6 +25,22 @@ FactoryBot.define do
           )
         end
       end
+    end
+
+    trait :pending do
+      status { "pending" }
+    end
+
+    trait :validated do
+      status { "validated" }
+    end
+
+    trait :submitted do
+      status { "submitted" }
+    end
+
+    trait :succeeded do
+      status { "succeeded" }
     end
 
     trait :failed do

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -22,7 +22,6 @@ FactoryBot.define do
             row_number: index + 1,
           )
         end
-
       end
     end
 
@@ -41,7 +40,7 @@ FactoryBot.define do
               error_type: :duplicate,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1
+              row_number: index + 1,
             )
           else
             create(
@@ -49,7 +48,7 @@ FactoryBot.define do
               :with_errors,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1
+              row_number: index + 1,
             )
           end
         end
@@ -69,7 +68,7 @@ FactoryBot.define do
               :bulk_update_trainee_upload_row,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1
+              row_number: index + 1,
             )
           else
             create(
@@ -77,7 +76,7 @@ FactoryBot.define do
               :with_errors,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1
+              row_number: index + 1,
             )
           end
         end
@@ -97,7 +96,7 @@ FactoryBot.define do
               :bulk_update_trainee_upload_row,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1
+              row_number: index + 1,
             )
           else
             create(
@@ -106,7 +105,7 @@ FactoryBot.define do
               error_type: :duplicate,
               trainee_upload: bulk_update_trainee_upload,
               data: row.to_h,
-              row_number: index + 1
+              row_number: index + 1,
             )
           end
         end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
     dttp_id { SecureRandom.uuid }
     welcome_email_sent_at { Faker::Time.backward(days: 1).utc }
 
+    trait :hei do
+      providers { [build(:provider, :hei)] }
+    end
+
     trait :system_admin do
       providers { [] }
       system_admin { true }

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -3,121 +3,179 @@
 require "rails_helper"
 
 feature "bulk add trainees" do
-  context "when authenticated as a provider user" do
-    let(:hei_provider) { create(:provider, :hei) }
-    let(:user) { create(:user, providers: [hei_provider]) }
+  include ActiveJob::TestHelper
 
+  before do
+    and_there_is_a_nationality
+  end
+
+  context "when the feature flag is off", feature_bulk_add_trainees: false do
     before do
-      allow(BulkUpdate::AddTrainees::ImportRowsJob).to receive(:perform_later)
-      given_i_am_authenticated(user:)
-      and_there_is_a_nationality
+      given_i_am_authenticated
     end
 
-    scenario "the bulk add trainees page is not-visible when feature flag is off", feature_bulk_add_trainees: false do
+    scenario "the bulk add trainees page is not-visible when feature flag is off" do
       when_i_visit_the_bulk_update_index_page
       then_i_cannot_see_the_bulk_add_trainees_link
       and_i_cannot_navigate_directly_to_the_bulk_add_trainees_page
     end
+  end
 
-    scenario "the bulk add trainees page is visible when feature flag is on", feature_bulk_add_trainees: true do
-      when_i_visit_the_bulk_update_index_page
-      and_i_click_the_bulk_add_trainees_page
-      then_i_see_how_instructions_on_how_to_bulk_add_trainees
-      and_i_see_the_empty_csv_link
+  context "when the feature flag is on", feature_bulk_add_trainees: true do
+    context "when the User is not a Provider" do
+      let(:user) { create(:user, :with_lead_partner_organisation) }
 
-      when_i_attach_an_empty_file
-      and_i_click_the_upload_button
-      then_i_see_the_upload_page_with_errors
+      before do
+        given_i_am_authenticated(user:)
+      end
 
-      when_i_visit_the_bulk_update_index_page
-      and_i_click_the_bulk_add_trainees_page
-      and_i_attach_a_valid_file
-      and_i_click_the_upload_button
-      then_i_see_the_review_page_with_no_errors
-
-      when_the_upload_validation_background_job_is_run
-      and_i_refresh_the_page
-      then_i_see_the_review_page_with_no_errors
-
-      when_i_click_the_submit_button
-      then_a_job_is_queued_to_process_the_upload
-      and_i_see_the_summary_page
-
-      when_the_submit_background_job_is_run
-      and_i_visit_the_trainees_page
-      then_i_can_see_the_new_trainees
+      scenario "attempts to visit the new upload trainees page" do
+        when_i_visit_the_new_bulk_update_trainees_upload_path
+        then_i_see_the_unauthorized_message
+      end
     end
 
-    scenario "when I try to look at the status of a different providers upload", feature_bulk_add_trainees: true do
-      when_there_is_a_bulk_update_trainee_upload
-      when_i_visit_the_bulk_update_status_page_for_another_provider
+    context "when the User is a Provider" do
+      before do
+        given_i_am_authenticated
+      end
+
+      scenario "the bulk add trainees page is visible" do
+        when_i_visit_the_bulk_update_index_page
+        and_i_click_the_bulk_add_trainees_page
+        then_i_see_how_instructions_on_how_to_bulk_add_trainees
+        and_i_see_the_empty_csv_link
+
+        when_i_attach_an_empty_file
+        and_i_click_the_upload_button
+        then_i_see_the_upload_page_with_errors(empty: true)
+
+        when_i_click_the_upload_button
+        then_i_see_the_upload_page_with_errors(empty: false)
+
+        when_i_visit_the_bulk_update_index_page
+        and_i_click_the_bulk_add_trainees_page
+        and_i_attach_a_valid_file
+        and_i_click_the_upload_button
+        then_i_see_that_the_upload_is_processing
+        and_i_dont_see_the_cancel_bulk_updates_link
+
+        when_i_click_the_back_to_bulk_updates_page_link
+        and_i_click_the_bulk_add_trainees_page
+        and_i_attach_a_valid_file
+
+        and_i_click_the_upload_button
+        then_i_see_that_the_upload_is_processing
+
+        when_the_background_job_is_run
+        and_i_refresh_the_page
+        then_i_see_the_review_page
+        and_i_dont_see_the_review_errors_link
+        and_i_dont_see_the_back_to_bulk_updates_link
+
+        when_i_click_the_cancel_bulk_updates_link
+        and_i_click_the_bulk_add_trainees_page
+        and_i_attach_a_valid_file
+        and_i_click_the_upload_button
+        then_a_job_is_queued_to_process_the_upload
+        then_i_see_that_the_upload_is_processing
+
+        when_the_background_job_is_run
+        and_i_refresh_the_page
+        then_i_see_the_review_page
+
+        when_i_click_the_submit_button
+        then_a_job_is_queued_to_process_the_upload
+        and_i_see_the_summary_page
+        and_i_dont_see_the_review_errors_message
+
+        and_i_visit_the_trainees_page
+        then_i_can_see_the_new_trainees
+
+        when_i_try_resubmit_the_same_upload
+        and_i_click_the_submit_button
+        then_i_see_the_unauthorized_message
+      end
+
+      scenario "when I try to look at the status of a different providers upload" do
+        when_there_is_a_bulk_update_trainee_upload
+
+        expect {
+          when_i_visit_the_bulk_update_status_page_for_another_provider
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      scenario "view the upload summary page with errors" do
+        when_the_upload_has_failed_with_validation_errors
+        and_i_dont_see_that_the_upload_is_processing
+        and_i_visit_the_summary_page(upload: @failed_upload)
+        then_i_see_the_review_page
+        and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
+        and_i_see_the_validation_errors(number: 2)
+        and_i_dont_see_any_duplicate_errors
+        and_i_see_the_review_errors_message
+        and_i_see_the_review_errors_link
+        and_i_dont_see_the_submit_button
+      end
+
+      scenario "view the upload summary page with duplicate errors" do
+        when_the_upload_has_failed_with_duplicate_errors
+        and_i_dont_see_that_the_upload_is_processing
+        and_i_visit_the_summary_page(upload: @failed_upload)
+        then_i_see_the_review_page
+        and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
+        and_i_dont_see_any_validation_errors
+        and_i_see_the_duplicate_errors(number: 2)
+        and_i_see_the_review_errors_message
+        and_i_see_the_review_errors_link
+        and_i_dont_see_the_submit_button
+      end
+
+      scenario "view the upload summary page with validation and duplicate errors" do
+        when_the_upload_has_failed_with_validation_and_duplicate_errors
+        and_i_dont_see_that_the_upload_is_processing
+        and_i_visit_the_summary_page(upload: @failed_upload)
+        then_i_see_the_review_page
+        and_i_dont_the_number_of_trainees_that_can_be_added
+        and_i_see_the_validation_errors(number: 2)
+        and_i_see_the_duplicate_errors(number: 3)
+        and_i_see_the_review_errors_message
+        and_i_see_the_review_errors_link
+        and_i_dont_see_the_submit_button
+      end
     end
-  end
-
-  context "when authenticated but not as a provider user" do
-    before do
-      given_i_am_authenticated_as_system_admin
-    end
-
-    scenario "the bulk add trainees page is visible when feature flag is on", feature_bulk_add_trainees: true do
-      when_i_visit_the_bulk_update_add_trainees_page
-      then_i_am_redirected_to_the_root_path
-    end
-  end
-
-  def when_i_visit_the_bulk_update_add_trainees_page
-    visit new_bulk_update_trainees_upload_path
-  end
-
-  def then_i_am_redirected_to_the_root_path
-    expect(page).to have_current_path(root_path)
-  end
-
-  scenario "view the upload summary page with errors", feature_bulk_add_trainees: true do
-    when_the_upload_has_failed_with_validation_errors
-    and_i_dont_see_that_the_upload_is_processing
-    and_i_visit_the_summary_page(upload: @failed_upload)
-    then_i_see_the_review_page
-    and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
-    and_i_see_the_validation_errors(number: 2)
-    and_i_dont_see_any_duplicate_errors
-    and_i_see_the_review_errors_message
-    and_i_see_the_review_errors_link
-    and_i_dont_see_the_submit_button
-  end
-
-  scenario "view the upload summary page with duplicate errors", feature_bulk_add_trainees: true do
-    when_the_upload_has_failed_with_duplicate_errors
-    and_i_dont_see_that_the_upload_is_processing
-    and_i_visit_the_summary_page(upload: @failed_upload)
-    then_i_see_the_review_page
-    and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
-    and_i_dont_see_any_validation_errors
-    and_i_see_the_duplicate_errors(number: 2)
-    and_i_see_the_review_errors_message
-    and_i_see_the_review_errors_link
-    and_i_dont_see_the_submit_button
-  end
-
-  scenario "view the uplaod summary page with validation and duplicate errors", feature_bulk_add_trainees: true do
-    when_the_upload_has_failed_with_validation_and_duplicate_errors
-    and_i_dont_see_that_the_upload_is_processing
-    and_i_visit_the_summary_page(upload: @failed_upload)
-    then_i_see_the_review_page
-    and_i_dont_the_number_of_trainees_that_can_be_added
-    and_i_see_the_validation_errors(number: 2)
-    and_i_see_the_duplicate_errors(number: 3)
-    and_i_see_the_review_errors_message
-    and_i_see_the_review_errors_link
-    and_i_dont_see_the_submit_button
   end
 
 private
 
+  def when_i_try_resubmit_the_same_upload
+    visit bulk_update_trainees_upload_path(BulkUpdate::TraineeUpload.last)
+  end
+
+  def then_i_see_the_unauthorized_message
+    expect(page).to have_content("You do not have permission to perform this action")
+  end
+
+  def and_i_dont_see_the_back_to_bulk_updates_link
+    expect(page).not_to have_link("Back to bulk updates page")
+  end
+
+  def and_i_dont_see_the_cancel_bulk_updates_link
+    expect(page).not_to have_link("Cancel bulk updates to records")
+  end
+
+  def when_i_click_the_cancel_bulk_updates_link
+    click_on "Cancel bulk updates to records"
+  end
+
+  def when_i_click_the_back_to_bulk_updates_page_link
+    click_on "Back to bulk updates page"
+  end
+
   def then_i_see_that_the_upload_is_processing
     expect(page).to have_content("File uploaded")
     expect(page).to have_content("Your file is being processed")
-    expect(page).to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.file_name}.")
+    expect(page).to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.filename}.")
     expect(page).to have_content("This is taking longer than usual")
     expect(page).to have_content("You'll receive and email to tell you when this is complete.")
     expect(page).to have_content("You can also check the status of new trainee files.")
@@ -127,7 +185,7 @@ private
   def and_i_dont_see_that_the_upload_is_processing
     expect(page).not_to have_content("File uploaded")
     expect(page).not_to have_content("Your file is being processed")
-    expect(page).not_to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.file_name}.")
+    expect(page).not_to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.filename}.")
     expect(page).not_to have_content("This is taking longer than usual")
     expect(page).not_to have_content("You'll receive and email to tell you when this is complete.")
     expect(page).not_to have_content("You can also check the status of new trainee files.")
@@ -147,8 +205,12 @@ private
   end
 
   def and_i_cannot_navigate_directly_to_the_bulk_add_trainees_page
-    visit new_bulk_update_trainees_upload_path
+    when_i_visit_the_new_bulk_update_trainees_upload_path
     expect(page).to have_current_path(not_found_path)
+  end
+
+  def when_i_visit_the_new_bulk_update_trainees_upload_path
+    visit new_bulk_update_trainees_upload_path
   end
 
   def and_i_click_the_bulk_add_trainees_page
@@ -168,7 +230,7 @@ private
     and_i_attach_a_file("")
   end
 
-  def and_i_attach_a_valid_file
+  def when_i_attach_a_valid_file
     csv = Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees.csv").read
     and_i_attach_a_file(csv)
   end
@@ -186,17 +248,10 @@ private
     click_on "Upload records"
   end
 
-  def then_i_see_the_upload_page_with_errors
+  def then_i_see_the_upload_page_with_errors(empty:)
     expect(page).to have_current_path(bulk_update_trainees_uploads_path)
     expect(page).to have_content("There is a problem")
-    expect(page).to have_content("The selected file is empty")
-  end
-
-  def then_i_see_the_review_page_with_no_errors
-    expect(page).to have_current_path(
-      bulk_update_trainees_upload_path(id: BulkUpdate::TraineeUpload.last.id),
-    )
-    expect(page).to have_content("You uploaded a CSV file with details of 5 trainees.")
+    expect(page).to have_content(empty ? "The selected file is empty" : "Select a CSV file")
   end
 
   def then_i_see_the_review_page
@@ -253,12 +308,14 @@ private
   end
 
   def then_a_job_is_queued_to_process_the_upload
-    expect(BulkUpdate::AddTrainees::ImportRowsJob).to have_received(:perform_later).with(BulkUpdate::TraineeUpload.last).at_least(:once)
+    expect(BulkUpdate::AddTrainees::ImportRowsJob).to have_been_enqueued.with(
+      id: BulkUpdate::TraineeUpload.last.id,
+    )
   end
 
   def and_i_see_the_summary_page
     expect(page).to have_current_path(
-      bulk_update_trainees_submission_path(id: BulkUpdate::TraineeUpload.last.id),
+      bulk_update_trainees_submission_path(BulkUpdate::TraineeUpload.last),
     )
     within(".govuk-panel") do
       expect(page).to have_content("Trainees submitted")
@@ -271,27 +328,15 @@ private
   end
 
   def when_i_visit_the_bulk_update_status_page_for_another_provider
-    visit bulk_update_trainees_upload_path(id: @upload_for_different_provider.id)
-  end
-
-  def then_i_see_a_not_found_page
-    expect(page).to have_current_path(not_found_path)
-  end
-
-  def when_the_upload_validation_background_job_is_run
-    Sidekiq::Testing.inline! do
-      BulkUpdate::AddTrainees::ImportRowsJob.perform_now(BulkUpdate::TraineeUpload.last)
-    end
+    visit bulk_update_trainees_upload_path(@upload_for_different_provider)
   end
 
   def and_i_refresh_the_page
     visit bulk_update_trainees_upload_path(id: BulkUpdate::TraineeUpload.last.id)
   end
 
-  def when_the_submit_background_job_is_run
-    Sidekiq::Testing.inline! do
-      BulkUpdate::AddTrainees::ImportRowsJob.perform_now(BulkUpdate::TraineeUpload.last)
-    end
+  def when_the_background_job_is_run
+    perform_enqueued_jobs
   end
 
   def and_i_visit_the_trainees_page
@@ -329,4 +374,8 @@ private
   def and_i_visit_the_summary_page(upload:)
     visit bulk_update_trainees_upload_path(upload)
   end
+
+  alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file
+  alias_method :and_i_click_the_submit_button, :when_i_click_the_submit_button
+  alias_method :when_i_click_the_upload_button, :and_i_click_the_upload_button
 end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -115,6 +115,7 @@ feature "bulk add trainees" do
 private
 
   def then_i_see_that_the_upload_is_processing
+    expect(page).to have_content("File uploaded")
     expect(page).to have_content("Your file is being processed")
     expect(page).to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.file_name}.")
     expect(page).to have_content("This is taking longer than usual")
@@ -124,6 +125,7 @@ private
   end
 
   def and_i_dont_see_that_the_upload_is_processing
+    expect(page).not_to have_content("File uploaded")
     expect(page).not_to have_content("Your file is being processed")
     expect(page).not_to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.file_name}.")
     expect(page).not_to have_content("This is taking longer than usual")

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -73,42 +73,64 @@ feature "bulk add trainees" do
     expect(page).to have_current_path(root_path)
   end
 
-
-  # scenario "the upload is processing", feature_bulk_add_trainees: true do
-
-  # end
-
   scenario "view the upload summary page with errors", feature_bulk_add_trainees: true do
     when_the_upload_has_failed_with_validation_errors
+    and_i_dont_see_that_the_upload_is_processing
     and_i_visit_the_summary_page(upload: @failed_upload)
     then_i_see_the_review_page
     and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
     and_i_see_the_validation_errors(number: 2)
     and_i_dont_see_any_duplicate_errors
     and_i_see_the_review_errors_message
+    and_i_see_the_review_errors_link
+    and_i_dont_see_the_submit_button
   end
 
   scenario "view the upload summary page with duplicate errors", feature_bulk_add_trainees: true do
     when_the_upload_has_failed_with_duplicate_errors
+    and_i_dont_see_that_the_upload_is_processing
     and_i_visit_the_summary_page(upload: @failed_upload)
     then_i_see_the_review_page
     and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
     and_i_dont_see_any_validation_errors
     and_i_see_the_duplicate_errors(number: 2)
     and_i_see_the_review_errors_message
+    and_i_see_the_review_errors_link
+    and_i_dont_see_the_submit_button
   end
 
   scenario "view the uplaod summary page with validation and duplicate errors", feature_bulk_add_trainees: true do
     when_the_upload_has_failed_with_validation_and_duplicate_errors
+    and_i_dont_see_that_the_upload_is_processing
     and_i_visit_the_summary_page(upload: @failed_upload)
     then_i_see_the_review_page
     and_i_dont_the_number_of_trainees_that_can_be_added
     and_i_see_the_validation_errors(number: 2)
     and_i_see_the_duplicate_errors(number: 3)
     and_i_see_the_review_errors_message
+    and_i_see_the_review_errors_link
+    and_i_dont_see_the_submit_button
   end
 
 private
+
+  def then_i_see_that_the_upload_is_processing
+    expect(page).to have_content("Your file is being processed")
+    expect(page).to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.file_name}.")
+    expect(page).to have_content("This is taking longer than usual")
+    expect(page).to have_content("You'll receive and email to tell you when this is complete.")
+    expect(page).to have_content("You can also check the status of new trainee files.")
+    expect(page).to have_link("Back to bulk updates page")
+  end
+
+  def and_i_dont_see_that_the_upload_is_processing
+    expect(page).not_to have_content("Your file is being processed")
+    expect(page).not_to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.file_name}.")
+    expect(page).not_to have_content("This is taking longer than usual")
+    expect(page).not_to have_content("You'll receive and email to tell you when this is complete.")
+    expect(page).not_to have_content("You can also check the status of new trainee files.")
+    expect(page).not_to have_link("Back to bulk updates page")
+  end
 
   def and_there_is_a_nationality
     create(:nationality, :british)
@@ -200,12 +222,28 @@ private
     expect(page).to have_content("You need to review the errors before you can add new trainees")
   end
 
+  def and_i_dont_see_the_review_errors_message
+    expect(page).not_to have_content("You need to review the errors before you can add new trainees")
+  end
+
   def and_i_dont_see_any_validation_errors
     expect(page).not_to have_content("0 trainees with errors in their details")
   end
 
   def and_i_dont_see_any_duplicate_errors
     expect(page).not_to have_content("0 trainees who will not be added, as they already exist in Register")
+  end
+
+  def and_i_dont_see_the_submit_button
+    expect(page).not_to have_button("Submit")
+  end
+
+  def and_i_see_the_review_errors_link
+    expect(page).to have_link("Review errors")
+  end
+
+  def and_i_dont_see_the_review_errors_link
+    expect(page).not_to have_link("Review errors")
   end
 
   def when_i_click_the_submit_button

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -73,6 +73,41 @@ feature "bulk add trainees" do
     expect(page).to have_current_path(root_path)
   end
 
+
+  # scenario "the upload is processing", feature_bulk_add_trainees: true do
+
+  # end
+
+  scenario "view the upload summary page with errors", feature_bulk_add_trainees: true do
+    when_the_upload_has_failed_with_validation_errors
+    and_i_visit_the_summary_page(upload: @failed_upload)
+    then_i_see_the_review_page
+    and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
+    and_i_see_the_validation_errors(number: 2)
+    and_i_dont_see_any_duplicate_errors
+    and_i_see_the_review_errors_message
+  end
+
+  scenario "view the upload summary page with duplicate errors", feature_bulk_add_trainees: true do
+    when_the_upload_has_failed_with_duplicate_errors
+    and_i_visit_the_summary_page(upload: @failed_upload)
+    then_i_see_the_review_page
+    and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
+    and_i_dont_see_any_validation_errors
+    and_i_see_the_duplicate_errors(number: 2)
+    and_i_see_the_review_errors_message
+  end
+
+  scenario "view the uplaod summary page with validation and duplicate errors", feature_bulk_add_trainees: true do
+    when_the_upload_has_failed_with_validation_and_duplicate_errors
+    and_i_visit_the_summary_page(upload: @failed_upload)
+    then_i_see_the_review_page
+    and_i_dont_the_number_of_trainees_that_can_be_added
+    and_i_see_the_validation_errors(number: 2)
+    and_i_see_the_duplicate_errors(number: 3)
+    and_i_see_the_review_errors_message
+  end
+
 private
 
   def and_there_is_a_nationality
@@ -140,6 +175,39 @@ private
     expect(page).to have_content("You uploaded a CSV file with details of 5 trainees.")
   end
 
+  def then_i_see_the_review_page
+    expect(page).to have_content("You uploaded a CSV file with details of 5 trainees.")
+    expect(page).to have_content("It included:")
+  end
+
+  def and_i_see_the_number_of_trainees_that_can_be_added(number:)
+    expect(page).to have_content("#{number} trainees who can be added")
+  end
+
+  def and_i_dont_the_number_of_trainees_that_can_be_added
+    expect(page).not_to have_content("trainees who can be added")
+  end
+
+  def and_i_see_the_validation_errors(number:)
+    expect(page).to have_content("#{number} trainees with errors in their details")
+  end
+
+  def and_i_see_the_duplicate_errors(number:)
+    expect(page).to have_content("#{number} trainees who will not be added, as they already exist in Register")
+  end
+
+  def and_i_see_the_review_errors_message
+    expect(page).to have_content("You need to review the errors before you can add new trainees")
+  end
+
+  def and_i_dont_see_any_validation_errors
+    expect(page).not_to have_content("0 trainees with errors in their details")
+  end
+
+  def and_i_dont_see_any_duplicate_errors
+    expect(page).not_to have_content("0 trainees who will not be added, as they already exist in Register")
+  end
+
   def when_i_click_the_submit_button
     click_on "Submit"
   end
@@ -192,5 +260,33 @@ private
 
   def then_i_can_see_the_new_trainees
     expect(page).to have_content("Jonas Padberg")
+  end
+
+  def when_the_upload_has_failed_with_validation_errors
+    @failed_upload = create(
+      :bulk_update_trainee_upload,
+      :failed_with_validation_errors,
+      provider: current_user.organisation
+    )
+  end
+
+  def when_the_upload_has_failed_with_duplicate_errors
+    @failed_upload = create(
+      :bulk_update_trainee_upload,
+      :failed_with_duplicate_errors,
+      provider: current_user.organisation
+    )
+  end
+
+  def when_the_upload_has_failed_with_validation_and_duplicate_errors
+    @failed_upload = create(
+      :bulk_update_trainee_upload,
+      :failed,
+      provider: current_user.organisation
+    )
+  end
+
+  def and_i_visit_the_summary_page(upload:)
+    visit bulk_update_trainees_upload_path(upload)
   end
 end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -304,7 +304,7 @@ private
     @failed_upload = create(
       :bulk_update_trainee_upload,
       :failed_with_validation_errors,
-      provider: current_user.organisation
+      provider: current_user.organisation,
     )
   end
 
@@ -312,7 +312,7 @@ private
     @failed_upload = create(
       :bulk_update_trainee_upload,
       :failed_with_duplicate_errors,
-      provider: current_user.organisation
+      provider: current_user.organisation,
     )
   end
 
@@ -320,7 +320,7 @@ private
     @failed_upload = create(
       :bulk_update_trainee_upload,
       :failed,
-      provider: current_user.organisation
+      provider: current_user.organisation,
     )
   end
 

--- a/spec/models/bulk_update/row_error_spec.rb
+++ b/spec/models/bulk_update/row_error_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe BulkUpdate::RowError do
   end
 
   it do
-    is_expected.to define_enum_for(
-      :error_type
+    expect(subject).to define_enum_for(
+      :error_type,
     ).with_values(
       duplicate: "duplicate",
       validation: "validation",

--- a/spec/models/bulk_update/row_error_spec.rb
+++ b/spec/models/bulk_update/row_error_spec.rb
@@ -6,4 +6,13 @@ RSpec.describe BulkUpdate::RowError do
   describe "associations" do
     it { is_expected.to belong_to(:errored_on) }
   end
+
+  it do
+    is_expected.to define_enum_for(
+      :error_type
+    ).with_values(
+      duplicate: "duplicate",
+      validation: "validation",
+    ).backed_by_column_of_type(:string)
+  end
 end

--- a/spec/models/bulk_update/trainee_upload_row_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_row_spec.rb
@@ -5,4 +5,13 @@ require "rails_helper"
 RSpec.describe BulkUpdate::TraineeUploadRow do
   it { is_expected.to belong_to(:trainee_upload) }
   it { is_expected.to have_many(:row_errors) }
+
+  describe "#without_errors" do
+    let!(:rows_with_errors) { create_list(:bulk_update_trainee_upload_row, 2, :with_errors) }
+    let!(:rows_without_errors) { create_list(:bulk_update_trainee_upload_row, 2) }
+
+    it "returns only the trainee upload rows that don't have errors" do
+      expect(described_class.without_errors).to eq(rows_without_errors)
+    end
+  end
 end

--- a/spec/models/bulk_update/trainee_upload_row_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_row_spec.rb
@@ -4,4 +4,5 @@ require "rails_helper"
 
 RSpec.describe BulkUpdate::TraineeUploadRow do
   it { is_expected.to belong_to(:bulk_update_trainee_upload) }
+  it { is_expected.to have_many(:row_errors) }
 end

--- a/spec/models/bulk_update/trainee_upload_row_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_row_spec.rb
@@ -3,6 +3,6 @@
 require "rails_helper"
 
 RSpec.describe BulkUpdate::TraineeUploadRow do
-  it { is_expected.to belong_to(:bulk_update_trainee_upload) }
+  it { is_expected.to belong_to(:trainee_upload) }
   it { is_expected.to have_many(:row_errors) }
 end

--- a/spec/models/bulk_update/trainee_upload_row_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_row_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::TraineeUploadRow do
+  it { is_expected.to belong_to(:bulk_update_trainee_upload) }
+end

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::TraineeUpload do
+  it { is_expected.to belong_to(:provider) }
+  it { is_expected.to have_many(:bulk_update_trainee_upload_rows).dependent(:destroy) }
+end

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -4,5 +4,5 @@ require "rails_helper"
 
 RSpec.describe BulkUpdate::TraineeUpload do
   it { is_expected.to belong_to(:provider) }
-  it { is_expected.to have_many(:bulk_update_trainee_upload_rows).dependent(:destroy) }
+  it { is_expected.to have_many(:trainee_upload_rows).dependent(:destroy) }
 end

--- a/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
 
   it { is_expected.to be < BulkUpdate::TraineeUploadPolicy }
 
-  context "when the User's organisation is a Provider" do
-    let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+  context "when the User's organisation is an HEI Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user, :hei), session: {}) }
 
     %i[validated].each do |status|
       context "when the upload is #{status}" do
@@ -48,6 +48,20 @@ RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
           it {
             expect(subject).not_to permit(user, trainee_upload)
           }
+        end
+      end
+    end
+  end
+
+  context "when the User's organisation is not an HEI Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+    %i[pending validated failed in_progress succeeded].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+        permissions :show?, :create? do
+          it { is_expected.not_to permit(user, trainee_upload) }
         end
       end
     end

--- a/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
       end
     end
 
-    %i[submitted succeeded].each do |status|
+    %i[in_progress succeeded].each do |status|
       context "when the upload is #{status}" do
         let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 
@@ -56,7 +56,7 @@ RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
   context "when the User's organisation is not a Provider" do
     let(:user) { UserWithOrganisationContext.new(user: create(:user, :with_lead_partner_organisation), session: {}) }
 
-    %i[pending validated failed submitted succeeded].each do |status|
+    %i[pending validated failed in_progress succeeded].each do |status|
       context "when the upload is #{status}" do
         let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 

--- a/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
+  subject { described_class }
+
+  let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+  it { is_expected.to be < BulkUpdate::TraineeUploadPolicy }
+
+  context "when the User's organisation is a Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+    %i[validated].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+        permissions :create? do
+          it { is_expected.to permit(user, trainee_upload) }
+        end
+
+        permissions :show? do
+          it { is_expected.not_to permit(user, trainee_upload) }
+        end
+      end
+    end
+
+    %i[submitted succeeded].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+        permissions :create? do
+          it { is_expected.not_to permit(user, trainee_upload) }
+        end
+
+        permissions :show? do
+          it { is_expected.to permit(user, trainee_upload) }
+        end
+      end
+    end
+
+    %i[pending failed].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+        permissions :create?, :show? do
+          it {
+            expect(subject).not_to permit(user, trainee_upload)
+          }
+        end
+      end
+    end
+  end
+
+  context "when the User's organisation is not a Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user, :with_lead_partner_organisation), session: {}) }
+
+    %i[pending validated failed submitted succeeded].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+        permissions :show?, :create? do
+          it { is_expected.not_to permit(user, trainee_upload) }
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/bulk_update/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/trainee_upload_policy_spec.rb
@@ -7,11 +7,21 @@ RSpec.describe BulkUpdate::TraineeUploadPolicy, type: :policy do
 
   let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
 
-  context "when the User's organisation is a Provider" do
+  context "when the User's organisation is an HEI Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user, :hei), session: {}) }
     let(:trainee_upload) { build(:bulk_update_trainee_upload, provider: user.providers.first) }
 
     permissions :show?, :new?, :create? do
       it { is_expected.to permit(user, trainee_upload) }
+    end
+  end
+
+  context "when the User's organisation is not an HEI Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+    let(:trainee_upload) { build(:bulk_update_trainee_upload, provider: user.providers.first) }
+
+    permissions :show?, :new?, :create? do
+      it { is_expected.not_to permit(user, trainee_upload) }
     end
   end
 

--- a/spec/policies/bulk_update/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/trainee_upload_policy_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::TraineeUploadPolicy, type: :policy do
+  subject { described_class }
+
+  let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+  %i[validated].each do |status|
+    context "when the upload is #{status}" do
+      let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+      permissions :create? do
+        it { is_expected.to permit(user, trainee_upload) }
+      end
+
+      permissions :show? do
+        it { is_expected.not_to permit(user, trainee_upload) }
+      end
+    end
+  end
+
+  %i[submitted succeeded].each do |status|
+    context "when the upload is #{status}" do
+      let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+      permissions :create? do
+        it { is_expected.not_to permit(user, trainee_upload) }
+      end
+
+      permissions :show? do
+        it { is_expected.to permit(user, trainee_upload) }
+      end
+    end
+  end
+
+  %i[pending failed].each do |status|
+    context "when the upload is #{status}" do
+      let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+      permissions :create?, :show? do
+        it {
+          expect(subject).not_to permit(user, trainee_upload)
+        }
+      end
+    end
+  end
+
+  describe described_class::Scope do
+    subject do
+      described_class.new(user, BulkUpdate::TraineeUpload).resolve
+    end
+
+    let(:other_user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+    let!(:pending_upload) { create(:bulk_update_trainee_upload, provider: user.providers.first) }
+    let!(:other_user_upload) { create(:bulk_update_trainee_upload, provider: other_user.providers.first) }
+
+    it { is_expected.to contain_exactly(pending_upload) }
+  end
+end

--- a/spec/policies/bulk_update/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/trainee_upload_policy_spec.rb
@@ -7,43 +7,20 @@ RSpec.describe BulkUpdate::TraineeUploadPolicy, type: :policy do
 
   let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
 
-  %i[validated].each do |status|
-    context "when the upload is #{status}" do
-      let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+  context "when the User's organisation is a Provider" do
+    let(:trainee_upload) { build(:bulk_update_trainee_upload, provider: user.providers.first) }
 
-      permissions :create? do
-        it { is_expected.to permit(user, trainee_upload) }
-      end
-
-      permissions :show? do
-        it { is_expected.not_to permit(user, trainee_upload) }
-      end
+    permissions :show?, :new?, :create? do
+      it { is_expected.to permit(user, trainee_upload) }
     end
   end
 
-  %i[submitted succeeded].each do |status|
-    context "when the upload is #{status}" do
-      let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+  context "when the User's organisation is not a Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user, :with_lead_partner_organisation), session: {}) }
+    let(:trainee_upload) { build(:bulk_update_trainee_upload, provider: user.providers.first) }
 
-      permissions :create? do
-        it { is_expected.not_to permit(user, trainee_upload) }
-      end
-
-      permissions :show? do
-        it { is_expected.to permit(user, trainee_upload) }
-      end
-    end
-  end
-
-  %i[pending failed].each do |status|
-    context "when the upload is #{status}" do
-      let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
-
-      permissions :create?, :show? do
-        it {
-          expect(subject).not_to permit(user, trainee_upload)
-        }
-      end
+    permissions :show?, :new?, :create? do
+      it { is_expected.not_to permit(user, trainee_upload) }
     end
   end
 


### PR DESCRIPTION
### Context

[Create upload summary page - part 2](https://trello.com/c/hQCuFxFe/7744-create-upload-summary-page-part-2)

This PR implements the summary page which renders the following:

1. The number of trainees to be created if the upload is successful
2. The number of validation errors
3. The number of duplicate errors

### Changes proposed in this pull request

* Add `row_errors` association for trainee uploads
* Add enum to to `BulkUpdate::RowError` to determine if each row is of type `validation` or `duplicate`
* Refactors the uploads show page 
* Refactors the `BulkAddTraineesUploadForm`
* Add `BulkUpdate::TraineeUploadPolicy`
* Add `BulkUpdate::Submissions::TraineeUploadPolicy`

### Guidance to review

* Currently `row_errors` are not created if a validation error occurs and this logic will be implemented as part of a separate ticket. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml


<img width="995" alt="Screenshot 2024-11-08 at 09 38 47" src="https://github.com/user-attachments/assets/47604128-1a2b-49d4-8c15-a6cc6631ecea">
<img width="1003" alt="Screenshot 2024-11-08 at 09 39 07" src="https://github.com/user-attachments/assets/2850c28d-b364-4d85-8243-f88d86a05f04">
<img width="999" alt="Screenshot 2024-11-08 at 09 39 13" src="https://github.com/user-attachments/assets/cc8ff088-372d-4eb2-aacd-5458a1edaa9c">