### PR TITLE
[7771] - lock rubyzip until 3.0 release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ gem "kaminari"
 
 gem "activerecord-session_store"
 # Zip file extracting
-gem "rubyzip"
+gem "rubyzip", "~> 2.3.0"
 
 # Monitoring
 gem "prometheus-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -838,7 +838,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-rspec_rails
   ruby-progressbar
-  rubyzip
+  rubyzip (~> 2.3.0)
   scss_lint-govuk
   sentry-rails
   sentry-ruby


### PR DESCRIPTION
### Context

[Update/review really old gem rubyzip](https://trello.com/c/O9Oy6Asv/7771-update-review-really-old-gem-rubyzip)

### Changes proposed in this pull request

locks to 2.3.x, (migration to 3.0.0 when rubyzip is out of alpha)
