### PR TITLE
[xxxxx] Removed Sentry automatic capture for check-ins

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,7 +6,10 @@ Sentry.init do |config|
     filter.filter(event.to_hash)
   end
 
-  config.enabled_patches += [:sidekiq_cron]
+  # NOTE: turn off Sentry Cron monitoring it seems to automatically create new monitor without notice
+  # https://dfe-teacher-services.sentry.io/crons/
+  # config.enabled_patches += [:sidekiq_cron]
+
   config.traces_sample_rate = 0.05
   config.profiles_sample_rate = 0.05
   config.release = ENV.fetch("COMMIT_SHA", nil)


### PR DESCRIPTION
### Context
After merging https://github.com/DFE-Digital/register-trainee-teachers/pull/4817

Which created monitors [here](https://dfe-teacher-services.sentry.io/crons/) without notice

An influx of annoying missed check-ins notification happened 
![image](https://github.com/user-attachments/assets/25a020ab-75f3-42dc-b3c4-0dbdae7b495b)


### Changes proposed in this pull request
Removed Sentry automatic capture for check-ins

### Guidance to review
https://docs.sentry.io/platforms/ruby/crons/#job-monitoring

There is a cost associated, we survived this long with monitoring, there seems to be very little need.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
