### PR TITLE
[xxxx] Fixed `citizen of guinea-bissau` flaky issue

### DIFF
--- a/app/components/personal_details/view.rb
+++ b/app/components/personal_details/view.rb
@@ -62,7 +62,7 @@ module PersonalDetails
       return if nationalities.blank?
 
       if nationalities.size == 1
-        nationalities.first.name.titleize
+        nationalities.first.name.to_title
       else
         sanitize(tag.ul(class: "govuk-list") do
           nationality_names.each do |nationality_name|
@@ -73,9 +73,9 @@ module PersonalDetails
     end
 
     def nationality_names
-      names = nationalities.map { |nationality| nationality.name.titleize }
-      promote_nationality(names, ::CodeSets::Nationalities::IRISH.titleize)
-      promote_nationality(names, ::CodeSets::Nationalities::BRITISH.titleize)
+      names = nationalities.map { |nationality| nationality.name.to_title }
+      promote_nationality(names, ::CodeSets::Nationalities::IRISH.to_title)
+      promote_nationality(names, ::CodeSets::Nationalities::BRITISH.to_title)
     end
 
     def promote_nationality(array, nationality)

--- a/app/components/personal_details/view.rb
+++ b/app/components/personal_details/view.rb
@@ -62,7 +62,7 @@ module PersonalDetails
       return if nationalities.blank?
 
       if nationalities.size == 1
-        nationalities.first.name.to_title
+        nationalities.first.name.titleize_with_hyphens
       else
         sanitize(tag.ul(class: "govuk-list") do
           nationality_names.each do |nationality_name|
@@ -73,9 +73,9 @@ module PersonalDetails
     end
 
     def nationality_names
-      names = nationalities.map { |nationality| nationality.name.to_title }
-      promote_nationality(names, ::CodeSets::Nationalities::IRISH.to_title)
-      promote_nationality(names, ::CodeSets::Nationalities::BRITISH.to_title)
+      names = nationalities.map { |nationality| nationality.name.titleize_with_hyphens }
+      promote_nationality(names, ::CodeSets::Nationalities::IRISH.titleize_with_hyphens)
+      promote_nationality(names, ::CodeSets::Nationalities::BRITISH.titleize_with_hyphens)
     end
 
     def promote_nationality(array, nationality)

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -57,7 +57,7 @@ class PersonalDetailsForm < TraineeForm
   end
 
   def nationality_names
-    @nationality_names ||= nationality_ids.map { |id| Nationality.find(id).name.to_title }
+    @nationality_names ||= nationality_ids.map { |id| Nationality.find(id).name.titleize_with_hyphens }
   end
 
   def nationality_ids
@@ -124,7 +124,7 @@ private
     @other_nationalities_hash ||=
       begin
         # Re-hydrate the 'Other nationality' fields from the trainee model.
-        nationality1, nationality2, nationality3 = trainee.nationalities.where.not(name: %w[british irish]).pluck(:name).map(&:to_title)
+        nationality1, nationality2, nationality3 = trainee.nationalities.where.not(name: %w[british irish]).pluck(:name).map(&:titleize_with_hyphens)
 
         {
           other_nationality1: nationality1,
@@ -205,7 +205,7 @@ private
       found_nationality = find_nationality(raw_value)
       next unless found_nationality
 
-      titleized_name = found_nationality.name.to_title
+      titleized_name = found_nationality.name.titleize_with_hyphens
       public_send("other_nationality#{index + 1}=", titleized_name)
       new_attributes[:"other_nationality#{index + 1}"] = titleized_name
       new_attributes[:"other_nationality#{index + 1}_raw"] = titleized_name

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -57,7 +57,7 @@ class PersonalDetailsForm < TraineeForm
   end
 
   def nationality_names
-    @nationality_names ||= nationality_ids.map { |id| Nationality.find(id).name.titleize }
+    @nationality_names ||= nationality_ids.map { |id| Nationality.find(id).name.to_title }
   end
 
   def nationality_ids
@@ -124,7 +124,7 @@ private
     @other_nationalities_hash ||=
       begin
         # Re-hydrate the 'Other nationality' fields from the trainee model.
-        nationality1, nationality2, nationality3 = trainee.nationalities.where.not(name: %w[british irish]).pluck(:name).map(&:titleize)
+        nationality1, nationality2, nationality3 = trainee.nationalities.where.not(name: %w[british irish]).pluck(:name).map(&:to_title)
 
         {
           other_nationality1: nationality1,
@@ -205,7 +205,7 @@ private
       found_nationality = find_nationality(raw_value)
       next unless found_nationality
 
-      titleized_name = found_nationality.name.titleize
+      titleized_name = found_nationality.name.to_title
       public_send("other_nationality#{index + 1}=", titleized_name)
       new_attributes[:"other_nationality#{index + 1}"] = titleized_name
       new_attributes[:"other_nationality#{index + 1}_raw"] = titleized_name

--- a/app/helpers/nationalities_helper.rb
+++ b/app/helpers/nationalities_helper.rb
@@ -6,8 +6,8 @@ module NationalitiesHelper
   def checkbox_nationalities(nationalities)
     nationalities.map do |nationality|
       NationalityOption.new(
-        id: nationality.name.titleize,
-        name: nationality.name.titleize,
+        id: nationality.name.to_title,
+        name: nationality.name.to_title,
         description: I18n.t("views.default_nationalities.#{nationality.name}.description"),
       )
     end
@@ -15,7 +15,7 @@ module NationalitiesHelper
 
   def nationalities_options(nationalities)
     result = nationalities.map do |nationality|
-      NationalityOption.new(id: nationality.name.titleize, name: nationality.name.titleize)
+      NationalityOption.new(id: nationality.name.to_title, name: nationality.name.to_title)
     end
     result.unshift(NationalityOption.new(id: "", name: ""))
     result

--- a/app/helpers/nationalities_helper.rb
+++ b/app/helpers/nationalities_helper.rb
@@ -6,8 +6,8 @@ module NationalitiesHelper
   def checkbox_nationalities(nationalities)
     nationalities.map do |nationality|
       NationalityOption.new(
-        id: nationality.name.to_title,
-        name: nationality.name.to_title,
+        id: nationality.name.titleize_with_hyphens,
+        name: nationality.name.titleize_with_hyphens,
         description: I18n.t("views.default_nationalities.#{nationality.name}.description"),
       )
     end
@@ -15,7 +15,7 @@ module NationalitiesHelper
 
   def nationalities_options(nationalities)
     result = nationalities.map do |nationality|
-      NationalityOption.new(id: nationality.name.to_title, name: nationality.name.to_title)
+      NationalityOption.new(id: nationality.name.titleize_with_hyphens, name: nationality.name.titleize_with_hyphens)
     end
     result.unshift(NationalityOption.new(id: "", name: ""))
     result

--- a/app/lib/code_sets/nationalities.rb
+++ b/app/lib/code_sets/nationalities.rb
@@ -14,6 +14,7 @@ module CodeSets
     GUERNSEY = "Guernsey"
     BRITISH_INDIAN_OCEAN_TERRITORY = "British Indian Ocean Territory (BIOT)"
     FALKLAND_ISLANDS = "Falkland Islands [Falkland Islands (Malvinas)]"
+    CITIZEN_OF_GUINEA_BISSAU = "citizen of guinea-bissau"
 
     CYPRIOT = "cypriot"
 
@@ -88,7 +89,7 @@ module CodeSets
       "chinese" => { entity_id: "9d7d640e-5c62-e711-80d1-005056ac45bb" },
       "citizen of antigua and barbuda" => { entity_id: "557d640e-5c62-e711-80d1-005056ac45bb" },
       "citizen of bosnia and herzegovina" => { entity_id: "697d640e-5c62-e711-80d1-005056ac45bb" },
-      "citizen of guinea-bissau" => { entity_id: "ed7d640e-5c62-e711-80d1-005056ac45bb" },
+      CITIZEN_OF_GUINEA_BISSAU => { entity_id: "ed7d640e-5c62-e711-80d1-005056ac45bb" },
       "citizen of kiribati" => { entity_id: "1d7e640e-5c62-e711-80d1-005056ac45bb" },
       "citizen of seychelles" => { entity_id: "a97e640e-5c62-e711-80d1-005056ac45bb" },
       "citizen of the dominican republic" => { entity_id: "b17d640e-5c62-e711-80d1-005056ac45bb" },

--- a/config/initializers/string.rb
+++ b/config/initializers/string.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class String
-  def to_title
-    humanize.gsub(/\b('?[a-z])/) { ::Regexp.last_match(1).capitalize }
+  def titleize_with_hyphens
+    humanize.gsub(/\b([a-z])/) { ::Regexp.last_match(1).capitalize }
   end
 end

--- a/config/initializers/string.rb
+++ b/config/initializers/string.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class String
+  def to_title
+    humanize.gsub(/\b('?[a-z])/) { ::Regexp.last_match(1).capitalize }
+  end
+end

--- a/spec/config/initializers/string_spec.rb
+++ b/spec/config/initializers/string_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "String" do
+  describe "#to_title" do
+    it "titleize the string retaining the hythen" do
+      expect("citizen of guinea-bissau".to_title).to eq("Citizen Of Guinea-Bissau")
+    end
+  end
+end

--- a/spec/config/initializers/string_spec.rb
+++ b/spec/config/initializers/string_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 describe "String" do
-  describe "#to_title" do
-    it "titleize the string retaining the hythen" do
-      expect("citizen of guinea-bissau".to_title).to eq("Citizen Of Guinea-Bissau")
+  describe "#titleize_with_hyphens" do
+    it "titleize the string retaining the hyphen" do
+      expect("citizen of guinea-bissau".titleize_with_hyphens).to eq("Citizen Of Guinea-Bissau")
     end
   end
 end

--- a/spec/factories/nationalities.rb
+++ b/spec/factories/nationalities.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :nationality do
-    name { CodeSets::Nationalities::MAPPING.keys.sample }
+    name { "citizen of guinea-bissau" }
 
     trait :british do
       name { CodeSets::Nationalities::BRITISH }

--- a/spec/factories/nationalities.rb
+++ b/spec/factories/nationalities.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :nationality do
-    name { "citizen of guinea-bissau" }
+    name { CodeSets::Nationalities::MAPPING.keys.sample }
 
     trait :british do
       name { CodeSets::Nationalities::BRITISH }
@@ -18,6 +18,10 @@ FactoryBot.define do
 
     trait :other do
       name { CodeSets::Nationalities::OTHER }
+    end
+
+    trait :citizen_of_guinea_bissau do
+      name { CodeSets::Nationalities::CITIZEN_OF_GUINEA_BISSAU }
     end
   end
 end

--- a/spec/features/form_sections/personal_and_education_details/reviewing_apply_trainee_data_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/reviewing_apply_trainee_data_spec.rb
@@ -32,11 +32,21 @@ feature "edit training details" do
     then_i_am_back_on_the_apply_trainee_data_page
   end
 
-  def given_a_trainee_with_degrees_exist
+  scenario "changing an attribute for a Citizen of Guinea-Bissau" do
+    given_a_trainee_with_degrees_exist(nationality: build(:nationality, :citizen_of_guinea_bissau))
+    when_i_visit_the_apply_trainee_data_page
+    and_i_click_to_change_the_trainee_full_name
+    and_i_change_the_first_name_to("Jeff")
+    then_i_am_back_on_the_apply_trainee_data_page
+  end
+
+private
+
+  def given_a_trainee_with_degrees_exist(nationality: build(:nationality))
     given_a_trainee_exists(
       :with_diversity_information,
       :with_apply_application,
-      nationalities: [build(:nationality)],
+      nationalities: [nationality],
       degrees: [build(:degree, :uk_degree_with_details)],
     )
   end

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -27,7 +27,7 @@ describe PersonalDetailsForm, type: :model do
       "other_nationality2_raw" => "American",
       "other_nationality3" => "Irish",
       "other_nationality3_raw" => "Irish",
-      "nationality_names" => [french.name.titleize, american.name.titleize, irish.name.titleize],
+      "nationality_names" => [french.name.to_title, american.name.to_title, irish.name.to_title],
     }
   end
 
@@ -194,7 +194,7 @@ describe PersonalDetailsForm, type: :model do
         year: "1963",
         other: true,
         nationality_ids: [french.id, american.id, irish.id],
-        nationality_names: [french.name.titleize, american.name.titleize, irish.name.titleize],
+        nationality_names: [french.name.to_title, american.name.to_title, irish.name.to_title],
       })
     end
   end
@@ -235,7 +235,7 @@ describe PersonalDetailsForm, type: :model do
           "other_nationality2_raw" => jamaican.name,
           "other_nationality3" => "",
           "other_nationality3_raw" => "",
-          "nationality_names" => [british.name.titleize],
+          "nationality_names" => [british.name.to_title],
         }
       }
 
@@ -255,7 +255,7 @@ describe PersonalDetailsForm, type: :model do
           "other_nationality2_raw" => jamaican.name,
           "other_nationality3" => "",
           "other_nationality3_raw" => "",
-          "nationality_names" => [british.name.titleize],
+          "nationality_names" => [british.name.to_title],
         }
       }
 

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -27,7 +27,7 @@ describe PersonalDetailsForm, type: :model do
       "other_nationality2_raw" => "American",
       "other_nationality3" => "Irish",
       "other_nationality3_raw" => "Irish",
-      "nationality_names" => [french.name.to_title, american.name.to_title, irish.name.to_title],
+      "nationality_names" => [french.name.titleize_with_hyphens, american.name.titleize_with_hyphens, irish.name.titleize_with_hyphens],
     }
   end
 
