### PR TITLE
[7850] Create status of new trainee files page

### DIFF
--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,9 +1,9 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <%= upload&.submitted_at&.to_fs(:govuk_date_and_time) %>
+    <%= submitted_at %>
   </td>
   <td class="govuk-table__cell">
-    <%= upload.filename %>
+    <%= filename %>
   </td>
   <td class="govuk-table__cell">
     <%= status %>

--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,0 +1,11 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell">
+    <%= upload&.submitted_at&.to_fs(:govuk_date_and_time) %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= upload.filename %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= status %>
+  </td>
+</tr>

--- a/app/components/bulk_update/trainee_uploads/row/view.rb
+++ b/app/components/bulk_update/trainee_uploads/row/view.rb
@@ -4,30 +4,31 @@ module BulkUpdate
   module TraineeUploads
     module Row
       class View < ViewComponent::Base
+        COLOURS = {
+          "pending" => "govuk-tag--light-blue",
+          "validated" => "govuk-tag--turquoise",
+          "in_progress" => "govuk-tag--blue",
+          "succeeded" => "govuk-tag--green",
+          "failed" => "govuk-tag--red",
+          "cancelled" => "govuk-tag--yellow",
+        }.freeze
+
         attr_reader :upload
 
-        delegate :created_at, :filename, :status, to: :upload
+        delegate :filename, to: :upload
 
         def initialize(upload:)
           @upload = upload
         end
 
         def status
-          content_tag(:span, class: "govuk-tag #{colour}") do
+          content_tag(:span, class: "govuk-tag #{COLOURS[upload.status]}") do
             upload.status.humanize
           end
         end
 
-      private
-
-        def colour
-          {
-            "pending" => "govuk-tag--grey",
-            "validated" => "govuk-tag--grey",
-            "in_progress" => "govuk-tag--grey",
-            "succeeded" => "govuk-tag--green",
-            "failed" => "govuk-tag--red",
-          }[upload.status]
+        def submitted_at
+          upload.submitted_at&.to_fs(:govuk_date_and_time)
         end
       end
     end

--- a/app/components/bulk_update/trainee_uploads/row/view.rb
+++ b/app/components/bulk_update/trainee_uploads/row/view.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module TraineeUploads
+    module Row
+      class View < ViewComponent::Base
+        attr_reader :upload
+
+        delegate :created_at, :filename, :status, to: :upload
+
+        def initialize(upload:)
+          @upload = upload
+        end
+
+        def status
+          content_tag(:span, class: "govuk-tag #{colour}") do
+            upload.status.humanize
+          end
+        end
+
+      private
+
+        def colour
+          {
+            "pending" => "govuk-tag--grey",
+            "validated" => "govuk-tag--grey",
+            "in_progress" => "govuk-tag--grey",
+            "succeeded" => "govuk-tag--green",
+            "failed" => "govuk-tag--red",
+          }[upload.status]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -5,6 +5,12 @@ module BulkUpdate
     class UploadsController < ApplicationController
       before_action { require_feature_flag(:bulk_add_trainees) }
 
+      def index
+        @bulk_update_trainee_uploads = policy_scope(
+          BulkUpdate::TraineeUpload,
+        ).includes(:file_attachment)
+      end
+
       def show
         authorize(bulk_update_trainee_upload)
       end

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -8,7 +8,7 @@ module BulkUpdate
       def index
         @bulk_update_trainee_uploads = policy_scope(
           BulkUpdate::TraineeUpload,
-        ).includes(:file_attachment)
+        ).current_academic_cycle.includes(:file_attachment)
       end
 
       def show

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -42,7 +42,7 @@ module BulkUpdate
       end
 
       def destroy
-        authorize(bulk_update_trainee_upload).cancelled!
+        authorize(bulk_update_trainee_upload).cancel!
 
         redirect_to(bulk_update_path, flash: { success: t(".success") })
       end

--- a/app/forms/bulk_update/bulk_add_trainees_submit_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_submit_form.rb
@@ -15,7 +15,7 @@ module BulkUpdate
     def save
       return false unless valid? && upload.validated?
 
-      upload.in_progress!
+      upload.submit!
 
       BulkUpdate::AddTrainees::ImportRowsJob.perform_later(upload)
     end

--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -50,9 +50,7 @@ module BulkUpdate
     end
 
     def build_upload
-      BulkUpdate::TraineeUpload.new(
-        status: :pending,
-      )
+      BulkUpdate::TraineeUpload.new
     end
 
     def tempfile

--- a/app/jobs/bulk_update/add_trainees/remove_cancelled_and_failed_job.rb
+++ b/app/jobs/bulk_update/add_trainees/remove_cancelled_and_failed_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module AddTrainees
+    class RemoveCancelledAndFailedJob < ApplicationJob
+      queue_as :default
+
+      def perform
+        return unless FeatureService.enabled?(:bulk_add_trainees)
+
+        RemoveUploads.call
+      end
+    end
+  end
+end

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -29,7 +29,27 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
     succeeded: "succeeded",
     failed: "failed",
     cancelled: "cancelled",
-  }
+  } do
+    event :process do
+      transition %i[pending] => :validated
+    end
+
+    event :submit do
+      before do
+        self.submitted_at = Time.current
+      end
+
+      transition %i[validated] => :in_progress
+    end
+
+    event :succeed do
+      transition %i[in_progress] => :succeeded
+    end
+
+    event :fail do
+      transition %i[in_progress] => :failed
+    end
+  end
 
   belongs_to :provider
   has_many :trainee_upload_rows,

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -47,7 +47,7 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
     end
 
     event :fail do
