### PR TITLE
[7851] Add performance profile banner as a view component

### DIFF
--- a/app/components/performance_profile_banner/view.html.erb
+++ b/app/components/performance_profile_banner/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_notification_banner(title_text: "Important") do |banner| %>
   <% banner.with_heading(text: banner_heading_text) %>
 
-  Find out <%= govuk_link_to("how to check your #{previous_academic_cycle_label} trainee data is accurate for the performance profile publication", "#")%> and how to <%= govuk_link_to("sign off to confirm", performance_profiles_guidance_path) %>.
+  <%= govuk_link_to("Sign off your performance profile", "#")%> by the <%= deadline_date %> deadline.
 <% end %>

--- a/app/components/performance_profile_banner/view.html.erb
+++ b/app/components/performance_profile_banner/view.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_notification_banner(title_text: "Important") do |banner| %>
+  <% banner.with_heading(text: banner_heading_text) %>
+
+  Find out <%= govuk_link_to("how to check your #{previous_academic_cycle_label} trainee data is accurate for the performance profile publication", "#")%> and how to <%= govuk_link_to("sign off to confirm", performance_profiles_guidance_path) %>.
+<% end %>

--- a/app/components/performance_profile_banner/view.rb
+++ b/app/components/performance_profile_banner/view.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PerformanceProfileBanner
+  class View < ViewComponent::Base
+    DEFAULT_ACADEMIC_CYCLE_START_DATE = "1 August"
+
+    def initialize(previous_academic_cycle: AcademicCycle.previous, sign_off_period: DetermineSignOffPeriod.call, provider:)
+      @previous_academic_cycle = previous_academic_cycle
+      @provider = provider
+      @sign_off_period = sign_off_period
+    end
+
+    def render?
+      performance_period? && provider_awaiting_sign_off?
+    end
+
+    def banner_heading_text
+      "The #{previous_academic_cycle_label} performance profile sign off deadline is #{deadline}."
+    end
+
+    delegate :label, :end_year, to: :previous_academic_cycle, prefix: true
+
+  private
+
+    attr_reader :previous_academic_cycle, :provider, :sign_off_period
+
+    def deadline
+      "31 January #{previous_academic_cycle_end_year}"
+    end
+
+    def provider_awaiting_sign_off?
+      !provider.performance_signed_off
+    end
+
+    def performance_period?
+      sign_off_period == :performance_period
+    end
+  end
+end

--- a/app/components/performance_profile_banner/view.rb
+++ b/app/components/performance_profile_banner/view.rb
@@ -15,18 +15,18 @@ module PerformanceProfileBanner
     end
 
     def banner_heading_text
-      "The #{previous_academic_cycle_label} performance profile sign off deadline is #{deadline}."
+      "The #{previous_academic_cycle_label} ITT performance profile sign off due"
     end
 
     delegate :label, :end_year, to: :previous_academic_cycle, prefix: true
 
+    def deadline_date
+      "28 February #{previous_academic_cycle_end_year + 1}"
+    end
+
   private
 
     attr_reader :previous_academic_cycle, :provider, :sign_off_period
-
-    def deadline
-      "31 January #{previous_academic_cycle_end_year + 1}"
-    end
 
     def provider_awaiting_sign_off?
       !provider.performance_signed_off?

--- a/app/components/performance_profile_banner/view.rb
+++ b/app/components/performance_profile_banner/view.rb
@@ -29,7 +29,7 @@ module PerformanceProfileBanner
     attr_reader :previous_academic_cycle, :provider, :sign_off_period
 
     def provider_awaiting_sign_off?
-      !provider.performance_signed_off?
+      !provider.performance_profile_signed_off?
     end
 
     def performance_period?

--- a/app/components/performance_profile_banner/view.rb
+++ b/app/components/performance_profile_banner/view.rb
@@ -25,11 +25,11 @@ module PerformanceProfileBanner
     attr_reader :previous_academic_cycle, :provider, :sign_off_period
 
     def deadline
-      "31 January #{previous_academic_cycle_end_year}"
+      "31 January #{previous_academic_cycle_end_year + 1}"
     end
 
     def provider_awaiting_sign_off?
-      !provider.performance_signed_off
+      !provider.performance_signed_off?
     end
 
     def performance_period?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -115,7 +115,7 @@ class Provider < ApplicationRecord
   end
 
   def performance_profile_signed_off?
-    sign_offs.performance_profile.current_academic_cycle.exists?
+    sign_offs.performance_profile.previous_academic_cycle.exists?
   end
 
 private