@@ -194,7 +194,7 @@ describe PersonalDetailsForm, type: :model do
         year: "1963",
         other: true,
         nationality_ids: [french.id, american.id, irish.id],
-        nationality_names: [french.name.to_title, american.name.to_title, irish.name.to_title],
+        nationality_names: [french.name.titleize_with_hyphens, american.name.titleize_with_hyphens, irish.name.titleize_with_hyphens],
       })
     end
   end
@@ -235,7 +235,7 @@ describe PersonalDetailsForm, type: :model do
           "other_nationality2_raw" => jamaican.name,
           "other_nationality3" => "",
           "other_nationality3_raw" => "",
-          "nationality_names" => [british.name.to_title],
+          "nationality_names" => [british.name.titleize_with_hyphens],
         }
       }
 
@@ -255,7 +255,7 @@ describe PersonalDetailsForm, type: :model do
           "other_nationality2_raw" => jamaican.name,
           "other_nationality3" => "",
           "other_nationality3_raw" => "",
-          "nationality_names" => [british.name.to_title],
+          "nationality_names" => [british.name.titleize_with_hyphens],
         }
       }
 

--- a/spec/helpers/nationalities_helper_spec.rb
+++ b/spec/helpers/nationalities_helper_spec.rb
@@ -10,8 +10,8 @@ describe NationalitiesHelper do
   describe "#checkbox_nationalities" do
     let(:expected_nationality) do
       NationalityOption.new(
-        id: nationality.name.to_title,
-        name: nationality.name.to_title,
+        id: nationality.name.titleize_with_hyphens,
+        name: nationality.name.titleize_with_hyphens,
         description: t("views.default_nationalities.#{nationality.name}.description"),
       )
     end