-      transition %i[in_progress] => :failed
+      transition %i[pending validated in_progress] => :failed
     end
   end
 

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -6,7 +6,7 @@
 #
 #  id                 :bigint           not null, primary key
 #  number_of_trainees :integer
-#  status             :string
+#  status             :string           default("pending")
 #  submitted_at       :datetime
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -67,6 +67,10 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
 
   delegate :filename, :download, :attach, to: :file
 
+  scope :current_academic_cycle, lambda {
+    where(created_at: AcademicCycle.current.start_date..AcademicCycle.current.end_date)
+  }
+
   def total_rows_with_errors
     trainee_upload_rows.with_errors.size
   end

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -7,6 +7,7 @@
 #  id                 :bigint           not null, primary key
 #  number_of_trainees :integer
 #  status             :string
+#  submitted_at       :datetime
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  provider_id        :bigint           not null

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -27,8 +27,8 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
     validated: "validated",
     in_progress: "in_progress",
     succeeded: "succeeded",
-    failed: "failed",
     cancelled: "cancelled",
+    failed: "failed",
   } do
     event :process do
       transition %i[pending] => :validated

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -46,6 +46,10 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
       transition %i[in_progress] => :succeeded
     end
 
+    event :cancel do
+      transition %i[validated] => :cancelled
+    end
+
     event :fail do
       transition %i[pending validated in_progress] => :failed
     end

--- a/app/services/bulk_update/add_trainees/import_rows.rb
+++ b/app/services/bulk_update/add_trainees/import_rows.rb
@@ -96,7 +96,7 @@ module BulkUpdate
 
             # Commit or rollback the transaction depending on whether all rows were error free
             if results.all?(&:success)
-              trainee_upload.succeeded! unless dry_run
+              trainee_upload.succeed! unless dry_run
             else
               success = false
             end
@@ -105,16 +105,16 @@ module BulkUpdate
           end
 
           if !success
-            trainee_upload.failed!
+            trainee_upload.fail!
             create_row_errors(results)
           elsif dry_run
-            trainee_upload.validated!
+            trainee_upload.process!
           end
         end
 
         success
       rescue ActiveRecord::ActiveRecordError
-        trainee_upload.failed!
+        trainee_upload.fail!
 
         raise
       end

--- a/app/services/bulk_update/add_trainees/remove_uploads.rb
+++ b/app/services/bulk_update/add_trainees/remove_uploads.rb
@@ -6,8 +6,8 @@ module BulkUpdate
       include ServicePattern
 
       def call
-        TraineeUpload.cancelled.or(
-          TraineeUpload.failed
+        BulkUpdate::TraineeUpload.cancelled.or(
+          BulkUpdate::TraineeUpload.failed,
         ).destroy_all
       end
     end

--- a/app/services/bulk_update/add_trainees/remove_uploads.rb
+++ b/app/services/bulk_update/add_trainees/remove_uploads.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module AddTrainees
+    class RemoveUploads
+      include ServicePattern
+
+      def call
+        TraineeUpload.cancelled.or(
+          TraineeUpload.failed
+        ).destroy_all
+      end
+    end
+  end
+end

--- a/app/views/bulk_update/bulk_updates/index.html.erb
+++ b/app/views/bulk_update/bulk_updates/index.html.erb
@@ -31,6 +31,10 @@
       <p class="govuk-body">
         <%= govuk_link_to("Bulk add new trainees", new_bulk_update_trainees_upload_path) %>
       </p>
+
+      <p class="govuk-body">
+        <%= govuk_link_to("View status of previously uploaded new trainee files", bulk_update_trainees_uploads_path) %>
+      </p>
     <% else %>
       <p class="govuk-body">
         Make changes to multiple trainee records at the same time.

--- a/app/views/bulk_update/trainees/uploads/index.html.erb
+++ b/app/views/bulk_update/trainees/uploads/index.html.erb
@@ -1,0 +1,36 @@
+<%= render PageTitle::View.new(text: "Bulk add new trainees") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: request.referrer) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-xl"><%= organisation_name %></span>
+      Status of new trainee files
+    </h1>
+
+    <p class="govuk-body">
+      View the status of recently uploaded files containing new trainees.<br>
+      This will list all successful new trainee uploads for the current academic year.<br>
+      Failed uploads will be removed after 30 days.
+    </p>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-visually-hidden">Schools</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Submitted</th>
+          <th class="govuk-table__header">Filename</th>
+          <th class="govuk-table__header">Validation status</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body"><tr class="govuk-table__row">
+        <% @bulk_update_trainee_uploads.each do |bulk_update_trainee_upload| %>
+          <%= render(BulkUpdate::TraineeUploads::Row::View.new(upload: bulk_update_trainee_upload)) %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/bulk_update/trainees/uploads/index.html.erb
+++ b/app/views/bulk_update/trainees/uploads/index.html.erb
@@ -18,7 +18,7 @@
     </p>
 
     <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-visually-hidden">Schools</caption>
+      <caption class="govuk-table__caption govuk-visually-hidden">Trainee uploads</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header">Submitted</th>

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -25,11 +25,11 @@
       </p>
 
       <p class="govuk-body">
-        You can also check the <%= link_to "status of new trainee files" %>.
+        You can also check the <%= govuk_link_to "status of new trainees files", bulk_update_trainees_uploads_path %>.
       </p>
 
       <p class="govuk-body">
-        <%= link_to "Back to bulk updates page", bulk_update_path %>
+        <%= govuk_link_to "Back to bulk updates page", bulk_update_path %>
       </p>
     <% else %>
       <h1 class="govuk-heading-l">

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -25,7 +25,7 @@
       </p>
 
       <p class="govuk-body">
