### PR TITLE
[xxxx] Fixed `language_specialism_options` issues

### DIFF
--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 feature "Change course", feature_publish_course_details: true do
+  include CourseDetailsHelper
+
   let(:itt_start_date) { Date.new(Settings.current_recruitment_cycle_year, 9, 1) }
   let(:itt_end_date) { itt_start_date + 1.year }
 
@@ -152,7 +154,7 @@ private
     end
 
     if page.current_path.include?("language-specialism")
-      language_specialism_page.language_specialism_options.sample.check
+      language_specialism_page.language_select_one.select(language_specialism_options.to_h.keys.compact_blank.sample)
       language_specialism_page.submit_button.click
     end
   end


### PR DESCRIPTION
### Context
`language_specialism_options`

### Changes proposed in this pull request
Fixed `language_specialism_options` issues

### Guidance to review
Was removed in https://github.com/DFE-Digital/register-trainee-teachers/pull/3350 

Before fix run and you see it breaks

```bash
for i in {1..100} 
do
bundle exec rspec ./spec/features/trainee_actions/change_course_spec.rb:9  --seed 27910
done
```

![image](https://github.com/user-attachments/assets/2af54a6a-7d52-4969-9d95-d37a80aab252)

https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/11819236768/job/32928810800?pr=4804

[Page](https://github.com/DFE-Digital/register-trainee-teachers/blob/83c395d249d4b30c126a16bf78a888ccd7e8b67d/spec/support/page_objects/trainees/language_specialism.rb) it was referring to.
### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
