### PR TITLE
[7766] 1+N query cleanup - avoid repeated query in `TrainingDetailsForm`

### DIFF
--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -50,7 +50,9 @@ private
   end
 
   def existing_trainee_with_id
-    @existing_trainee_with_id ||= Trainee.where.not(id: trainee.id)
+    return @existing_trainee_with_id if defined?(@existing_trainee_with_id)
+
+    @existing_trainee_with_id = Trainee.where.not(id: trainee.id)
       .where(provider_id:)
       .where("UPPER(provider_trainee_id) = ?", provider_trainee_id.upcase).first
   end


### PR DESCRIPTION
### Context
When we validate a trainee record, e.g. to show the status of a draft trainee we run a query in `TrainingDetailsForm` to search for an existing record with similar details. When there is no match the query is repeated 7 times because although it is memoised (in the conventional way) the query returns `nil` (because there is no matching trainee).

Strictly speaking it's not a 1+N query though Sentry flags it as such.

### Changes proposed in this pull request
We need to use `defined?` rather than `||=`.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