--- a/app/models/sign_off.rb
+++ b/app/models/sign_off.rb
@@ -33,9 +33,9 @@ class SignOff < ApplicationRecord
   TYPES = %w[performance_profile census].freeze
   enum(:sign_off_type, TYPES.to_h { |type| [type, type] })
 
-  scope :current_academic_cycle, lambda {
-    return none if AcademicCycle.current.blank?
+  scope :previous_academic_cycle, lambda {
+    return none if AcademicCycle.previous.blank?
 
-    joins(:academic_cycle).where(academic_cycles: { id: AcademicCycle.current.id })
+    joins(:academic_cycle).where(academic_cycles: { id: AcademicCycle.previous.id })
   }
 end

--- a/spec/components/performance_profile_banner/view_preview.rb
+++ b/spec/components/performance_profile_banner/view_preview.rb
@@ -20,10 +20,10 @@ class PerformanceProfileBanner::ViewPreview < ViewComponent::Preview
 private
 
   def provider_awaiting_sign_off
-    OpenStruct.new(performance_signed_off: false)
+    OpenStruct.new(performance_signed_off?: false)
   end
 
   def provider_performance_signed_off
-    OpenStruct.new(performance_signed_off: true)
+    OpenStruct.new(performance_signed_off?: true)
   end
 end

--- a/spec/components/performance_profile_banner/view_preview.rb
+++ b/spec/components/performance_profile_banner/view_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class PerformanceProfileBanner::ViewPreview < ViewComponent::Preview
+  def census_period
+    render(PerformanceProfileBanner::View.new(previous_academic_cycle: AcademicCycle.previous, sign_off_period: :census_period, provider: provider_awaiting_sign_off))
+  end
+
+  def outside_period
+    render(PerformanceProfileBanner::View.new(previous_academic_cycle: AcademicCycle.previous, sign_off_period: :outside_period, provider: provider_awaiting_sign_off))
+  end
+
+  def performance_period_signed_off
+    render(PerformanceProfileBanner::View.new(previous_academic_cycle: AcademicCycle.previous, sign_off_period: :performance_period, provider: provider_performance_signed_off))
+  end
+
+  def performance_period_awaiting_sign_off
+    render(PerformanceProfileBanner::View.new(previous_academic_cycle: AcademicCycle.previous, sign_off_period: :performance_period, provider: provider_awaiting_sign_off))
+  end
+
+private
+
+  def provider_awaiting_sign_off
+    OpenStruct.new(performance_signed_off: false)
+  end
+
+  def provider_performance_signed_off
+    OpenStruct.new(performance_signed_off: true)
+  end
+end

--- a/spec/components/performance_profile_banner/view_preview.rb
+++ b/spec/components/performance_profile_banner/view_preview.rb
@@ -20,10 +20,10 @@ class PerformanceProfileBanner::ViewPreview < ViewComponent::Preview
 private
 
   def provider_awaiting_sign_off
-    OpenStruct.new(performance_signed_off?: false)
+    OpenStruct.new(performance_profile_signed_off?: false)
   end
 
   def provider_performance_signed_off
-    OpenStruct.new(performance_signed_off?: true)
+    OpenStruct.new(performance_profile_signed_off?: true)
   end
 end

--- a/spec/components/performance_profile_banner/view_spec.rb
+++ b/spec/components/performance_profile_banner/view_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe PerformanceProfileBanner::View do
   let(:previous_academic_cycle) { create(:academic_cycle, previous_cycle: true) }
+  let(:previous_academic_cycle_label) { previous_academic_cycle.label }
   let(:sign_off_period) { :census_period }
 
   let(:provider_awaiting_sign_off) { OpenStruct.new(performance_signed_off?: false) }
@@ -47,12 +48,11 @@ describe PerformanceProfileBanner::View do
 
     it "renders correctly" do
       expect(@result).to have_css("#govuk-notification-banner-title", text: "Important")
-      expect(@result).to have_css(".govuk-notification-banner__heading", text: "The #{previous_academic_cycle.label} performance profile sign off deadline is 31 January #{previous_academic_cycle.end_year + 1}.")
+      expect(@result).to have_css(".govuk-notification-banner__heading", text: "The #{previous_academic_cycle_label} ITT performance profile sign off due")
     end
 
-    it "renders the links correctly" do
-      expect(@result).to have_link("sign off to confirm", href: "/guidance/performance-profiles")
-      expect(@result).to have_link("how to check your #{previous_academic_cycle.label} trainee data is accurate for the performance profile publication", href: "#")
+    it "renders the link correctly" do
+      expect(@result).to have_link("Sign off your performance profile", href: "#")
     end
   end
 end

--- a/spec/components/performance_profile_banner/view_spec.rb
+++ b/spec/components/performance_profile_banner/view_spec.rb
@@ -3,13 +3,15 @@
 require "rails_helper"
 
 describe PerformanceProfileBanner::View do
-  let(:previous_academic_cycle) { create(:academic_cycle, previous_cycle: true) }
+  let(:previous_academic_cycle) { create(:academic_cycle, :previous) }
+  let(:current_academic_cycle) { create(:academic_cycle, :current) }
   let(:previous_academic_cycle_label) { previous_academic_cycle.label }
+
   let(:sign_off_period) { :census_period }
 
-  let(:provider_awaiting_sign_off) { OpenStruct.new(performance_signed_off?: false) }
+  let(:provider_awaiting_sign_off) { create(:provider, sign_offs: [build(:sign_off, :performance_profile, academic_cycle: current_academic_cycle)]) }
 
-  let(:provider_performance_signed_off) { OpenStruct.new(performance_signed_off?: true) }
+  let(:provider_performance_signed_off) { create(:provider, sign_offs: [build(:sign_off, :performance_profile, academic_cycle: previous_academic_cycle)]) }
 
   before do
     @result = render_inline(PerformanceProfileBanner::View.new(previous_academic_cycle:, sign_off_period:, provider:))

--- a/spec/components/performance_profile_banner/view_spec.rb
+++ b/spec/components/performance_profile_banner/view_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PerformanceProfileBanner::View do
+  let(:previous_academic_cycle) { create(:academic_cycle, previous_cycle: true) }
+  let(:sign_off_period) { :census_period }
+
+  let(:provider_awaiting_sign_off) { OpenStruct.new(performance_signed_off?: false) }
+
+  let(:provider_performance_signed_off) { OpenStruct.new(performance_signed_off?: true) }
+
+  before do
+    @result = render_inline(PerformanceProfileBanner::View.new(previous_academic_cycle:, sign_off_period:, provider:))
+  end
+
+  context "census_period" do
+    let(:sign_off_period) { :census_period }
+    let(:provider) { provider_awaiting_sign_off }
+
+    it "renders nothing" do
+      expect(@result.text).to be_blank
+    end
+  end
+
+  context "outside_period" do
+    let(:sign_off_period) { :outside_period }
+    let(:provider) { provider_awaiting_sign_off }
+
+    it "renders nothing" do
+      expect(@result.text).to be_blank
+    end
+  end
+
+  context "performance_period_signed_off" do
+    let(:sign_off_period) { :performance_period }
+    let(:provider) { provider_performance_signed_off }
+
+    it "renders nothing" do
+      expect(@result.text).to be_blank
+    end
+  end
+
+  context "performance_period_awaiting_sign_off" do
+    let(:sign_off_period) { :performance_period }
+    let(:provider) { provider_awaiting_sign_off }
+
+    it "renders correctly" do
+      expect(@result).to have_css("#govuk-notification-banner-title", text: "Important")
+      expect(@result).to have_css(".govuk-notification-banner__heading", text: "The #{previous_academic_cycle.label} performance profile sign off deadline is 31 January #{previous_academic_cycle.end_year + 1}.")
+    end
+
+    it "renders the links correctly" do
+      expect(@result).to have_link("sign off to confirm", href: "/guidance/performance-profiles")
+      expect(@result).to have_link("how to check your #{previous_academic_cycle.label} trainee data is accurate for the performance profile publication", href: "#")
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -262,16 +262,16 @@ describe Provider do
     context "when there are performance sign offs from the previous academic cycle" do
       let(:provider) { create(:provider, :previous_performance_profile_sign_off) }
 
-      it "returns false" do
-        expect(provider.performance_profile_signed_off?).to be false
+      it "returns true" do
+        expect(provider.performance_profile_signed_off?).to be true
       end
     end
 
-    context "when there are performace sign offs from the current academic cycle" do
+    context "when there are performance sign offs from the current academic cycle" do
       let(:provider) { create(:provider, :performance_profile_sign_off) }
 
-      it "returns true" do
-        expect(provider.performance_profile_signed_off?).to be true
+      it "returns false" do
+        expect(provider.performance_profile_signed_off?).to be false
       end
     end
   end


### PR DESCRIPTION
### Context
The performance profile banner

### Changes proposed in this pull request
Added the component
### Guidance to review
Just the component

https://register-pr-4828.test.teacherservices.cloud/view_components/performance_profile_banner/view

![image](https://github.com/user-attachments/assets/7e49b20f-d4e2-401f-bb36-b2a6094bafe0)





There a a few loose ends, will be fix in future PRs (actually showing it to the user)

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
