### PR TITLE
[7745] Added playbook notes for `Adding a previous trainee for a former accredited provider

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -380,3 +380,20 @@ This command will:
       - `create_trainees_from_apply`
 
 Note: This process will import a fresh copy of the applicants' details and use them to create new records. This ensures that the system realigns with its normal mode of operation, correcting any issues caused by previously imported, potentially stale data.
+
+### Adding a previous trainee for a former accredited provider
+
+
+Given a lead provider and the former accredited provider is the same.
+```ruby
+
+lead_partner = LeadPartner.find(1363)
+
+lead_partner.name == lead_partner.provider.name && lead_partner.provider.accredited? == false
+
+trainee = Trainee.new(provider: lead_partner.provider, state: :draft)
+```
+
+Create a `draft` trainee for `lead_partner.provider` and have support agent to liaise with the provider to ensure the the details are correct, and the dates are correct.
+
+May need overseeing from `draft` to `awarded`.

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -381,10 +381,10 @@ This command will:
 
 Note: This process will import a fresh copy of the applicants' details and use them to create new records. This ensures that the system realigns with its normal mode of operation, correcting any issues caused by previously imported, potentially stale data.
 
-### Adding a previous trainee for a former accredited provider
+## Adding a previous trainee for a former accredited provider
 
 
-Given a lead provider and the former accredited provider is the same.
+Given a lead partner and the former accredited provider is the same.
 ```ruby
 
 lead_partner = LeadPartner.find(1363)
@@ -394,6 +394,6 @@ lead_partner.name == lead_partner.provider.name && lead_partner.provider.accredi
 trainee = Trainee.new(provider: lead_partner.provider, state: :draft)
 ```
 
-Create a `draft` trainee for `lead_partner.provider` and have support agent to liaise with the provider to ensure the the details are correct, and the dates are correct.
+Create a `draft` trainee for `lead_partner.provider` and ask the support agent to liaise with the provider to ensure that the details are correct, and the dates are correct.
 
 May need overseeing from `draft` to `awarded`.


### PR DESCRIPTION
### Context
Adding a previous trainee for a former accredited provider

### Changes proposed in this pull request
Added playbook notes for `Adding a previous trainee for a former accredited provider

### Guidance to review
For the next support dev

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