-        You can also check the <%= govuk_link_to "status of new trainees files", bulk_update_trainees_uploads_path %>.
+        You can also check the <%= govuk_link_to "status of new trainee files", bulk_update_trainees_uploads_path %>.
       </p>
 
       <p class="govuk-body">

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -429,6 +429,7 @@
     - file_name
     - number_of_trainees
     - status
+    - submitted_at
     - created_at
     - updated_at
   :bulk_update_trainee_upload_rows:

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -16,5 +16,5 @@ Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
              "%e %B %Y at %l:%M%P"
            end
 
-  time.in_time_zone("London").strftime(format)
+  time.in_time_zone("London").strftime(format).squeeze(" ")
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
     end
 
     namespace :trainees do
-      resources :uploads, only: %i[show new create destroy] do
+      resources :uploads, only: %i[index show new create destroy] do
         member do
           resources :submissions, only: %i[show create]
         end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -1,3 +1,10 @@
+# Jobs that run once a month at a specific time, sorted by their running time
+
+delete_cancelled_and_failed_bulk_update_trainee_uploads:
+  cron: "0 0 1 * *" # Every month at 00:00 (midnight).
+  class: "BulkUpdate::AddTrainees::RemoveCancelledAndFailedJob"
+  queue: default
+
 # Jobs that run multiple times a day, sorted by frequency
 import_collection_from_hesa:
   cron: "0 8-23/2 * * *" # every 2 hours, starting at 08:00 and ending at 23:59

--- a/db/migrate/20241121135207_add_submitted_at_to_bulk_update_trainee_uploads.rb
+++ b/db/migrate/20241121135207_add_submitted_at_to_bulk_update_trainee_uploads.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSubmittedAtToBulkUpdateTraineeUploads < ActiveRecord::Migration[7.2]
+  def change
+    add_column :bulk_update_trainee_uploads, :submitted_at, :datetime
+  end
+end

--- a/db/migrate/20241121151740_add_status_default_to_bulk_update_trainee_uploads.rb
+++ b/db/migrate/20241121151740_add_status_default_to_bulk_update_trainee_uploads.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddStatusDefaultToBulkUpdateTraineeUploads < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      change_column_default :bulk_update_trainee_uploads, :status, from: nil, to: :pending
+    end
+  end
+end

--- a/db/migrate/20241126164709_add_status_index_to_bulk_update_trainee_upload.rb
+++ b/db/migrate/20241126164709_add_status_index_to_bulk_update_trainee_upload.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddStatusIndexToBulkUpdateTraineeUpload < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :bulk_update_trainee_uploads, :status, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_21_151740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -266,7 +266,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
     t.datetime "updated_at", null: false
     t.datetime "submitted_at"
     t.index ["provider_id"], name: "index_bulk_update_trainee_uploads_on_provider_id"
-    t.index ["status"], name: "index_bulk_update_trainee_uploads_on_status"
   end
 
   create_table "course_subjects", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_21_134348) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_21_135207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -263,6 +263,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_134348) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "submitted_at"
     t.index ["provider_id"], name: "index_bulk_update_trainee_uploads_on_provider_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,8 +23,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
     t.date "end_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-
-    t.exclusion_constraint "tsrange((start_date)::timestamp without time zone, (end_date)::timestamp without time zone) WITH &&", using: :gist, name: "academic_cycles_date_range"
+    t.index "tsrange((start_date)::timestamp without time zone, (end_date)::timestamp without time zone)", name: "academic_cycles_date_range", using: :gist
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -304,6 +303,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
     t.index ["code", "accredited_body_code"], name: "index_courses_on_code_and_accredited_body_code"
     t.index ["recruitment_cycle_year"], name: "index_courses_on_recruitment_cycle_year"
     t.index ["uuid"], name: "index_courses_on_uuid", unique: true
+  end
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "degrees", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_21_135207) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -23,7 +23,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_135207) do
     t.date "end_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "tsrange((start_date)::timestamp without time zone, (end_date)::timestamp without time zone)", name: "academic_cycles_date_range", using: :gist
+
+    t.exclusion_constraint "tsrange((start_date)::timestamp without time zone, (end_date)::timestamp without time zone) WITH &&", using: :gist, name: "academic_cycles_date_range"
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -260,11 +261,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_135207) do
   create_table "bulk_update_trainee_uploads", force: :cascade do |t|
     t.bigint "provider_id", null: false
     t.integer "number_of_trainees"
-    t.string "status"
+    t.string "status", default: "pending"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "submitted_at"
     t.index ["provider_id"], name: "index_bulk_update_trainee_uploads_on_provider_id"
+    t.index ["status"], name: "index_bulk_update_trainee_uploads_on_status"
   end
 
   create_table "course_subjects", force: :cascade do |t|
@@ -302,9 +304,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_135207) do
     t.index ["code", "accredited_body_code"], name: "index_courses_on_code_and_accredited_body_code"
     t.index ["recruitment_cycle_year"], name: "index_courses_on_recruitment_cycle_year"
     t.index ["uuid"], name: "index_courses_on_uuid", unique: true
-  end
-
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "degrees", force: :cascade do |t|
@@ -670,10 +669,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_135207) do
     t.string "surname16"
     t.string "ttcid"
     t.string "hesa_committed_at"
-    t.string "previous_hesa_id"
     t.string "application_choice_id"
     t.string "itt_start_date"
     t.string "trainee_start_date"
