### PR TITLE
[7852] Fix bug with updating disabilities via the API

### DIFF
--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -153,6 +153,8 @@ module Api
         self.trainee_disabilities_attributes = []
 
         new_attributes[:disabilities]&.each do |disability|
+          next if disability.blank?
+
           trainee_disabilities_attributes << { disability_id: disability.id }
         end
 

--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -119,9 +119,9 @@ module Api
           nationalisations_attributes << NationalityAttributes.new(nationalisation_params)
         end
 
-        hesa_trainee_detail_attributes_raw = new_attributes.slice(*HesaTraineeDetailAttributes::ATTRIBUTES)
-        if hesa_trainee_detail_attributes_raw.present?
-          self.hesa_trainee_detail_attributes = V01::HesaTraineeDetailAttributes.new(hesa_trainee_detail_attributes_raw)
+        new_hesa_trainee_detail_attributes = new_attributes.slice(*HesaTraineeDetailAttributes::ATTRIBUTES)
+        if new_hesa_trainee_detail_attributes.present?
+          self.hesa_trainee_detail_attributes = V01::HesaTraineeDetailAttributes.new(new_hesa_trainee_detail_attributes)
         end
 
         self.trainee_disabilities_attributes = []
@@ -186,10 +186,10 @@ module Api
       end
 
       def self.update_hesa_disabilities(original_hesa_disabilities, params_for_update)
-        updated_hesa_disabilites = original_hesa_disabilities
-        updated_hesa_disabilites = updated_hesa_disabilites.merge(params_for_update[:hesa_disabilities]) if params_for_update[:hesa_disabilities].present?
+        updated_hesa_disabilities = original_hesa_disabilities
+        updated_hesa_disabilities = updated_hesa_disabilities.merge(params_for_update[:hesa_disabilities]) if params_for_update[:hesa_disabilities].present?
 
-        updated_hesa_disabilites
+        updated_hesa_disabilities
       end
 
       def self.from_trainee(trainee, params_for_update)

--- a/spec/components/diversity/view_spec.rb
+++ b/spec/components/diversity/view_spec.rb
@@ -86,7 +86,7 @@ describe Diversity::View do
 
     context "disabled" do
       let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] }
-      let(:trainee) { create(:trainee, :diversity_disclosed, :disabled_with_disabilites_disclosed, disability_disclosure:) }
+      let(:trainee) { create(:trainee, :diversity_disclosed, :disabled_with_disabilities_disclosed, disability_disclosure:) }
 
       it "returns a message stating the user is disabled" do
         expect(rendered_content).to have_text("They shared that they’re disabled")
@@ -120,7 +120,7 @@ describe Diversity::View do
     end
 
     context "when there are disabilities" do
-      let(:trainee) { create(:trainee, :diversity_disclosed, :disabled_with_disabilites_disclosed) }
+      let(:trainee) { create(:trainee, :diversity_disclosed, :disabled_with_disabilities_disclosed) }
 
       it "renders the disability names" do
         trainee.disabilities.each do |disability|

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -62,7 +62,7 @@ FactoryBot.define do
       diversity_disclosure { "diversity_disclosed" }
       ethnic_group { "asian_ethnic_group" }
       disability_disclosure { "disabled" }
-      disabled_with_disabilites_disclosed
+      disabled_with_disabilities_disclosed
       training_initiative { "now_teach" }
       itt_start_date { compute_valid_past_itt_start_date }
       itt_end_date { itt_start_date + 2.years }
@@ -335,7 +335,7 @@ FactoryBot.define do
       disability_disclosure { Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] }
     end
 
-    trait :disabled_with_disabilites_disclosed do
+    trait :disabled_with_disabilities_disclosed do
       disabled
       transient do
         disabilities_count { 1 }
@@ -359,7 +359,7 @@ FactoryBot.define do
       diversity_disclosed
       with_ethnic_group
       with_ethnic_background