@@ -29,7 +29,7 @@ describe NationalitiesHelper do
       result = nationalities_options([nationality])
       expect(result.size).to be 2
       expect(result.first.name).to be ""
-      expect(result.second.name).to eq nationality.name.to_title
+      expect(result.second.name).to eq nationality.name.titleize_with_hyphens
     end
   end
 end

--- a/spec/helpers/nationalities_helper_spec.rb
+++ b/spec/helpers/nationalities_helper_spec.rb
@@ -10,8 +10,8 @@ describe NationalitiesHelper do
   describe "#checkbox_nationalities" do
     let(:expected_nationality) do
       NationalityOption.new(
-        id: nationality.name.titleize,
-        name: nationality.name.titleize,
+        id: nationality.name.to_title,
+        name: nationality.name.to_title,
         description: t("views.default_nationalities.#{nationality.name}.description"),
       )
     end
@@ -29,7 +29,7 @@ describe NationalitiesHelper do
       result = nationalities_options([nationality])
       expect(result.size).to be 2
       expect(result.first.name).to be ""
-      expect(result.second.name).to eq nationality.name.titleize
+      expect(result.second.name).to eq nationality.name.to_title
     end
   end
 end

--- a/spec/support/features/personal_details_steps.rb
+++ b/spec/support/features/personal_details_steps.rb
@@ -24,9 +24,9 @@ module Features
 
       if other_nationality
         personal_details_page.nationality.check("Other")