+    t.string "previous_hesa_id"
     t.string "provider_trainee_id"
     t.string "lead_partner_urn"
     t.index ["hesa_id", "rec_id"], name: "index_hesa_students_on_hesa_id_and_rec_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_21_151740) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -266,6 +266,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_151740) do
     t.datetime "updated_at", null: false
     t.datetime "submitted_at"
     t.index ["provider_id"], name: "index_bulk_update_trainee_uploads_on_provider_id"
+    t.index ["status"], name: "index_bulk_update_trainee_uploads_on_status"
   end
 
   create_table "course_subjects", force: :cascade do |t|

--- a/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
+++ b/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
       }.with_indifferent_access
     end
 
-    %w[pending validated in_progress succeeded failed cancelled].each do |status|
+    BulkUpdate::TraineeUpload.statuses.keys.each do |status|
       context "when #{status}" do
         let(:upload) { build(:bulk_update_trainee_upload, status) }
 

--- a/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
+++ b/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
       }.with_indifferent_access
     end
 
-    BulkUpdate::TraineeUpload.statuses.keys.each do |status|
+    BulkUpdate::TraineeUpload.statuses.each_key do |status|
       context "when #{status}" do
         let(:upload) { build(:bulk_update_trainee_upload, status) }
 

--- a/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
+++ b/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
+  subject { described_class.new(upload:) }
+
+  describe "#status" do
+    let(:colours) do
+      {
+        "pending" => "govuk-tag--light-blue",
+        "validated" => "govuk-tag--turquoise",
+        "in_progress" => "govuk-tag--blue",
+        "succeeded" => "govuk-tag--green",
+        "failed" => "govuk-tag--red",
+        "cancelled" => "govuk-tag--yellow",
+      }.with_indifferent_access
+    end
+
+    let(:statuses) do
+      {
+        "pending" => "Pending",
+        "validated" => "Validated",
+        "in_progress" => "In progress",
+        "succeeded" => "Succeeded",
+        "failed" => "Failed",
+        "cancelled" => "Cancelled",
+      }.with_indifferent_access
+    end
+
+    %w[pending validated in_progress succeeded failed cancelled].each do |status|
+      context "when #{status}" do
+        let(:upload) { build(:bulk_update_trainee_upload, status) }
+
+        it do
+          expect(
+            render_inline(subject),
+          ).to have_css(
+            "span", class: "govuk-tag #{colours[upload.status]}", text: statuses[status]
+          )
+        end
+      end
+    end
+  end
+
+  describe "#submitted_at" do
+    context "when bulk_update_trainee_upload#submitted_at is nil" do
+      let(:upload) { build(:bulk_update_trainee_upload) }
+
+      it do
+        expect(subject.submitted_at).to be_nil
+      end
+    end
+
+    context "when bulk_update_trainee_upload#submitted_at is not nil" do
+      let(:submitted_at) { Time.current }
+      let(:upload) { build(:bulk_update_trainee_upload, submitted_at:) }
+
+      it do
+        expect(subject.submitted_at).to eq(submitted_at.to_fs(:govuk_date_and_time))
+      end
+    end
+  end
+end

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -11,7 +11,6 @@ UPLOAD_ERROR_MESSAGES = [
 FactoryBot.define do
   factory :bulk_update_trainee_upload, class: "BulkUpdate::TraineeUpload" do
     provider
-    status { nil }
     number_of_trainees { 5 }
 
     after(:build) do |upload|
@@ -56,10 +55,12 @@ FactoryBot.define do
 
     trait :in_progress do
       status { "in_progress" }
+      submitted_at { Time.current }
     end
 
     trait :succeeded do
       status { "succeeded" }
+      submitted_at { Time.current }
     end
 
     trait :cancelled do
@@ -68,6 +69,7 @@ FactoryBot.define do
 
     trait :failed do
       status { "failed" }
+      submitted_at { Time.current }
 
       after(:create) do |bulk_update_trainee_upload|
         CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -96,13 +96,11 @@ feature "bulk add trainees" do
         and_i_click_on_back_link
 
         when_the_background_job_is_run
-        and_i_refresh_the_page
-        then_i_see_the_review_page_without_validation_errors
-
-        when_i_click_the_view_status_of_new_trainee_files_link
+        and_i_click_the_view_status_of_new_trainee_files_link
         then_i_see_the_upload_status_row_as_validated(BulkUpdate::TraineeUpload.last)
+
         and_i_click_on_back_link
-        then_i_see_the_review_page
+        and_i_see_the_review_page_without_validation_errors
         and_i_dont_see_the_review_errors_link
         and_i_dont_see_the_back_to_bulk_updates_link
 
@@ -121,7 +119,7 @@ feature "bulk add trainees" do
 
         when_the_background_job_is_run
         and_i_refresh_the_page
-        then_i_see_the_review_page
+        then_i_see_the_review_page_without_validation_errors
 
         when_i_click_the_submit_button
         then_a_job_is_queued_to_process_the_upload
@@ -150,7 +148,7 @@ feature "bulk add trainees" do
         when_the_upload_has_failed_with_validation_errors
         and_i_dont_see_that_the_upload_is_processing
         and_i_visit_the_summary_page(upload: @failed_upload)
-        then_i_see_the_review_page
+        then_i_see_the_review_page_without_validation_errors
         and_i_see_the_number_of_trainees_that_can_be_added(number: 3)
         and_i_see_the_validation_errors(number: 2)
         and_i_dont_see_any_duplicate_errors
@@ -431,10 +429,6 @@ private
     expect(page).to have_content(empty ? "The selected file is empty" : "Select a CSV file")
   end
 
-  def then_i_see_the_review_page
-    expect(page).to have_content("You uploaded a CSV file with details of 5 trainees.")
-  end
-
   def then_i_see_the_review_page_without_validation_errors
     expect(page).to have_content("You uploaded a CSV file with details of 5 trainees.")
     expect(page).to have_content("It included:")
@@ -604,4 +598,6 @@ private
   alias_method :when_i_click_the_upload_button, :and_i_click_the_upload_button
   alias_method :and_i_visit_the_bulk_update_index_page, :when_i_visit_the_bulk_update_index_page
   alias_method :when_i_click_on_back_link, :and_i_click_on_back_link
+  alias_method :and_i_click_the_view_status_of_new_trainee_files_link, :when_i_click_the_view_status_of_new_trainee_files_link
+  alias_method :and_i_see_the_review_page_without_validation_errors, :then_i_see_the_review_page_without_validation_errors
 end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -232,7 +232,7 @@ private
 
   def when_an_upload_exists_from_the_previous_academic_cycle
     @previous_academic_cycle_upload ||= Timecop.travel(
-      rand(AcademicCycle.previous.start_date..AcademicCycle.previous.end_date)
+      rand(AcademicCycle.previous.start_date..AcademicCycle.previous.end_date),
     ) do
       create(
         :bulk_update_trainee_upload,

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -89,7 +89,7 @@ feature "bulk add trainees" do
         and_i_click_the_upload_button
         then_i_see_that_the_upload_is_processing
 
-        when_i_click_the_view_status_of_new_trainees_files_link
+        when_i_click_the_view_status_of_new_trainee_files_link
         then_i_see_the_upload_status_row_as_pending(BulkUpdate::TraineeUpload.last)
         and_i_click_on_back_link
 
@@ -97,7 +97,7 @@ feature "bulk add trainees" do
         and_i_refresh_the_page
         then_i_see_the_review_page_without_validation_errors
 
-        when_i_click_the_view_status_of_new_trainees_files_link
+        when_i_click_the_view_status_of_new_trainee_files_link
         then_i_see_the_upload_status_row_as_validated(BulkUpdate::TraineeUpload.last)
         and_i_click_on_back_link
         then_i_see_the_review_page
@@ -214,6 +214,7 @@ feature "bulk add trainees" do
         Timecop.freeze do
           when_multiple_uploads_exist
           and_i_visit_the_bulk_update_index_page
+          and_i_click_on_view_status_of_uploaded_trainee_files
           then_i_see_the_uploads
         end
       end
@@ -226,8 +227,8 @@ private
     click_on "Back"
   end
 
-  def when_i_click_the_view_status_of_new_trainees_files_link
-    click_on "status of new trainees files"
+  def when_i_click_the_view_status_of_new_trainee_files_link
+    click_on "status of new trainee files"
   end
 
   def then_i_see_the_upload_status_row_as_pending(upload)
@@ -246,6 +247,10 @@ private
 
   def and_i_visit_the_bulk_update_index_page
     visit bulk_update_trainees_uploads_path
+  end
+
+  def and_i_click_on_view_status_of_uploaded_trainee_files
+    click_on "View status of previously uploaded new trainee files"
   end
 
   def then_i_see_the_uploads
@@ -307,7 +312,7 @@ private
     expect(page).to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.filename}.")
     expect(page).to have_content("This is taking longer than usual")
     expect(page).to have_content("You'll receive and email to tell you when this is complete.")
-    expect(page).to have_content("You can also check the status of new trainees files.")
+    expect(page).to have_content("You can also check the status of new trainee files.")
     expect(page).to have_link("Back to bulk updates page")
   end
 
@@ -317,7 +322,7 @@ private
     expect(page).not_to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.filename}.")
     expect(page).not_to have_content("This is taking longer than usual")
     expect(page).not_to have_content("You'll receive and email to tell you when this is complete.")
