### PR TITLE
Performance Profiles Reports Page

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -4,7 +4,6 @@ class ReportsController < BaseTraineeController
   include DateOfTheNthWeekdayHelper
 
   before_action :set_cycle_variables
-  before_action :set_sign_off_date, only: %i[index performance_profiles]
 
   helper_method :itt_new_starter_trainees
 
@@ -124,10 +123,6 @@ private
     @previous_academic_cycle = AcademicCycle.previous
     @current_academic_cycle_label = @current_academic_cycle.label
     @previous_academic_cycle_label = @previous_academic_cycle.label
-  end
-
-  def set_sign_off_date
-    @sign_off_date = Date.new(@current_academic_cycle.end_year, 1, 31).strftime("%d %B %Y")
   end
 
   def base_trainee_scope

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -125,7 +125,7 @@ private
     @current_academic_cycle_label = @current_academic_cycle.label
     @previous_academic_cycle_label = @previous_academic_cycle.label
   end
-  
+
   def set_sign_off_date
     @sign_off_date = Date.new(@current_academic_cycle.end_year, 1, 31).strftime("%d %B %Y")
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -4,6 +4,7 @@ class ReportsController < BaseTraineeController
   include DateOfTheNthWeekdayHelper
 
   before_action :set_cycle_variables
+  before_action :set_sign_off_date, only: %i[index performance_profiles]
 
   helper_method :itt_new_starter_trainees
 
@@ -41,7 +42,6 @@ class ReportsController < BaseTraineeController
 
     respond_to do |format|
       format.html do
-        @sign_off_date = Date.new(@current_academic_cycle.end_year, 1, 31).strftime("%d %B %Y")
         @sign_off_url = Settings.sign_off_performance_profiles_url
       end
 
@@ -124,6 +124,10 @@ private
     @previous_academic_cycle = AcademicCycle.previous
     @current_academic_cycle_label = @current_academic_cycle.label
     @previous_academic_cycle_label = @previous_academic_cycle.label
+  end
+  
+  def set_sign_off_date
+    @sign_off_date = Date.new(@current_academic_cycle.end_year, 1, 31).strftime("%d %B %Y")
   end
 
   def base_trainee_scope

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -9,6 +9,12 @@ class ReportsController < BaseTraineeController
 
   def index
     authorize(current_user, :reports?)
+
+    @partial_page = DetermineSignOffPeriod.call
+
+    if @partial_page == :performance_period && current_user.organisation.performance_profile_signed_off?
+      @partial_page = :outside_period
+    end
   end
 
   def itt_new_starter_data_sign_off

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -10,7 +10,7 @@ class UserPolicy < ProviderPolicy
   end
 
   def drafts?
-    user.system_admin? || !user.lead_partner?
+    user.system_admin? || user.provider?
   end
 
   def bulk_recommend?

--- a/app/services/determine_sign_off_period.rb
+++ b/app/services/determine_sign_off_period.rb
@@ -5,9 +5,8 @@ class DetermineSignOffPeriod
 
   VALID_PERIODS = %i[census_period performance_period outside_period].freeze
 
-  def initialize(previous_academic_cycle: AcademicCycle.previous, provider: nil)
+  def initialize(previous_academic_cycle: AcademicCycle.previous)
     @previous_academic_cycle = previous_academic_cycle
-    @provider = provider
   end
 
   def call
@@ -23,7 +22,7 @@ class DetermineSignOffPeriod
 
 private
 
-  attr_reader :previous_academic_cycle, :provider
+  attr_reader :previous_academic_cycle
 
   def valid_sign_off_period?
     return false if Settings.sign_off_period.blank?
@@ -40,10 +39,5 @@ private
     start_date..end_date
   end
 
-  def in_performance_profile_range?(current_date)
-    result = previous_academic_cycle.in_performance_profile_range?(current_date)
-    result = false if result && provider.present? && provider.performance_profile_signed_off?
-
-    result
-  end
+  delegate :in_performance_profile_range?, to: :previous_academic_cycle
 end

--- a/app/views/reports/_census_period.html.erb
+++ b/app/views/reports/_census_period.html.erb
@@ -1,8 +1,11 @@
+<h2 class="govuk-heading-m">
+  Census Sign Off
+</h2>
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
       <%= govuk_link_to "New trainees for the #{@current_academic_cycle_label} academic year", itt_new_starter_data_sign_off_reports_path, class: "new-trainee-data" %>
-      - for census sign off
+      - for performance profiles sign off
     </p>
   </li>
   <li>

--- a/app/views/reports/_census_period.html.erb
+++ b/app/views/reports/_census_period.html.erb
@@ -5,12 +5,12 @@
   <li>
     <p>
       <%= govuk_link_to "New trainees for the #{@current_academic_cycle_label} academic year", itt_new_starter_data_sign_off_reports_path, class: "new-trainee-data" %>
-      - for performance profiles sign off
+      - for census sign off.
     </p>
   </li>
   <li>
     <p>
-       Trainees who studied in the <%= @previous_academic_cycle_label %> academic year - will be available for performance profiles sign off
+       Trainees who studied in the <%= @previous_academic_cycle_label %> academic year - will be available for performance profiles sign off.
     </p>
   </li>
 </ul>

