### PR TITLE
[7833] Install turbo-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby "3.3.5"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 7.2"
 gem "sprockets-rails"
+gem "turbo-rails"
 
 # Use postgresql as the database for Active Record
 gem "pg", ">= 0.18", "< 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,6 +702,9 @@ GEM
     timecop (0.9.10)
     timeout (0.4.2)
     trailblazer-option (0.1.2)
+    turbo-rails (2.0.11)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
@@ -853,6 +856,7 @@ DEPENDENCIES
   store_model (~> 4.1)
   strong_migrations
   timecop (~> 0.9.10)
+  turbo-rails
   tzinfo-data
   uk_postcode
   webmock

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,4 @@
-import '@hotwired/turbo-rails'
-
-Turbo.session.drive = false
+import { Turbo } from '@hotwired/turbo-rails'
 
 import jQuery from 'jquery'
 
@@ -22,6 +20,8 @@ import FilterToggle from './scripts/filter_toggle'
 import CookieBanner from './scripts/cookie_banner'
 
 import { initAll } from 'govuk-frontend'
+
+Turbo.session.drive = false
 
 window.jQuery = jQuery
 window.$ = jQuery

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,5 @@
 import '@hotwired/turbo-rails'
+
 import jQuery from 'jquery'
 
 import './scripts/global/nationality_select'
@@ -23,11 +24,12 @@ import { initAll } from 'govuk-frontend'
 window.jQuery = jQuery
 window.$ = jQuery
 
-// Initialize GOV.UK Frontend components
-initAll()
+document.addEventListener('turbo:load', function() {
+  // Initialize GOV.UK Frontend components
+  initAll()
 
-// Initialize custom components
-LiveFilter.init()
-FilterToggle.init()
-CookieBanner.init()
-import "@hotwired/turbo-rails"
+  // Initialize custom components
+  LiveFilter.init()
+  FilterToggle.init()
+  CookieBanner.init()
+})

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,7 @@
 import '@hotwired/turbo-rails'
 
+Turbo.session.drive = false
+
 import jQuery from 'jquery'
 
 import './scripts/global/nationality_select'

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -24,7 +24,7 @@ import { initAll } from 'govuk-frontend'
 window.jQuery = jQuery
 window.$ = jQuery
 