-    expect(page).not_to have_content("You can also check the status of new trainees files.")
+    expect(page).not_to have_content("You can also check the status of new trainee files.")
     expect(page).not_to have_link("Back to bulk updates page")
   end
 
@@ -558,4 +563,5 @@ private
   alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file
   alias_method :and_i_click_the_submit_button, :when_i_click_the_submit_button
   alias_method :when_i_click_the_upload_button, :and_i_click_the_upload_button
+  alias_method :and_i_visit_the_bulk_update_index_page, :when_i_visit_the_bulk_update_index_page
 end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -216,6 +216,9 @@ feature "bulk add trainees" do
           and_i_visit_the_bulk_update_index_page
           and_i_click_on_view_status_of_uploaded_trainee_files
           then_i_see_the_uploads
+
+          when_i_click_on_back_link
+          then_i_see_the_bulk_update_index_page
         end
       end
     end
@@ -560,8 +563,13 @@ private
     visit bulk_update_trainees_review_error_path(id: BulkUpdate::TraineeUpload.last.id)
   end
 
+  def then_i_see_the_bulk_update_index_page
+    expect(page).to have_content("Bulk updates")
+  end
+
   alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file
   alias_method :and_i_click_the_submit_button, :when_i_click_the_submit_button
   alias_method :when_i_click_the_upload_button, :and_i_click_the_upload_button
   alias_method :and_i_visit_the_bulk_update_index_page, :when_i_visit_the_bulk_update_index_page
+  alias_method :when_i_click_on_back_link, :and_i_click_on_back_link
 end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -89,9 +89,18 @@ feature "bulk add trainees" do
         and_i_click_the_upload_button
         then_i_see_that_the_upload_is_processing
 
+        when_i_click_the_view_status_of_new_trainees_files_link
+        then_i_see_the_upload_status_row_as_pending(BulkUpdate::TraineeUpload.last)
+        and_i_click_on_back_link
+
         when_the_background_job_is_run
         and_i_refresh_the_page
         then_i_see_the_review_page_without_validation_errors