-        personal_details_page.other_nationality.select(@french.name.to_title)
+        personal_details_page.other_nationality.select(@french.name.titleize_with_hyphens)
       else
-        personal_details_page.nationality.check(@british.name.to_title)
+        personal_details_page.nationality.check(@british.name.titleize_with_hyphens)
       end
     end
 

--- a/spec/support/features/personal_details_steps.rb
+++ b/spec/support/features/personal_details_steps.rb
@@ -24,9 +24,9 @@ module Features
 
       if other_nationality
         personal_details_page.nationality.check("Other")
-        personal_details_page.other_nationality.select(@french.name.titleize)
+        personal_details_page.other_nationality.select(@french.name.to_title)
       else
-        personal_details_page.nationality.check(@british.name.titleize)
+        personal_details_page.nationality.check(@british.name.to_title)
       end
     end
 


### PR DESCRIPTION
### Context
citizen of guinea-bissau

### Changes proposed in this pull request
Flake it with `citizen of guinea-bissau``
### Guidance to review
![image](https://github.com/user-attachments/assets/e2b70200-72a4-430c-89a9-559fbcf467f2)

```
rspec ./spec/features/form_sections/personal_and_education_details/reviewing_apply_trainee_data_spec.rb:27 # edit training details changing an attribute
```


![image](https://github.com/user-attachments/assets/38eb6139-f83a-4587-98cb-59cd615ed1ee)


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
