### PR TITLE
[7748] remove pii from logs sent to logitio

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "stackprof"
 gem "amazing_print", "~> 1.6"
 
 # There seems to be an issue with 4.17.0 where the workers log the sql
-gem "rails_semantic_logger", "4.17.0"
+gem "rails_semantic_logger", github: "kennyevil/rails_semantic_logger", branch: "filter-bind-values"
 
 # Thread-safe global state
 gem "request_store", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,16 @@ GIT
       activesupport
       tzinfo
 
+GIT
+  remote: https://github.com/kennyevil/rails_semantic_logger.git
+  revision: c09d7158bdcd8884a13d185848c3a519d9d4bf6d
+  branch: filter-bind-values
+  specs:
+    rails_semantic_logger (4.17.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -515,10 +525,6 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    rails_semantic_logger (4.17.0)
-      rack
-      railties (>= 5.1)
-      semantic_logger (~> 4.16)
     railties (7.2.0)
       actionpack (= 7.2.0)
       activesupport (= 7.2.0)
@@ -814,7 +820,7 @@ DEPENDENCIES
   rails (~> 7.2)
   rails-controller-testing
   rails-erd
-  rails_semantic_logger (= 4.17.0)
+  rails_semantic_logger!
   request_store (~> 1.7)
   rotp
   rspec-benchmark

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -32,4 +32,5 @@ Rails.application.config.filter_parameters += [
   :region,
   :town_city,
   :trn,
+  :audited_changes,
 ]


### PR DESCRIPTION
### Context

[Rails Semantic Logger](https://github.com/reidmorrison/rails_semantic_logger) does not filter sensitive information, as defined by the `Rails.configuration.filter_paramters` setting from the sql statements in the log file.

### Changes proposed in this pull request

I have forked the repo and put in a [Pull Request](https://github.com/reidmorrison/rails_semantic_logger/pull/247) to address this issue. 

I've also added `audited_changes` as a filtered parameter to ensure PII does not sent to third parties that way.

Use the forked version of `Rails Semantic Logger` until the PR has been accepted.

<img width="1672" alt="Screenshot 2024-11-07 at 12 39 29" src="https://github.com/user-attachments/assets/c028f33f-5570-4ad7-8571-f1e922770dab">
<img width="1675" alt="Screenshot 2024-11-07 at 12 39 01" src="https://github.com/user-attachments/assets/3bc9e7bd-8603-4bc2-bd5a-e4db90e55732">


### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