+
+        when_i_click_the_view_status_of_new_trainees_files_link
+        then_i_see_the_upload_status_row_as_validated(BulkUpdate::TraineeUpload.last)
+        and_i_click_on_back_link
+        then_i_see_the_review_page
         and_i_dont_see_the_review_errors_link
         and_i_dont_see_the_back_to_bulk_updates_link
 
@@ -200,10 +209,69 @@ feature "bulk add trainees" do
         and_i_click_the_upload_button
         then_i_see_that_the_upload_is_processing
       end
+
+      scenario "view the upload status page" do
+        Timecop.freeze do
+          when_multiple_uploads_exist
+          and_i_visit_the_bulk_update_index_page
+          then_i_see_the_uploads
+        end
+      end
     end
   end
 
 private
+
+  def and_i_click_on_back_link
+    click_on "Back"
+  end
+
+  def when_i_click_the_view_status_of_new_trainees_files_link
+    click_on "status of new trainees files"
+  end
+
+  def then_i_see_the_upload_status_row_as_pending(upload)
+    expect(page).to have_content("#{upload.filename} Pending")
+  end
+
+  def then_i_see_the_upload_status_row_as_validated(upload)
+    expect(page).to have_content("#{upload.filename} Validated")
+  end
+
+  def when_multiple_uploads_exist
+    %i[pending validated in_progress succeeded failed].each do |status|
+      create(:bulk_update_trainee_upload, status, provider: current_user.organisation)
+    end
+  end
+
+  def and_i_visit_the_bulk_update_index_page
+    visit bulk_update_trainees_uploads_path
+  end
+
+  def then_i_see_the_uploads
+    expect(page).to have_content(current_user.organisation.name)
+
+    expect(page).to have_content("Status of new trainee files")
+    expect(page).to have_content("View the status of recently uploaded files containing new trainees.")
+    expect(page).to have_content("This will list all successful new trainee uploads for the current academic year.")
+    expect(page).to have_content("Failed uploads will be removed after 30 days.")
+
+    expect(page).to have_content(
+      "five_trainees.csv Pending",
+    )
+    expect(page).to have_content(
+      "five_trainees.csv Validated",
+    )
+    expect(page).to have_content(
+      "#{Time.current.to_fs(:govuk_date_and_time)} five_trainees.csv In progress",
+    )
+    expect(page).to have_content(
+      "#{Time.current.to_fs(:govuk_date_and_time)} five_trainees.csv Succeeded",
+    )
+    expect(page).to have_content(
+      "#{Time.current.to_fs(:govuk_date_and_time)} five_trainees.csv Failed",
+    )
+  end
 
   def when_i_try_resubmit_the_same_upload
     visit bulk_update_trainees_upload_path(BulkUpdate::TraineeUpload.last)
@@ -239,7 +307,7 @@ private
     expect(page).to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.filename}.")
     expect(page).to have_content("This is taking longer than usual")
     expect(page).to have_content("You'll receive and email to tell you when this is complete.")
-    expect(page).to have_content("You can also check the status of new trainee files.")
+    expect(page).to have_content("You can also check the status of new trainees files.")
     expect(page).to have_link("Back to bulk updates page")
   end
 
@@ -249,7 +317,7 @@ private
     expect(page).not_to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.filename}.")
     expect(page).not_to have_content("This is taking longer than usual")
     expect(page).not_to have_content("You'll receive and email to tell you when this is complete.")
-    expect(page).not_to have_content("You can also check the status of new trainee files.")
+    expect(page).not_to have_content("You can also check the status of new trainees files.")
     expect(page).not_to have_link("Back to bulk updates page")
   end
 
@@ -292,8 +360,11 @@ private
   end
 
   def when_i_attach_a_valid_file
-    csv = Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees.csv").read
-    and_i_attach_a_file(csv)
+    file     = Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees.csv")
+    filename = File.basename(file)
+    content  = file.read
+
+    and_i_attach_a_file(content, filename)
   end
 
   def when_i_attach_a_file_with_invalid_rows
@@ -301,8 +372,8 @@ private
     and_i_attach_a_file(csv)
   end
 
-  def and_i_attach_a_file(content)
-    tempfile = Tempfile.new("csv")
+  def and_i_attach_a_file(content, filename = "csv")
+    tempfile = Tempfile.new([filename])
     tempfile.write(content)
     tempfile.rewind
     tempfile.path
@@ -402,7 +473,7 @@ private
   end
 
   def and_i_refresh_the_page
-    visit bulk_update_trainees_upload_path(id: BulkUpdate::TraineeUpload.last.id)
+    visit bulk_update_trainees_upload_path(BulkUpdate::TraineeUpload.last)
   end
 
   def when_the_background_job_is_run
@@ -458,10 +529,6 @@ private
     visit bulk_update_trainees_upload_path(upload)
   end
 
-  alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file
-  alias_method :and_i_click_the_submit_button, :when_i_click_the_submit_button
-  alias_method :when_i_click_the_upload_button, :and_i_click_the_upload_button
-
   def then_i_see_the_review_page_with_validation_errors
     expect(page).to have_content("2 trainees with errors in their details")
   end
@@ -487,4 +554,8 @@ private
   def when_i_return_to_the_review_errors_page
     visit bulk_update_trainees_review_error_path(id: BulkUpdate::TraineeUpload.last.id)
   end
+
+  alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file
+  alias_method :and_i_click_the_submit_button, :when_i_click_the_submit_button
+  alias_method :when_i_click_the_upload_button, :and_i_click_the_upload_button
 end