--- a/app/views/reports/_performance_period.html.erb
+++ b/app/views/reports/_performance_period.html.erb
@@ -1,10 +1,10 @@
+<h2 class="govuk-heading-m">
+  Performance Profile
+</h2>
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
-      Reports are available for <%= govuk_link_to "trainees who studied in the #{@previous_academic_cycle_label} academic year", performance_profiles_reports_path, class: "performance-profiles" %> - for performance profiles sign off
+      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year report", performance_profiles_reports_path, class: "performance-profiles" %> - for performance profiles sign off with a deadline of <%="#{@sign_off_date}"%>
     </p>
-  </li>
-  <li>
-    <p>You can read <%= govuk_link_to("guidance about signing off performance profiles", performance_profiles_guidance_path) %></p>
   </li>
 </ul>

--- a/app/views/reports/_performance_period.html.erb
+++ b/app/views/reports/_performance_period.html.erb
@@ -4,7 +4,7 @@
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
-      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year report", performance_profiles_reports_path, class: "performance-profiles" %> - for performance profiles sign off with a deadline of <%="#{@sign_off_date}"%>
+      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year report", performance_profiles_reports_path, class: "performance-profiles" %> - for performance profiles sign off with a deadline of <%= @previous_academic_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) %>.
     </p>
   </li>
 </ul>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,6 +10,6 @@
     <h1 class="govuk-heading-l">
         Reports
     </h1>
-    <%= render DetermineSignOffPeriod.call(provider: current_user.organisation).to_s %>
+    <%= render @partial_page.to_s %>
   </div>
 </div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -5,11 +5,11 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop" >
+  <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <h1 class="govuk-heading-l">
         Reports
     </h1>
-    <%= render DetermineSignOffPeriod.call.to_s %>
+    <%= render DetermineSignOffPeriod.call(provider: current_user.organisation).to_s %>
   </div>
 </div>

--- a/spec/features/reports/index_spec.rb
+++ b/spec/features/reports/index_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 feature "viewing reports index" do
-  let!(:previous_cycle) { create(:academic_cycle, previous_cycle: true) }
-  let!(:current_cycle) { create(:academic_cycle, :current) }
-  let(:performance_profile_sign_off_date) { previous_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) }
-  let!(:trainee) { create(:trainee, :trn_received, start_academic_cycle: previous_cycle, end_academic_cycle: previous_cycle) }
+  let!(:previous_academic_cycle) { AcademicCycle.previous }
+  let!(:current_academic_cycle) { AcademicCycle.current }
+  let(:performance_profile_sign_off_date) { previous_academic_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) }
+  let!(:trainee) { create(:trainee, :trn_received, start_academic_cycle: previous_academic_cycle, end_academic_cycle: previous_academic_cycle) }
 
   context "in the performance period" do
     before { allow(DetermineSignOffPeriod).to receive(:call).and_return(:performance_period) }
@@ -18,6 +18,19 @@ feature "viewing reports index" do
 
     scenario "shows the correct content" do
       then_i_should_see_the_performance_period_content
+    end
+
+    context "the provider performance profile has been signed off" do
+      let!(:user) { create(:user, providers: [build(:provider, sign_offs: [build(:sign_off, :performance_profile, academic_cycle: previous_academic_cycle)])]) }
+
+      background do
+        given_i_am_authenticated(user:)
+        given_i_am_on_the_reports_page
+      end
+
+      scenario "shows the correct content" do
+        then_i_should_see_the_outside_period_content
+      end
     end
   end
 
@@ -64,14 +77,14 @@ private
   def then_i_should_see_the_performance_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
     expect(reports_page).to have_text("Performance Profile")
-    expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year report - for performance profiles sign off with a deadline of #{performance_profile_sign_off_date}")
+    expect(reports_page).to have_text("Trainees who studied in the #{previous_academic_cycle.label} academic year report - for performance profiles sign off with a deadline of #{performance_profile_sign_off_date}")
   end
 
   def then_i_should_see_the_census_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
     expect(reports_page).to have_text("Census Sign Off")
-    expect(reports_page).to have_text("New trainees for the #{current_cycle.label} academic year - for census sign off")
-    expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year - will be available for performance profiles sign off")
+    expect(reports_page).to have_text("New trainees for the #{current_academic_cycle.label} academic year - for census sign off")
+    expect(reports_page).to have_text("Trainees who studied in the #{previous_academic_cycle.label} academic year - will be available for performance profiles sign off")
   end
 
   def then_i_should_see_the_outside_period_content

--- a/spec/features/reports/index_spec.rb
+++ b/spec/features/reports/index_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 feature "viewing reports index" do
   let!(:previous_cycle) { create(:academic_cycle, previous_cycle: true) }
   let!(:current_cycle) { create(:academic_cycle, :current) }
+  let(:sign_off_date) { Date.new(current_cycle.end_year, 1, 31).strftime("%d %B %Y") }
   let!(:trainee) { create(:trainee, :trn_received, start_academic_cycle: previous_cycle, end_academic_cycle: previous_cycle) }
 
   context "in the performance period" do
