### PR TITLE
[7766] Fix 1+N query in `FundingManager`

### DIFF
--- a/app/lib/funding_manager.rb
+++ b/app/lib/funding_manager.rb
@@ -91,8 +91,13 @@ private
   def available_amount(funding_type)
     return unless allocation_subject && academic_cycle
 
-    allocation_subject.funding_methods.find_by(training_route:,
-                                               funding_type:,
-                                               academic_cycle:)&.amount
+    @available_amounts ||= {}
+    return @available_amounts[funding_type] if @available_amounts.key?(funding_type)
+
+    @available_amounts[funding_type] = allocation_subject.funding_methods.find_by(
+      training_route:,
+      funding_type:,
+      academic_cycle:,
+    )&.amount
   end
 end


### PR DESCRIPTION
### Context
This method seems to be the root cause of the worst of a set of alleged 1+N queries https://dfe-teacher-services.sentry.io/issues/5830325660/?project=5552118&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2Cmedium%2Clow%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=9.

Doesn't seem to be a classic 1+N query and bullet doesn't recognise it. However we are calling this method 22 times with just 3 different arguments (the 3 funding types).

### Changes proposed in this pull request
- Memoize results of `FundingManager#available_amount` (we have to keep the results in a hash because the method has a `funding_type` arg but there are only 3 types).

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