--- a/spec/jobs/bulk_update/add_trainees/remove_cancelled_and_failed_job_spec.rb
+++ b/spec/jobs/bulk_update/add_trainees/remove_cancelled_and_failed_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::AddTrainees::RemoveCancelledAndFailedJob do
+  context "when the feature is enabled", feature_bulk_add_trainees: true do
+    it "calls the RemoveDeadDuplicates service" do
+      allow(BulkUpdate::AddTrainees::RemoveUploads).to receive(:call)
+
+      subject.perform
+
+      expect(BulkUpdate::AddTrainees::RemoveUploads).to have_received(:call)
+    end
+  end
+
+  context "when the feature is disabled", feature_bulk_add_trainees: false do
+    it "does not call the RemoveDeadDuplicates service" do
+      allow(BulkUpdate::AddTrainees::RemoveUploads).to receive(:call)
+
+      subject.perform
+
+      expect(BulkUpdate::AddTrainees::RemoveUploads).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/models/bulk_update/trainee_upload_row_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_row_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BulkUpdate::TraineeUploadRow do
   it { is_expected.to belong_to(:trainee_upload) }
-  it { is_expected.to have_many(:row_errors) }
+  it { is_expected.to have_many(:row_errors).dependent(:destroy) }
 
   describe "#without_errors" do
     let!(:rows_with_errors) { create_list(:bulk_update_trainee_upload_row, 2, :with_errors) }

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe BulkUpdate::TraineeUpload do
   it { is_expected.to have_many(:trainee_upload_rows).dependent(:destroy) }
 
   it do
