### PR TITLE
[7772] - remove scss_lint-govuk

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,1 +1,0 @@
-plugin_gems: ['scss_lint-govuk']

--- a/Gemfile
+++ b/Gemfile
@@ -156,8 +156,6 @@ group :development, :test do
   gem "rubocop-rspec"
   gem "rubocop-rspec_rails"
 
-  gem "scss_lint-govuk"
-
   # Debugging
   gem "debug"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -616,15 +616,6 @@ GEM
       base64
     rubyzip (2.3.2)
     safely_block (0.4.1)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
-    scss_lint-govuk (0.2.0)
-      scss_lint
     securerandom (0.3.1)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -839,7 +830,6 @@ DEPENDENCIES
   rubocop-rspec_rails
   ruby-progressbar
   rubyzip
-  scss_lint-govuk
   sentry-rails
   sentry-ruby
   sentry-sidekiq


### PR DESCRIPTION
### Context

[Update/review really old gem sass](https://trello.com/c/81rQkegV/7772-update-review-really-old-gem-sass)

### Changes proposed in this pull request

Fairly sure this gem isn't being used, have removed and will see if anything fails in CI