-document.addEventListener('turbo:load', function() {
+document.addEventListener('turbo:load', function () {
   // Initialize GOV.UK Frontend components
   initAll()
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
+import '@hotwired/turbo-rails'
 import jQuery from 'jquery'
 
 import './scripts/global/nationality_select'
@@ -29,3 +30,4 @@ initAll()
 LiveFilter.init()
 FilterToggle.init()
 CookieBanner.init()
+import "@hotwired/turbo-rails"

--- a/app/javascript/scripts/components/form_components/lead_partners_autocomplete.js
+++ b/app/javascript/scripts/components/form_components/lead_partners_autocomplete.js
@@ -13,8 +13,14 @@ const fetchLeadPartners = ({ query, populateResults }) => {
   window.fetch(`/autocomplete/lead_partners?query=${encodedQuery}`)
     .then(response => response.json())
     .then(guard)
-    .then((data) => data.lead_partners)
-    .then((data) => { if (data.length === 0) { statusMessage = 'No results found' } else { return data } })
+    .then(data => data.lead_partners)
+    .then((leadPartners) => {
+      if (leadPartners.length === 0) {
+        statusMessage = 'No results found'
+      }
+
+      return leadPartners
+    })
     .then(populateResults)
     .catch(console.log)
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <%= favicon_link_tag image_path('govuk-icon-180.png'), rel: 'apple-touch-icon', type: nil %>
 
     <%= stylesheet_link_tag "accessible-autocomplete/dist/accessible-autocomplete.min" %>
-    <%= stylesheet_link_tag "application" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 
     <% if google_analytics_allowed? %>
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/app/views/trainees/employing_schools/details/edit.html.erb
+++ b/app/views/trainees/employing_schools/details/edit.html.erb
@@ -6,9 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with model: @employing_school_form, url: trainee_employing_schools_details_path(@trainee), local: true,
-                           html: { data: { module: "app-schools-autocomplete" } } do |f| %>
-
+    <%= register_form_with model: @employing_school_form, url: trainee_employing_schools_details_path(@trainee) do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons :employing_school_not_applicable,
         @employing_school_form.employing_school_not_applicable_options,

--- a/app/views/trainees/lead_partners/details/edit.html.erb
+++ b/app/views/trainees/lead_partners/details/edit.html.erb
@@ -6,8 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with model: @lead_partner_form, url: trainee_lead_partners_details_path(@trainee), local: true,
-                           html: { data: { module: "app-lead-partners-autocomplete" } } do |f| %>
+    <%= register_form_with model: @lead_partner_form, url: trainee_lead_partners_details_path(@trainee) do |f| %>
 
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons :lead_partner_not_applicable,

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -38,5 +38,6 @@ Rails.application.config.content_security_policy do |policy|
                     "https://www.googletagmanager.com",
                     "https://www.google-analytics.com",
                     "https://az416426.vo.msecnd.net") # needed for App Insights
+  policy.style_src(:self, "'sha256-WAyOw4V+FqDc35lQPyRADLBWbuNK8ahvYEaQIYF1+Ps='") # Turbo progress bar stylesheet https://github.com/hotwired/turbo/issues/809
   policy.font_src(:self, :data)
 end

--- a/package.json
+++ b/package.json
@@ -1,47 +1,48 @@
-  {
-    "engines": {
-      "node": "20.x"
-    },
-    "scripts": {
-      "js:lint": "standard",
-      "js:lint:fix": "standard --fix",
-      "scss:lint": "stylelint 'app/assets/stylesheets/**/*.scss'",
-      "scss:lint:fix": "stylelint 'app/assets/stylesheets/**/*.scss' --fix",
-      "test": "jest",
-      "test:ci": "jest --ci --runInBand --coverage",
-      "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
-      "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --load-path=. --quiet-deps"
-    },
-    "dependencies": {
-      "@ministryofjustice/frontend": "^3.0.3",
-      "accessible-autocomplete": "^3.0.1",
-      "govuk-country-and-territory-autocomplete": "^2.0.0",
-      "govuk-frontend": "^5.7.1",
-      "jquery": "^3.7.1",
-      "rails-ujs": "^5.2.8",
-      "sass": "^1.81.0",
-      "turbolinks": "^5.2.0"
-    },
-    "devDependencies": {
-      "esbuild": "^0.24.0",
-      "esbuild-jest-transform": "^2.0.1",
-      "jest": "^29.7.0",
-      "jest-environment-jsdom": "^29.7.0",
-      "postcss": "^8.4.49",
-      "standard": "^17.1.2",
-      "stylelint": "^15.11.0",
-      "stylelint-config-gds": "^1.1.1",
-      "stylelint-config-standard-scss": "^11.1.0",
-      "stylelint-scss": "^5.3.2"
-    },
-    "standard": {
-      "env": [
-        "jest"
-      ]
-    },
-    "stylelint": {
-      "extends": "stylelint-config-gds/scss"
-    },
-    "license": "MIT",
-    "packageManager": "yarn@1.22.22"
-  }
+{
+  "engines": {
+    "node": "20.x"
+  },
+  "scripts": {
+    "js:lint": "standard",
+    "js:lint:fix": "standard --fix",
+    "scss:lint": "stylelint 'app/assets/stylesheets/**/*.scss'",
+    "scss:lint:fix": "stylelint 'app/assets/stylesheets/**/*.scss' --fix",
+    "test": "jest",
+    "test:ci": "jest --ci --runInBand --coverage",
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
+    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --load-path=. --quiet-deps"
+  },
+  "dependencies": {
+    "@hotwired/turbo-rails": "^8.0.12",
+    "@ministryofjustice/frontend": "^3.0.3",
+    "accessible-autocomplete": "^3.0.1",
+    "govuk-country-and-territory-autocomplete": "^2.0.0",
+    "govuk-frontend": "^5.7.1",
+    "jquery": "^3.7.1",
+    "rails-ujs": "^5.2.8",
+    "sass": "^1.81.0",
+    "turbolinks": "^5.2.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0",
+    "esbuild-jest-transform": "^2.0.1",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "postcss": "^8.4.49",
+    "standard": "^17.1.2",
+    "stylelint": "^15.11.0",
+    "stylelint-config-gds": "^1.1.1",
+    "stylelint-config-standard-scss": "^11.1.0",
+    "stylelint-scss": "^5.3.2"
+  },
+  "standard": {
+    "env": [
+      "jest"
+    ]
+  },
+  "stylelint": {
+    "extends": "stylelint-config-gds/scss"
+  },
+  "license": "MIT",
+  "packageManager": "yarn@1.22.22"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,6 +474,19 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.55.0.tgz#b721d52060f369aa259cf97392403cb9ce892ec6"
   integrity sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==
 
+"@hotwired/turbo-rails@^8.0.12":
+  version "8.0.12"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.12.tgz#6f1a2661122c0a2bf717f3bc68b5106638798c89"
+  integrity sha512-ZXwu9ez+Gd4RQNeHIitqOQgi/LyqY8J4JqsUN0nnYiZDBRq7IreeFdMbz29VdJpIsmYqwooE4cFzPU7QvJkQkA==
+  dependencies:
+    "@hotwired/turbo" "^8.0.12"
+    "@rails/actioncable" "^7.0"
+
+"@hotwired/turbo@^8.0.12":
+  version "8.0.12"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.12.tgz#50aa8345d7f62402680c6d2d9814660761837001"
+  integrity sha512-l3BiQRkD7qrnQv6ms6sqPLczvwbQpXt5iAVwjDvX0iumrz6yEonQkNAzNjeDX25/OJMFDTxpHjkJZHGpM9ikWw==
+
 "@humanwhocodes/config-array@^0.11.13":
   version "0.11.13"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.13.tgz#075dc9684f40a531d9b26b0822153c1e832ee297"
@@ -844,6 +857,11 @@
     "@parcel/watcher-win32-arm64" "2.4.1"
     "@parcel/watcher-win32-ia32" "2.4.1"
     "@parcel/watcher-win32-x64" "2.4.1"
+
+"@rails/actioncable@^7.0":
+  version "7.2.200"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.200.tgz#7f56b3313762dbb85b64490aa33c5f431419aafd"
+  integrity sha512-gVmi3MabEa+Bkatvw0/k1Y3WTidcIf3qNbb9L8qc+AmT2UmkVqUZhJpSLvKmH10twCYIGzn7yySW/lOpg81Duw==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"


### PR DESCRIPTION
### Context

[7833-install-turbo-rails](https://trello.com/c/XvobXmPU/7833-install-turbo-rails)

`turbo-rails` is required to support links with the `delete` method

### Changes proposed in this pull request

* Install `turbo-rails` gem
* Disable turbo drive by default for links and form submissions
* Fix autocomplete bug for lead partners

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
