### PR TITLE
[7773] - replace webdriver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -205,7 +205,7 @@ end
 group :test do
   # Headless browser testing kit
   gem "cuprite", "~> 0.15"
-  gem "webdrivers", "~> 5.3"
+  gem "selenium-webdriver"
 
   gem "shoulda-matchers", "~> 6.4"
   # Code coverage reporter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,9 @@ GEM
     rubyzip (2.3.2)
     safely_block (0.4.1)
     securerandom (0.3.1)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.26.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -709,10 +711,6 @@ GEM
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webfinger (2.1.3)
       activesupport
       faraday (~> 2.0)
@@ -723,7 +721,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.2)
     webrobots (0.1.2)
-    websocket (1.2.9)
+    websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -828,6 +826,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   ruby-progressbar
   rubyzip
+  selenium-webdriver
   sentry-rails
   sentry-ruby
   sentry-sidekiq
@@ -850,7 +849,6 @@ DEPENDENCIES
   timecop (~> 0.9.10)
   tzinfo-data
   uk_postcode
-  webdrivers (~> 5.3)
   webmock
   yabeda-prometheus
   yabeda-rails


### PR DESCRIPTION
### Context
`webdriver` is no longer needed and selenium-webdriver should be used instead

### Changes proposed in this pull request

* Removes `webdriver` and adds `selenium-webdriver`
* Smoke testing has been run by @d-a-v-e and still works with new gem-set