-    expect(subject).to define_enum_for(:status).with_values(
+    expect(subject).to define_enum_for(:status)
+      .without_instance_methods.with_values(
       pending: "pending",
       validated: "validated",
       in_progress: "in_progress",
@@ -15,6 +16,61 @@ RSpec.describe BulkUpdate::TraineeUpload do
       failed: "failed",
       cancelled: "cancelled",
     ).backed_by_column_of_type(:string)
+  end
+
+  describe "events" do
+    subject { create(:bulk_update_trainee_upload) }
+
+    describe "#process!" do
+      it "sets the status to validated" do
+        expect {
+          subject.process!
+        }.to change(subject, :status).from("pending").to("validated")
+      end
+    end
+
+    describe "#submit!" do
+      let(:current_time) { Time.current }
+
+      before do
+        subject.process!
+      end
+
+      it "sets the status to in_progress and the submitted_at to Time.current" do
+        Timecop.freeze(current_time) do
+          expect {
+            subject.submit!
+          }.to change(subject, :status).from("validated").to("in_progress")
+            .and change(subject, :submitted_at).from(nil).to(current_time)
+        end
+      end
+    end
+
+    describe "#succeed!" do
+      before do
+        subject.process!
+        subject.submit!
+      end
+
+      it "sets the status to succeeded" do
+        expect {
+          subject.succeed!
+        }.to change(subject, :status).from("in_progress").to("succeeded")
+      end
+    end
+
+    describe "#fail!" do
+      before do
+        subject.process!
+        subject.submit!
+      end
+
+      it "sets the status to failed" do
+        expect {
+          subject.fail!
+        }.to change(subject, :status).from("in_progress").to("failed")
+      end
+    end
   end
 
   describe "#total_rows_with_errors" do

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -111,6 +111,43 @@ RSpec.describe BulkUpdate::TraineeUpload do
     end
   end
 
+  describe "scopes" do
+    describe "#current_academic_cycle" do
+      let(:previous_academic_cycle) { create(:academic_cycle, previous_cycle: true) }
+      let(:current_academic_cycle) { create(:academic_cycle, :current) }
+      let(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
+
+      let!(:previous_academic_cycle_upload) do
+        create(
+          :bulk_update_trainee_upload,
+          created_at: rand(
+            previous_academic_cycle.start_date..previous_academic_cycle.end_date,
+          ),
+        )
+      end
+      let!(:current_academic_cycle_upload) do
+        create(
+          :bulk_update_trainee_upload,
+          created_at: rand(
+            current_academic_cycle.start_date..current_academic_cycle.end_date,
+          ),
+        )
+      end
+      let!(:next_academic_cycle_upload) do
+        create(
+          :bulk_update_trainee_upload,
+          created_at: rand(
+            next_academic_cycle.start_date..next_academic_cycle.end_date,
+          ),
+        )
+      end
+
+      it "returns records from the current academic cycle" do
+        expect(described_class.current_academic_cycle).to contain_exactly(current_academic_cycle_upload)
+      end
+    end
+  end
+
   describe "#total_rows_with_errors" do
     subject(:trainee_upload) { create(:bulk_update_trainee_upload) }
 

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -30,19 +30,23 @@ RSpec.describe BulkUpdate::TraineeUpload do
     end
 
     describe "#submit!" do
-      let(:current_time) { Time.current }
+      let!(:current_time) { Time.current.round }
 
       before do
         subject.process!
+
+        Timecop.freeze(current_time)
+      end
+
+      after do
+        Timecop.return
       end
 
       it do
-        Timecop.freeze(current_time) do
-          expect {
-            subject.submit!
-          }.to change(subject, :status).from("validated").to("in_progress")
-            .and change(subject, :submitted_at).from(nil).to(current_time)
-        end
+        expect {
+          subject.submit!
+        }.to change(subject, :status).from("validated").to("in_progress")
+          .and change(subject, :submitted_at).from(nil).to(current_time)
       end
     end
 

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe BulkUpdate::TraineeUpload do
     subject { create(:bulk_update_trainee_upload) }
 
     describe "#process!" do
-      it "sets the status to validated" do
+      it do
         expect {
           subject.process!
         }.to change(subject, :status).from("pending").to("validated")
@@ -36,7 +36,7 @@ RSpec.describe BulkUpdate::TraineeUpload do
         subject.process!
       end
 
-      it "sets the status to in_progress and the submitted_at to Time.current" do
+      it do
         Timecop.freeze(current_time) do
           expect {
             subject.submit!
@@ -52,16 +52,28 @@ RSpec.describe BulkUpdate::TraineeUpload do
         subject.submit!
       end
 
-      it "sets the status to succeeded" do
+      it do
         expect {
           subject.succeed!
         }.to change(subject, :status).from("in_progress").to("succeeded")
       end
     end
 
+    describe "#cancel!" do
+      before do
+        subject.process!
+      end
+
+      it do
+        expect {
+          subject.cancel!
+        }.to change(subject, :status).from("validated").to("cancelled")
+      end
+    end
+
     describe "#fail!" do
       context "when the status is 'pending'" do
-        it "sets the status to failed" do
+        it do
           expect {
             subject.fail!
           }.to change(subject, :status).from("pending").to("failed")
@@ -73,7 +85,7 @@ RSpec.describe BulkUpdate::TraineeUpload do
           subject.process!
         end
 
-        it "sets the status to failed" do
+        it do
           expect {
             subject.fail!
           }.to change(subject, :status).from("validated").to("failed")
@@ -86,7 +98,7 @@ RSpec.describe BulkUpdate::TraineeUpload do
           subject.submit!
         end
 
-        it "sets the status to failed" do
+        it do
           expect {
             subject.fail!
           }.to change(subject, :status).from("in_progress").to("failed")

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe BulkUpdate::TraineeUpload do
   it do
     expect(subject).to define_enum_for(:status)
       .without_instance_methods.with_values(
-      pending: "pending",
-      validated: "validated",
-      in_progress: "in_progress",
-      succeeded: "succeeded",
-      failed: "failed",
-      cancelled: "cancelled",
-    ).backed_by_column_of_type(:string)
+        pending: "pending",
+        validated: "validated",
+        in_progress: "in_progress",
+        succeeded: "succeeded",
+        failed: "failed",
+        cancelled: "cancelled",
+      ).backed_by_column_of_type(:string)
   end
 
   describe "events" do

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -60,15 +60,37 @@ RSpec.describe BulkUpdate::TraineeUpload do
     end
 
     describe "#fail!" do
-      before do
-        subject.process!
-        subject.submit!
+      context "when the status is 'pending'" do
+        it "sets the status to failed" do
+          expect {
+            subject.fail!
+          }.to change(subject, :status).from("pending").to("failed")
+        end
       end
 
-      it "sets the status to failed" do
-        expect {
-          subject.fail!
-        }.to change(subject, :status).from("in_progress").to("failed")
+      context "when the status is 'validated'" do
+        before do
+          subject.process!
+        end
+
+        it "sets the status to failed" do
+          expect {
+            subject.fail!
+          }.to change(subject, :status).from("validated").to("failed")
+        end
+      end
+
+      context "when the status is 'in_progress'" do
+        before do
+          subject.process!
+          subject.submit!
+        end
+
+        it "sets the status to failed" do
+          expect {
+            subject.fail!
+          }.to change(subject, :status).from("in_progress").to("failed")
+        end
       end
     end
   end

--- a/spec/services/bulk_update/add_trainees/remove_uploads_spec.rb
+++ b/spec/services/bulk_update/add_trainees/remove_uploads_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::AddTrainees::RemoveUploads do
+  %i[pending validated in_progress succeeded cancelled failed].each do |status|
+    let!("#{status}_upload") { create(:bulk_update_trainee_upload, :with_rows, status) }
+  end
+
+  describe "#call" do
+    it "removes only the failed and cancelled uploads" do
+      expect {
+        described_class.call
+      }.to change { BulkUpdate::TraineeUpload.count }.to(4)
+        .and change { BulkUpdate::TraineeUploadRow.count }.to(20)
+        .and change { BulkUpdate::RowError.count }.to(0)
+
+      expect(pending_upload.reload).to be_present
+      expect(validated_upload.reload).to be_present
+      expect(in_progress_upload.reload).to be_present
+      expect(succeeded_upload.reload).to be_present
+      expect {
+        cancelled_upload.reload
+      }.to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        failed_upload.reload
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
### Context

[7850-create-status-of-new-trainee-files-page](https://trello.com/c/MNr8s1Cc/7850-create-status-of-new-trainee-files-page)

<img width="739" alt="Screenshot 2024-11-27 at 16 56 31" src="https://github.com/user-attachments/assets/452037fc-5041-4f5a-bacb-fc08b36a5754">

### Changes proposed in this pull request

* Use `stateful_enum` for `BulkUpdate::TraineeUpload#status`
* Use the events instead of the delegated enum method for `BulkUpdate::TraineeUpload#status`
* Add `BulkUpdate::TraineeUploadsController#index`
* Add `BulkUpdate::TraineeUploads::Row::View` component to render each row in the index page
* Add `BulkUpdate::AddTrainees::RemoveUploads`
* Add `BulkUpdate::AddTrainees::RemoveCancelledAndFailedJob`

#### Migrations

* Add `submitted_at` to capture the `datetime` of the submitted for `in_progress` upload
* Set `pending` as the default `BulkUpdate::TraineeUpload#status`
* Add index for `BulkUpdate::TraineeUpload#status`




### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