-      disabled_with_disabilites_disclosed
+      disabled_with_disabilities_disclosed
     end
 
     trait :with_placement_assignment do

--- a/spec/models/api/v0_1/trainee_attributes_spec.rb
+++ b/spec/models/api/v0_1/trainee_attributes_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Api::V01::TraineeAttributes do
   end
 
   describe ".from_trainee" do
-    let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilites_disclosed, :completed, sex: :prefer_not_to_say) }
+    let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilities_disclosed, :completed, sex: :prefer_not_to_say) }
     let(:blind_disability) { create(:disability, :blind) }
     let(:deaf_disability) { create(:disability, :deaf) }
     let(:trainee_disability) { trainee.disabilities.to_h { |disability| [:disability_id, disability.id] } }

--- a/spec/models/api/v0_1/trainee_attributes_spec.rb
+++ b/spec/models/api/v0_1/trainee_attributes_spec.rb
@@ -173,10 +173,6 @@ RSpec.describe Api::V01::TraineeAttributes do
         expect(attributes.hesa_trainee_detail_attributes.hesa_disabilities).to match({ "disability1" => "55", "disability2" => "58" })
         expect(attributes.trainee_disabilities_attributes).to match([trainee_disability, { disability_id: blind_disability.id }])
       end
-
-      it "correctly sets the sex attribute as an integer" do
-        expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
-      end
     end
 
     context "with replacing hesa_disabilities disability1" do
@@ -193,10 +189,6 @@ RSpec.describe Api::V01::TraineeAttributes do
       it "correct sets both hesa_disabilities & trainee_disabilities_attributes" do
         expect(attributes.hesa_trainee_detail_attributes.hesa_disabilities).to match({ "disability1" => "58" })
         expect(attributes.trainee_disabilities_attributes).to match([{ disability_id: blind_disability.id }])
-      end
-
-      it "correctly sets the sex attribute as an integer" do
-        expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
       end
     end
 
@@ -215,9 +207,22 @@ RSpec.describe Api::V01::TraineeAttributes do
         expect(attributes.hesa_trainee_detail_attributes.hesa_disabilities).to match({ "disability1" => "57", "disability2" => "58" })
         expect(attributes.trainee_disabilities_attributes).to match([{ disability_id: deaf_disability.id }, { disability_id: blind_disability.id }])
       end
+    end
 
-      it "correctly sets the sex attribute as an integer" do
-        expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
+    context "with hesa_disabilities disability1 set to blank and disability2 set to null" do
+      subject(:attributes) { described_class.from_trainee(trainee, { hesa_disabilities: { "disability1" => "", "disability2" => "null" } }) }
+
+      it "pulls HesaTraineeDetail attributes from association" do
+        expect(attributes.hesa_trainee_detail_attributes).to be_present
+
+        Api::V01::HesaTraineeDetailAttributes::ATTRIBUTES.each do |attr|
+          expect(attributes.hesa_trainee_detail_attributes.send(attr)).to be_present
+        end
+      end
+
+      it "correct sets both hesa_disabilities & trainee_disabilities_attributes" do
+        expect(attributes.hesa_trainee_detail_attributes.hesa_disabilities).to match({ "disability1" => "", "disability2" => "null" })
+        expect(attributes.trainee_disabilities_attributes).to be_empty
       end
     end
   end


### PR DESCRIPTION
### Context

Reported via [Trello](https://trello.com/c/qXbNhw5V/24-updating-trainees-without-including-disability-fields) this is a bug where we don't handle blank values for disability.

The fix is simple, but when looking at reproducing this, it raised a couple of other questions around the handling of blank values, and HESA trainee details not being set prior to an update request. These will be looked at in subsequent tickets, so we can get this fix out quickly.

### Changes proposed in this pull request

* Add a test for this scenario
* Guard for blank disabilities
* Fixes some spellings and tweaks names

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