@@ -62,8 +63,7 @@ private
 
   def then_i_should_see_the_performance_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
-    expect(reports_page).to have_text("Reports are available for trainees who studied in the #{previous_cycle.label} academic year - for performance profiles sign off")
-    expect(reports_page).to have_text("You can read guidance about signing off performance profiles")
+    expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year report - for performance profiles sign off with a deadline of #{sign_off_date}")
   end
 
   def then_i_should_see_the_census_period_content

--- a/spec/features/reports/index_spec.rb
+++ b/spec/features/reports/index_spec.rb
@@ -63,12 +63,14 @@ private
 
   def then_i_should_see_the_performance_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
+    expect(reports_page).to have_text("Performance Profile")
     expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year report - for performance profiles sign off with a deadline of #{sign_off_date}")
   end
 
   def then_i_should_see_the_census_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
-    expect(reports_page).to have_text("New trainees for the #{current_cycle.label} academic year - for census sign off")
+    expect(reports_page).to have_text("Census Sign Off")
+    expect(reports_page).to have_text("New trainees for the #{current_cycle.label} academic year - for performance profiles sign off")
     expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year - will be available for performance profiles sign off")
   end
 

--- a/spec/features/reports/index_spec.rb
+++ b/spec/features/reports/index_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "viewing reports index" do
   let!(:previous_cycle) { create(:academic_cycle, previous_cycle: true) }
   let!(:current_cycle) { create(:academic_cycle, :current) }
-  let(:sign_off_date) { Date.new(current_cycle.end_year, 1, 31).strftime("%d %B %Y") }
+  let(:performance_profile_sign_off_date) { previous_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) }
   let!(:trainee) { create(:trainee, :trn_received, start_academic_cycle: previous_cycle, end_academic_cycle: previous_cycle) }
 
   context "in the performance period" do
@@ -64,13 +64,13 @@ private
   def then_i_should_see_the_performance_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
     expect(reports_page).to have_text("Performance Profile")
-    expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year report - for performance profiles sign off with a deadline of #{sign_off_date}")
+    expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year report - for performance profiles sign off with a deadline of #{performance_profile_sign_off_date}")
   end
 
   def then_i_should_see_the_census_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
     expect(reports_page).to have_text("Census Sign Off")
-    expect(reports_page).to have_text("New trainees for the #{current_cycle.label} academic year - for performance profiles sign off")
+    expect(reports_page).to have_text("New trainees for the #{current_cycle.label} academic year - for census sign off")
     expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year - will be available for performance profiles sign off")
   end
 

--- a/spec/services/determine_sign_off_period_spec.rb
+++ b/spec/services/determine_sign_off_period_spec.rb
@@ -4,10 +4,9 @@ require "rails_helper"
 
 describe DetermineSignOffPeriod do
   describe ".call" do
-    subject { described_class.call(previous_academic_cycle:, provider:) }
+    subject { described_class.call(previous_academic_cycle: academic_cycle) }
 
-    let(:previous_academic_cycle) { create(:academic_cycle, :previous) }
-    let(:provider) { nil }
+    let(:academic_cycle) { create(:academic_cycle) }
 
     before do
       allow(Settings).to receive(:sign_off_period).and_return(nil)
@@ -61,27 +60,11 @@ describe DetermineSignOffPeriod do
       context "on #{performance_date} the performance profiles sign off period" do
         before do
           allow(Time.zone).to receive(:today).and_return(performance_date)
-          allow(previous_academic_cycle).to receive(:in_performance_profile_range?).with(performance_date).and_return(true)
+          allow(academic_cycle).to receive(:in_performance_profile_range?).with(performance_date).and_return(true)
         end
 
         it "returns :performance_period" do
           expect(subject).to eq(:performance_period)
-        end
-
-        context "provider has awaiting performance profile sign off" do
-          let(:provider) { create(:provider) }
-
-          it "returns :performance_period" do
-            expect(subject).to eq(:performance_period)
-          end
-        end
-
-        context "provider has performance profile signed off" do
-          let(:provider) { create(:provider, sign_offs: [build(:sign_off, :performance_profile, academic_cycle: previous_academic_cycle)]) }
-
-          it "returns :outside_period" do
-            expect(subject).to eq(:outside_period)
-          end
         end
       end
     end


### PR DESCRIPTION
### Context
Performance Profiles Reports Page

### Changes proposed in this pull request
The Reports Page should show different content based on the different date periods 
### Guidance to review
https://register-pr-4849.test.teacherservices.cloud/reports

#### Performance period
Review app is set to this one
Show only if they have not signed off performance profile
![image](https://github.com/user-attachments/assets/c5cadfe4-437e-4023-8228-3c011ecb671b)


#### Outside period

Show when outside or when performance profile has been signed off

![image](https://github.com/user-attachments/assets/ee5a2b11-6770-4445-bca0-a12f2a3b5361)

#### Census period
![image](https://github.com/user-attachments/assets/69a822c7-de44-4f3e-b777-b6e11f5faa8d)


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
