### PR TITLE
[7884] Create trainee upload details page

### DIFF
--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,7 +1,7 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
     <% if submitted_at %>
-      <%= link_to submitted_at, bulk_update_trainees_details_path(upload) %>
+      <%= link_to submitted_at, upload_path %>
     <% end %>
   </td>
   <td class="govuk-table__cell">

--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,7 +1,7 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
     <% if submitted_at %>
-      <%= link_to submitted_at, upload_path %>
+      <%= govuk_link_to submitted_at, upload_path %>
     <% end %>
   </td>
   <td class="govuk-table__cell">

--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,6 +1,8 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <%= submitted_at %>
+    <% if submitted_at %>
+      <%= link_to submitted_at, bulk_update_trainees_details_path(upload) %>
+    <% end %>
   </td>
   <td class="govuk-table__cell">
     <%= filename %>

--- a/app/components/bulk_update/trainee_uploads/row/view.rb
+++ b/app/components/bulk_update/trainee_uploads/row/view.rb
@@ -13,6 +13,18 @@ module BulkUpdate
           "cancelled" => "govuk-tag--yellow",
         }.freeze
 
+        PATHS = {
+          "succeeded" => lambda do |upload|
+            Rails.application.routes.url_helpers.bulk_update_trainees_details_path(upload)
+          end,
+          "in_progress" => lambda do |upload|
+            Rails.application.routes.url_helpers.bulk_update_trainees_submission_path(upload)
+          end,
+          "failed" => lambda do |upload|
+            Rails.application.routes.url_helpers.bulk_update_trainees_review_error_path(upload)
+          end,
+        }.freeze
+
         attr_reader :upload
 
         delegate :filename, to: :upload
@@ -25,6 +37,10 @@ module BulkUpdate
           content_tag(:span, class: "govuk-tag #{COLOURS[upload.status]}") do
             upload.status.humanize
           end
+        end
+
+        def upload_path
+          PATHS[upload.status]&.call(upload)
         end
 
         def submitted_at

--- a/app/components/bulk_update/trainee_uploads/row/view.rb
+++ b/app/components/bulk_update/trainee_uploads/row/view.rb
@@ -4,6 +4,8 @@ module BulkUpdate
   module TraineeUploads
     module Row
       class View < ViewComponent::Base
+        include Rails.application.routes.url_helpers
+
         COLOURS = {
           "pending" => "govuk-tag--light-blue",
           "validated" => "govuk-tag--turquoise",
@@ -11,18 +13,6 @@ module BulkUpdate
           "succeeded" => "govuk-tag--green",
           "failed" => "govuk-tag--red",
           "cancelled" => "govuk-tag--yellow",
-        }.freeze
-
-        PATHS = {
-          "succeeded" => lambda do |upload|
-            Rails.application.routes.url_helpers.bulk_update_trainees_details_path(upload)
-          end,
-          "in_progress" => lambda do |upload|
-            Rails.application.routes.url_helpers.bulk_update_trainees_submission_path(upload)
-          end,
-          "failed" => lambda do |upload|
-            Rails.application.routes.url_helpers.bulk_update_trainees_review_error_path(upload)
-          end,
         }.freeze
 
         attr_reader :upload
@@ -40,7 +30,11 @@ module BulkUpdate
         end
 
         def upload_path
-          PATHS[upload.status]&.call(upload)
+          {
+            "succeeded" => bulk_update_trainees_details_path(upload),
+            "in_progress" => bulk_update_trainees_submission_path(upload),
+            "failed" => bulk_update_trainees_review_error_path(upload),
+          }[upload.status]
         end
 
         def submitted_at

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,7 +53,7 @@ private
 
   def current_user
     @current_user ||= if sign_in_user
-                        UserWithOrganisationContext.new(
+                        Current.user = UserWithOrganisationContext.new(
                           user: sign_in_user.user,
                           session: session,
                         )

--- a/app/controllers/bulk_update/trainees/details_controller.rb
+++ b/app/controllers/bulk_update/trainees/details_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module Trainees
+    class DetailsController < ApplicationController
+      before_action { require_feature_flag(:bulk_add_trainees) }
+
+      def show
+        authorize(
+          bulk_update_trainee_upload,
+          policy_class: BulkUpdate::Details::TraineeUploadPolicy,
+        )
+      end
+
+    private
+
+      def bulk_update_trainee_upload
+        @bulk_update_trainee_upload ||= policy_scope(
+          BulkUpdate::TraineeUpload,
+        ).find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/bulk_update/trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/trainees/uploads_controller.rb
@@ -9,6 +9,8 @@ module BulkUpdate
         @bulk_update_trainee_uploads = policy_scope(
           BulkUpdate::TraineeUpload,
         ).current_academic_cycle.includes(:file_attachment)
+
+        authorize(@bulk_update_trainee_uploads)
       end
 
       def show

--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -43,9 +43,8 @@ module BulkUpdate
 
     def upload_attributes
       {
-        provider: provider,
-        file: file,
-        number_of_trainees: csv&.count,
+        provider:,
+        file:,
       }
     end
 

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -59,6 +59,8 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
   end
 
   belongs_to :provider
+  belongs_to :submitted_by, class_name: "User", optional: true
+
   has_many :trainee_upload_rows,
            class_name: "BulkUpdate::TraineeUploadRow",
            foreign_key: :bulk_update_trainee_upload_id,

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -13,15 +13,18 @@
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  provider_id        :bigint           not null
+#  submitted_by_id    :bigint
 #
 # Indexes
 #
-#  index_bulk_update_trainee_uploads_on_provider_id  (provider_id)
-#  index_bulk_update_trainee_uploads_on_status       (status)
+#  index_bulk_update_trainee_uploads_on_provider_id      (provider_id)
+#  index_bulk_update_trainee_uploads_on_status           (status)
+#  index_bulk_update_trainee_uploads_on_submitted_by_id  (submitted_by_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (provider_id => providers.id)
+#  fk_rails_...  (submitted_by_id => users.id)
 #
 
 class BulkUpdate::TraineeUpload < ApplicationRecord
@@ -39,6 +42,7 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
 
     event :submit do
       before do
+        self.submitted_by = Current.user
         self.submitted_at = Time.current
       end
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,10 @@ class User < ApplicationRecord
   has_many :lead_partner_users
   has_many :lead_partners, through: :lead_partner_users
 
+  has_many :submitted_bulk_update_trainee_uploads,
+    class_name: "BulkUpdate::TraineeUpload",
+    foreign_key: :submitted_by_id, inverse_of: :submitted_by
+
   scope :order_by_last_name, -> { order(:last_name) }
   scope :system_admins, -> { where(system_admin: true) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,8 +37,8 @@ class User < ApplicationRecord
   has_many :lead_partners, through: :lead_partner_users
 
   has_many :submitted_bulk_update_trainee_uploads,
-    class_name: "BulkUpdate::TraineeUpload",
-    foreign_key: :submitted_by_id, inverse_of: :submitted_by
+           class_name: "BulkUpdate::TraineeUpload",
+           foreign_key: :submitted_by_id, inverse_of: :submitted_by
 
   scope :order_by_last_name, -> { order(:last_name) }
   scope :system_admins, -> { where(system_admin: true) }

--- a/app/policies/bulk_update/details/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/details/trainee_upload_policy.rb
@@ -2,7 +2,10 @@
 
 module BulkUpdate
   module Details
-    class TraineeUploadPolicy
+    class TraineeUploadPolicy < BulkUpdate::TraineeUploads::BasePolicy
+      def show?
+        user.hei_provider? && trainee_upload.succeeded?
+      end
     end
   end
 end

--- a/app/policies/bulk_update/details/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/details/trainee_upload_policy.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module Details
+    class TraineeUploadPolicy
+    end
+  end
+end

--- a/app/policies/bulk_update/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/trainee_upload_policy.rb
@@ -1,27 +1,7 @@
 # frozen_string_literal: true
 
 module BulkUpdate
-  class TraineeUploadPolicy
-    class Scope
-      attr_reader :user, :scope
-
-      def initialize(user, scope)
-        @user  = user
-        @scope = scope
-      end
-
-      def resolve
-        scope.where(provider: user.organisation)
-      end
-    end
-
-    attr_reader :user, :trainee_upload
-
-    def initialize(user, trainee_upload)
-      @user           = user
-      @trainee_upload = trainee_upload
-    end
-
+  class TraineeUploadPolicy < TraineeUploads::BasePolicy
     def new?
       user.hei_provider?
     end

--- a/app/policies/bulk_update/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/trainee_upload_policy.rb
@@ -12,5 +12,6 @@ module BulkUpdate
 
     alias_method :show?, :create?
     alias_method :destroy?, :create?
+    alias_method :index?, :new?
   end
 end

--- a/app/policies/bulk_update/trainee_uploads/base_policy.rb
+++ b/app/policies/bulk_update/trainee_uploads/base_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module TraineeUploads
+    class BasePolicy
+      class Scope
+        attr_reader :user, :scope
+
+        def initialize(user, scope)
+          @user  = user
+          @scope = scope
+        end
+
+        def resolve
+          scope.where(provider: user.organisation)
+        end
+      end
+
+      attr_reader :user, :trainee_upload
+
+      def initialize(user, trainee_upload)
+        @user           = user
+        @trainee_upload = trainee_upload
+      end
+    end
+  end
+end

--- a/app/views/bulk_update/trainees/details/show.html.erb
+++ b/app/views/bulk_update/trainees/details/show.html.erb
@@ -1,0 +1,55 @@
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t(:back),
+    href: request.referrer.include?(
+      bulk_update_trainees_details_path(@bulk_update_trainee_upload)
+    ) ? request.referrer : bulk_update_trainees_uploads_path
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop" >
+    <h1 class="govuk-heading-l">
+      Your new trainees have been registered
+    </h1>
+
+    <dl class="govuk-summary-list govuk-summary-list--no-border">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Submitted by:</dt>
+        <dd class="govuk-summary-list__value"><%= @bulk_update_trainee_upload.submitted_by.name %></dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Date and time:</dt>
+        <dd class="govuk-summary-list__value"><%= @bulk_update_trainee_upload.submitted_at.to_fs(:govuk_date_and_time) %></dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Number of registered trainees:</dt>
+        <dd class="govuk-summary-list__value"><%= @bulk_update_trainee_upload.trainee_upload_rows.size %></dd>
+      </div>
+    </dl>
+
+    <p class="govuk-body">
+      You can also check the <%= govuk_link_to("status of new trainee files", bulk_update_trainees_uploads_path) %>.
+    </p>
+
+    <p class="govuk-heading-s">
+      Check data submitted into Register from CSV bulk add new trainees
+    </p>
+
+    <p class="govuk-body">
+      You can check your trainee data once it has been submitted into Register. At any time you can:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        view 'Choose trainee status export' from the 'Registered trainees' section, using the 'academic year' or
+        'start year' filter to select the  current academic year
+      </li>
+      <li>
+        check your trainees directly in the service one by one.
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/bulk_update/trainees/details/show.html.erb
+++ b/app/views/bulk_update/trainees/details/show.html.erb
@@ -1,9 +1,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: t(:back),
-    href: request.referrer.include?(
-      bulk_update_trainees_details_path(@bulk_update_trainee_upload)
-    ) ? request.referrer : bulk_update_trainees_uploads_path
+    href: bulk_update_trainees_uploads_path
   ) %>
 <% end %>
 

--- a/app/views/bulk_update/trainees/details/show.html.erb
+++ b/app/views/bulk_update/trainees/details/show.html.erb
@@ -11,22 +11,22 @@
       Your new trainees have been registered
     </h1>
 
-    <dl class="govuk-summary-list govuk-summary-list--no-border">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Submitted by:</dt>
-        <dd class="govuk-summary-list__value"><%= @bulk_update_trainee_upload.submitted_by.name %></dd>
-      </div>
+    <%= govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border") do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <%= row.with_key(text: "Submitted by:") %>
+        <%= row.with_value(text: @bulk_update_trainee_upload.submitted_by.name) %>
+      <% end %>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Date and time:</dt>
-        <dd class="govuk-summary-list__value"><%= @bulk_update_trainee_upload.submitted_at.to_fs(:govuk_date_and_time) %></dd>
-      </div>
+      <% summary_list.with_row do |row| %>
+        <%= row.with_key(text: "Date and time:") %>
+        <%= row.with_value(text: @bulk_update_trainee_upload.submitted_at.to_fs(:govuk_date_and_time)) %>
+      <% end %>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Number of registered trainees:</dt>
-        <dd class="govuk-summary-list__value"><%= @bulk_update_trainee_upload.trainee_upload_rows.size %></dd>
-      </div>
-    </dl>
+      <% summary_list.with_row do |row| %>
+        <%= row.with_key(text: "Number of registered trainees:") %>
+        <%= row.with_value(text: @bulk_update_trainee_upload.trainee_upload_rows.size) %>
+      <% end %>
+    <% end %>
 
     <p class="govuk-body">
       You can also check the <%= govuk_link_to("status of new trainee files", bulk_update_trainees_uploads_path) %>.

--- a/app/views/bulk_update/trainees/review_errors/show.html.erb
+++ b/app/views/bulk_update/trainees/review_errors/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: request.referrer) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/trainees/review_errors/show.html.erb
+++ b/app/views/bulk_update/trainees/review_errors/show.html.erb
@@ -1,7 +1,13 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: request.referrer) %>
+  <%= render(
+    GovukComponent::BackLinkComponent.new(
+      text: "Back",
+      href: request.referrer.present? && request.referrer.match?(bulk_update_trainees_uploads_path) ?
+        request.referrer : bulk_update_trainees_upload_path(@bulk_update_trainee_upload)
+    )
+  )%>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/trainees/submissions/show.html.erb
+++ b/app/views/bulk_update/trainees/submissions/show.html.erb
@@ -1,7 +1,11 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>
+  <% if request.referrer.match?(bulk_update_trainees_uploads_path) %>
+    <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: bulk_update_trainees_uploads_path) %>
+  <% else %>
+    <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/trainees/uploads/index.html.erb
+++ b/app/views/bulk_update/trainees/uploads/index.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(text: "Bulk add new trainees") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: request.referrer) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: request.referrer) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/trainees/uploads/index.html.erb
+++ b/app/views/bulk_update/trainees/uploads/index.html.erb
@@ -34,5 +34,7 @@
         <% end %>
       </tbody>
     </table>
+
+    <%= govuk_link_to "Cancel reviewing uploads", root_path %>
   </div>
 </div>

--- a/app/views/bulk_update/trainees/uploads/index.html.erb
+++ b/app/views/bulk_update/trainees/uploads/index.html.erb
@@ -1,7 +1,9 @@
 <%= render PageTitle::View.new(text: "Bulk add new trainees") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: request.referrer) %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t(:back),
+    href: (request.referrer.present? && request.referrer.match?(bulk_update_trainees_uploads_path)) ? request.referrer : bulk_update_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/trainees/uploads/index.html.erb
+++ b/app/views/bulk_update/trainees/uploads/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: t(:back),
-    href: (request.referrer.present? && request.referrer.match?(bulk_update_trainees_uploads_path)) ? request.referrer : bulk_update_path) %>
+    href: (request.referrer.present? && request.referrer.match?(/#{bulk_update_trainees_uploads_path}\/\d+$/)) ? request.referrer : bulk_update_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: request.referrer) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: new_bulk_update_trainees_upload_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: request.referrer) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/trainees/uploads/show.html.erb
@@ -38,7 +38,7 @@
       </h1>
 
       <p class="govuk-body">
-        You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.number_of_trainees, "trainee") %>.
+        You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.trainee_upload_rows.size, "trainee") %>.
       </p>
 
       <p class="govuk-body">

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -428,7 +428,6 @@
     - submitted_by_id
     - file
     - file_name
-    - number_of_trainees
     - status
     - submitted_at
     - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -425,6 +425,7 @@
   :bulk_update_trainee_uploads:
     - id
     - provider_id
+    - submitted_by_id
     - file
     - file_name
     - number_of_trainees

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -16,5 +16,5 @@ Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
              "%e %B %Y at %l:%M%P"
            end
 
-  time.in_time_zone("London").strftime(format).squeeze(" ")
+  time.in_time_zone("London").strftime(format).squeeze(" ").lstrip
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
       resources :uploads, only: %i[index show new create destroy] do
         member do
           resources :submissions, only: %i[show create]
+          resource :details, only: :show
         end
       end
       resources :review_errors, path: "review_errors", only: %i[show], as: :review_errors

--- a/db/migrate/20241127141931_add_submitted_by_id_to_bulk_update_trainee_uploads.rb
+++ b/db/migrate/20241127141931_add_submitted_by_id_to_bulk_update_trainee_uploads.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddSubmittedByIdToBulkUpdateTraineeUploads < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_reference :bulk_update_trainee_uploads,
+        :submitted_by,
+        index: {algorithm: :concurrently},
+        foreign_key: { to_table: :users }
+    end
+  end
+end

--- a/db/migrate/20241127141931_add_submitted_by_id_to_bulk_update_trainee_uploads.rb
+++ b/db/migrate/20241127141931_add_submitted_by_id_to_bulk_update_trainee_uploads.rb
@@ -6,9 +6,9 @@ class AddSubmittedByIdToBulkUpdateTraineeUploads < ActiveRecord::Migration[7.2]
   def change
     safety_assured do
       add_reference :bulk_update_trainee_uploads,
-        :submitted_by,
-        index: {algorithm: :concurrently},
-        foreign_key: { to_table: :users }
+                    :submitted_by,
+                    index: { algorithm: :concurrently },
+                    foreign_key: { to_table: :users }
     end
   end
 end

--- a/db/migrate/20241202115711_remove_number_of_trainees_from_bulk_update_trainee_uploads.rb
+++ b/db/migrate/20241202115711_remove_number_of_trainees_from_bulk_update_trainee_uploads.rb
@@ -1,0 +1,5 @@
+class RemoveNumberOfTraineesFromBulkUpdateTraineeUploads < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :bulk_update_trainee_uploads, :number_of_trainees, :integer }
+  end
+end

--- a/db/migrate/20241202115711_remove_number_of_trainees_from_bulk_update_trainee_uploads.rb
+++ b/db/migrate/20241202115711_remove_number_of_trainees_from_bulk_update_trainee_uploads.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveNumberOfTraineesFromBulkUpdateTraineeUploads < ActiveRecord::Migration[7.2]
   def change
     safety_assured { remove_column :bulk_update_trainee_uploads, :number_of_trainees, :integer }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_27_141931) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_02_115711) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -259,9 +259,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_27_141931) do
 
   create_table "bulk_update_trainee_uploads", force: :cascade do |t|
     t.bigint "provider_id", null: false
-    t.text "file"
-    t.string "file_name"
-    t.integer "number_of_trainees"
     t.string "status", default: "pending"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_27_141931) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -266,8 +266,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "submitted_at"
+    t.bigint "submitted_by_id"
     t.index ["provider_id"], name: "index_bulk_update_trainee_uploads_on_provider_id"
     t.index ["status"], name: "index_bulk_update_trainee_uploads_on_status"
+    t.index ["submitted_by_id"], name: "index_bulk_update_trainee_uploads_on_submitted_by_id"
   end
 
   create_table "course_subjects", force: :cascade do |t|
@@ -1047,6 +1049,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_26_164709) do
   add_foreign_key "bulk_update_recommendations_uploads", "providers"
   add_foreign_key "bulk_update_trainee_upload_rows", "bulk_update_trainee_uploads"
   add_foreign_key "bulk_update_trainee_uploads", "providers"
+  add_foreign_key "bulk_update_trainee_uploads", "users", column: "submitted_by_id"
   add_foreign_key "course_subjects", "courses"
   add_foreign_key "course_subjects", "subjects"
   add_foreign_key "degrees", "trainees"

--- a/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
+++ b/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
 
     BulkUpdate::TraineeUpload.statuses.each_key do |status|
       context "when #{status}" do
-        let(:upload) { build(:bulk_update_trainee_upload, status) }
+        let(:upload) { create(:bulk_update_trainee_upload, status) }
 
         it do
           expect(
@@ -45,7 +45,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
 
   describe "#submitted_at" do
     context "when bulk_update_trainee_upload#submitted_at is nil" do
-      let(:upload) { build(:bulk_update_trainee_upload) }
+      let!(:upload) { create(:bulk_update_trainee_upload) }
 
       it do
         expect(subject.submitted_at).to be_nil
@@ -54,7 +54,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
 
     context "when bulk_update_trainee_upload#submitted_at is not nil" do
       let(:submitted_at) { Time.current }
-      let(:upload) { build(:bulk_update_trainee_upload, submitted_at:) }
+      let(:upload) { create(:bulk_update_trainee_upload, submitted_at:) }
 
       it do
         expect(subject.submitted_at).to eq(submitted_at.to_fs(:govuk_date_and_time))

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -10,10 +10,6 @@ UPLOAD_ERROR_MESSAGES = [
 
 FactoryBot.define do
   factory :bulk_update_trainee_upload, class: "BulkUpdate::TraineeUpload" do
-    transient do
-      user { association(:user) }
-    end
-
     provider
 
     after(:build) do |upload|
@@ -58,20 +54,14 @@ FactoryBot.define do
 
     trait :in_progress do
       status { "in_progress" }
+      submitted_by { association(:user) }
       submitted_at { Time.current }
-
-      after(:build) do |bulk_update_trainee_upload, evaluator|
-        bulk_update_trainee_upload.submitted_by ||= evaluator.user
-      end
     end
 
     trait :succeeded do
       status { "succeeded" }
+      submitted_by { association(:user) }
       submitted_at { Time.current }
-
-      after(:build) do |bulk_update_trainee_upload, evaluator|
-        bulk_update_trainee_upload.submitted_by ||= evaluator.user
-      end
 
       with_rows
     end
@@ -82,11 +72,8 @@ FactoryBot.define do
 
     trait :failed do
       status { "failed" }
+      submitted_by { association(:user) }
       submitted_at { Time.current }
-
-      after(:build) do |bulk_update_trainee_upload, evaluator|
-        bulk_update_trainee_upload.submitted_by ||= evaluator.user
-      end
 
       after(:create) do |bulk_update_trainee_upload|
         CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
 
     trait :in_progress do
       status { "in_progress" }
-      submitted_at { Time.zone.at(SecureRandom.random_number(1_000_000_000)) }
+      submitted_at { Time.current }
 
       after(:build) do |bulk_update_trainee_upload, evaluator|
         bulk_update_trainee_upload.submitted_by ||= evaluator.user
@@ -67,7 +67,7 @@ FactoryBot.define do
 
     trait :succeeded do
       status { "succeeded" }
-      submitted_at { Time.zone.at(SecureRandom.random_number(1_000_000_000)) }
+      submitted_at { Time.current }
 
       after(:build) do |bulk_update_trainee_upload, evaluator|
         bulk_update_trainee_upload.submitted_by ||= evaluator.user
@@ -82,7 +82,7 @@ FactoryBot.define do
 
     trait :failed do
       status { "failed" }
-      submitted_at { Time.zone.at(SecureRandom.random_number(1_000_000_000)) }
+      submitted_at { Time.current }
 
       after(:build) do |bulk_update_trainee_upload, evaluator|
         bulk_update_trainee_upload.submitted_by ||= evaluator.user

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -10,6 +10,10 @@ UPLOAD_ERROR_MESSAGES = [
 
 FactoryBot.define do
   factory :bulk_update_trainee_upload, class: "BulkUpdate::TraineeUpload" do
+    transient do
+      user { create(:user) }
+    end
+
     provider
 
     after(:build) do |upload|
@@ -54,12 +58,22 @@ FactoryBot.define do
 
     trait :in_progress do
       status { "in_progress" }
-      submitted_at { Time.current }
+      submitted_at { Time.zone.at(SecureRandom.random_number(1_000_000_000)) }
+
+      after(:build) do |bulk_update_trainee_upload, evaluator|
+        bulk_update_trainee_upload.submitted_by ||= evaluator.user
+      end
     end
 
     trait :succeeded do
       status { "succeeded" }
-      submitted_at { Time.current }
+      submitted_at { Time.zone.at(SecureRandom.random_number(1_000_000_000)) }
+
+      after(:build) do |bulk_update_trainee_upload, evaluator|
+        bulk_update_trainee_upload.submitted_by ||= evaluator.user
+      end
+
+      with_rows
     end
 
     trait :cancelled do
@@ -68,7 +82,11 @@ FactoryBot.define do
 
     trait :failed do
       status { "failed" }
-      submitted_at { Time.current }
+      submitted_at { Time.zone.at(SecureRandom.random_number(1_000_000_000)) }
+
+      after(:build) do |bulk_update_trainee_upload, evaluator|
+        bulk_update_trainee_upload.submitted_by ||= evaluator.user
+      end
 
       after(:create) do |bulk_update_trainee_upload|
         CSV.parse(bulk_update_trainee_upload.download, headers: true).each_with_index do |row, index|

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -11,7 +11,7 @@ UPLOAD_ERROR_MESSAGES = [
 FactoryBot.define do
   factory :bulk_update_trainee_upload, class: "BulkUpdate::TraineeUpload" do
     transient do
-      user { create(:user) }
+      user { association(:user) }
     end
 
     provider

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -11,7 +11,6 @@ UPLOAD_ERROR_MESSAGES = [
 FactoryBot.define do
   factory :bulk_update_trainee_upload, class: "BulkUpdate::TraineeUpload" do
     provider
-    number_of_trainees { 5 }
 
     after(:build) do |upload|
       upload.file.attach(

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -409,7 +409,7 @@ private
           :bulk_update_trainee_upload,
           status,
           provider: current_user.organisation,
-          user: current_user,
+          submitted_by: current_user,
         )
       end
     end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -275,6 +275,9 @@ feature "bulk add trainees" do
 
         when_i_click_on_back_link
         then_i_see_the_bulk_update_index_page
+        and_i_click_on_view_status_of_uploaded_trainee_files
+        and_i_click_on_cancel_link
+        then_i_see_the_root_page
       end
 
       scenario "when I try to upload a file with duplicate trainees" do
@@ -296,6 +299,14 @@ feature "bulk add trainees" do
   end
 
 private
+
+  def then_i_see_the_root_page
+    expect(page).to have_content("Your trainee teachers")
+  end
+
+  def and_i_click_on_cancel_link
+    click_on "Cancel reviewing uploads"
+  end
 
   def when_an_upload_exists_from_the_previous_academic_cycle
     @previous_academic_cycle_upload ||= Timecop.travel(

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -331,7 +331,7 @@ private
     first(:link, upload.submitted_at.to_fs(:govuk_date_and_time)).click
   end
 
-  def then_i_see_the_upload_details_page(upload: BulkUpdate::TraineeUpload.last)
+  def then_i_see_the_upload_details_page
     expect(page).to have_content("Your new trainees have been registered")
     expect(page).to have_content("Submitted by: #{current_user.name}")
     expect(page).to have_content("Number of registered trainees: 5")
@@ -727,11 +727,11 @@ private
   end
 
   def then_i_see_the_bulk_update_index_page
-    expect(current_path).to eq(bulk_update_path)
+    expect(page).to have_current_path(bulk_update_path, ignore_query: true)
   end
 
   def then_i_see_the_bulk_trainees_uploads_index_page
-    expect(current_path).to eq(bulk_update_trainees_uploads_path)
+    expect(page).to have_current_path(bulk_update_trainees_uploads_path, ignore_query: true)
   end
 
   def then_i_cannot_see_the_bulk_view_status_link

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -354,8 +354,8 @@ private
 
   def then_i_see_the_upload_details_page
     expect(page).to have_content("Your new trainees have been registered")
-    expect(page).to have_content("Submitted by: #{current_user.name}")
-    expect(page).to have_content("Number of registered trainees: 5")
+    expect(page).to have_content("Submitted by:#{current_user.name}")
+    expect(page).to have_content("Number of registered trainees:5")
     expect(page).to have_content("You can also check the status of new trainee files.")
     expect(page).to have_content("Check data submitted into Register from CSV bulk add new trainees")
     expect(page).to have_content("You can check your trainee data once it has been submitted into Register. At any time you can:")

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -234,6 +234,19 @@ feature "bulk add trainees" do
         when_i_click_the_review_errors_link
         then_i_see_the_review_errors_page
 
+        when_i_click_on_back_link
+        then_i_see_the_review_page_with_validation_errors
+
+        when_i_click_the_review_errors_link
+        then_i_see_the_review_errors_page
+
+        when_i_visit_the_review_errors_page
+        and_i_click_on_back_link
+        then_i_see_the_review_page_with_validation_errors
+
+        when_i_click_the_review_errors_link
+        then_i_see_the_review_errors_page
+
         when_i_click_on_the_download_link
         then_i_receive_the_file
 
@@ -765,6 +778,10 @@ private
 
   def and_i_visit_the_bulk_update_trainee_upload_details_page(upload: BulkUpdate::TraineeUpload.last)
     visit bulk_update_trainees_details_path(upload)
+  end
+
+  def when_i_visit_the_review_errors_page(upload: BulkUpdate::TraineeUpload.last)
+    visit bulk_update_trainees_review_error_path(upload)
   end
 
   alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -262,11 +262,20 @@ feature "bulk add trainees" do
         when_i_click_on_back_link
         then_i_see_the_bulk_trainees_uploads_index_page
 
-        when_i_click_on_an_upload(upload: BulkUpdate::TraineeUpload.in_progress.first)
-        and_i_see_the_summary_page(upload: BulkUpdate::TraineeUpload.in_progress.first)
+        when_i_click_on_back_link
+        then_i_see_the_bulk_update_index_page
 
-        when_i_visit_the_bulk_update_index_page
-        and_i_click_on_view_status_of_uploaded_trainee_files
+        when_i_click_the_view_status_of_new_trainee_files_link(full_link: true)
+        and_i_click_on_an_upload(upload: BulkUpdate::TraineeUpload.in_progress.first)
+        then_i_see_the_summary_page(upload: BulkUpdate::TraineeUpload.in_progress.first)
+
+        when_i_click_on_back_link
+        then_i_see_the_bulk_trainees_uploads_index_page
+
+        when_i_click_on_back_link
+        then_i_see_the_bulk_update_index_page
+
+        when_i_click_the_view_status_of_new_trainee_files_link(full_link: true)
         and_i_click_on_an_upload(upload: BulkUpdate::TraineeUpload.failed.first)
         then_i_see_the_review_errors_page(upload: BulkUpdate::TraineeUpload.failed.first)
 
@@ -275,7 +284,8 @@ feature "bulk add trainees" do
 
         when_i_click_on_back_link
         then_i_see_the_bulk_update_index_page
-        and_i_click_on_view_status_of_uploaded_trainee_files
+        and_i_click_the_view_status_of_new_trainee_files_link(full_link: true)
+
         and_i_click_on_cancel_link
         then_i_see_the_root_page
       end
@@ -766,4 +776,5 @@ private
   alias_method :and_i_see_the_review_page_without_validation_errors, :then_i_see_the_review_page_without_validation_errors
   alias_method :when_i_visit_the_bulk_update_index_page, :and_i_visit_the_bulk_update_index_page
   alias_method :and_i_click_on_an_upload, :when_i_click_on_an_upload
+  alias_method :then_i_see_the_summary_page, :and_i_see_the_summary_page
 end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -54,6 +54,14 @@ feature "bulk add trainees" do
         when_i_visit_the_new_bulk_update_trainees_upload_path
         then_i_see_the_unauthorized_message
       end
+
+      scenario "attempts to visit the upload status page" do
+        when_i_visit_the_bulk_update_index_page
+        then_i_cannot_see_the_bulk_view_status_link
+
+        when_i_visit_the_bulk_trainee_uploads_page
+        then_i_see_the_unauthorized_message
+      end
     end
 
     context "when the User is an HEI Provider" do

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe BulkUpdate::TraineeUpload do
   it { is_expected.to belong_to(:provider) }
+  it { is_expected.to belong_to(:submitted_by).class_name("User").optional }
   it { is_expected.to have_many(:trainee_upload_rows).dependent(:destroy) }
 
   it do

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe BulkUpdate::TraineeUpload do
   describe "events" do
     subject { create(:bulk_update_trainee_upload) }
 
+    let!(:user) { create(:user) }
+
+    before do
+      Current.user = user
+    end
+
+    after do
+      Current.user = nil
+    end
+
     describe "#process!" do
       it do
         expect {
@@ -47,6 +57,7 @@ RSpec.describe BulkUpdate::TraineeUpload do
         expect {
           subject.submit!
         }.to change(subject, :status).from("validated").to("in_progress")
+          .and change(subject, :submitted_by).from(nil).to(user)
           .and change(subject, :submitted_at).from(nil).to(current_time)
       end
     end

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -53,8 +53,9 @@ describe User do
     it { is_expected.to have_many(:provider_users) }
     it { is_expected.to have_many(:lead_partner_users) }
     it { is_expected.to have_many(:lead_partners).through(:lead_partner_users) }
+
     it do
-      is_expected.to have_many(:submitted_bulk_update_trainee_uploads)
+      expect(subject).to have_many(:submitted_bulk_update_trainee_uploads)
       .class_name("BulkUpdate::TraineeUpload").with_foreign_key(:submitted_by_id)
     end
   end

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -53,6 +53,10 @@ describe User do
     it { is_expected.to have_many(:provider_users) }
     it { is_expected.to have_many(:lead_partner_users) }
     it { is_expected.to have_many(:lead_partners).through(:lead_partner_users) }
+    it do
+      is_expected.to have_many(:submitted_bulk_update_trainee_uploads)
+      .class_name("BulkUpdate::TraineeUpload").with_foreign_key(:submitted_by_id)
+    end
   end
 
   describe "indexes" do

--- a/spec/policies/bulk_update/details/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/details/trainee_upload_policy_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::Details::TraineeUploadPolicy, type: :policy do
+  subject { described_class }
+
+  let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+  it { is_expected.to be < BulkUpdate::TraineeUploads::BasePolicy }
+
+  context "when the User's organisation is an HEI Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user, :hei), session: {}) }
+
+    describe "#show" do
+      context "when the upload is succeeded" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, :succeeded) }
+
+        permissions :show? do
+          it { is_expected.to permit(user, trainee_upload) }
+        end
+      end
+
+      %i[pending validated in_progress cancelled failed].each do |status|
+        context "when the upload is #{status}" do
+          let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+          permissions :show? do
+            it { is_expected.not_to permit(user, trainee_upload) }
+          end
+        end
+      end
+    end
+
+    context "when the User's organisation is not an HEI Provider" do
+      let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+      %i[pending validated in_progress succeeded cancelled failed].each do |status|
+        context "when the upload is #{status}" do
+          let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+          permissions :show? do
+            it { is_expected.not_to permit(user, trainee_upload) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/bulk_update/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/trainee_upload_policy_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BulkUpdate::TraineeUploadPolicy, type: :policy do
       context "when the upload is #{status}" do
         let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 
-        permissions :show?, :new?, :create?, :destroy? do
+        permissions :index?, :show?, :new?, :create?, :destroy? do
           it { is_expected.to permit(user, trainee_upload) }
         end
       end
@@ -40,7 +40,7 @@ RSpec.describe BulkUpdate::TraineeUploadPolicy, type: :policy do
       context "when the upload is #{status}" do
         let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 
-        permissions :show?, :new?, :create?, :destroy? do
+        permissions :index?, :show?, :new?, :create?, :destroy? do
           it { is_expected.not_to permit(user, trainee_upload) }
         end
       end

--- a/spec/policies/bulk_update/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/trainee_upload_policy_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe BulkUpdate::TraineeUploadPolicy, type: :policy do
 
   let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
 
+  it { is_expected.to be < BulkUpdate::TraineeUploads::BasePolicy }
+
   context "when the User's organisation is an HEI Provider" do
     let(:user) { UserWithOrganisationContext.new(user: create(:user, :hei), session: {}) }
 

--- a/spec/policies/bulk_update/trainee_uploads/base_policy_spec.rb
+++ b/spec/policies/bulk_update/trainee_uploads/base_policy_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::TraineeUploads::BasePolicy, type: :policy do
+  subject { described_class }
+
+  let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+  describe described_class::Scope do
+    subject do
+      described_class.new(user, BulkUpdate::TraineeUpload).resolve
+    end
+
+    let(:other_user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+    let!(:pending_upload) { create(:bulk_update_trainee_upload, provider: user.providers.first) }
+    let!(:other_user_upload) { create(:bulk_update_trainee_upload, provider: other_user.providers.first) }
+
+    it { is_expected.to contain_exactly(pending_upload) }
+  end
+end

--- a/spec/services/bulk_update/add_trainees/remove_uploads_spec.rb
+++ b/spec/services/bulk_update/add_trainees/remove_uploads_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BulkUpdate::AddTrainees::RemoveUploads do
       expect {
         described_class.call
       }.to change { BulkUpdate::TraineeUpload.count }.to(4)
-        .and change { BulkUpdate::TraineeUploadRow.count }.to(20)
+        .and change { BulkUpdate::TraineeUploadRow.count }.to(25)
         .and change { BulkUpdate::RowError.count }.to(0)
 
       expect(pending_upload.reload).to be_present


### PR DESCRIPTION
### Context

[7884-create-trainee-upload-details-page](https://trello.com/c/p1QOPEJ4/7884-create-trainee-upload-details-page)

### Changes proposed in this pull request

* Use `Current Attributes` singleton to access the `Current.user`
* Add `submitted_by`
* Remove `number_of_trainees`
* Add `BulkUpdate::Trainees::DetailsController#show`
* Refactor `BulkUpdate` policies
* Add `submitted_at` links
 
<img width="714" alt="Screenshot 2024-12-04 at 19 26 37" src="https://github.com/user-attachments/assets/e2a121e4-1a86-426c-a680-2678be9ee346">

<img width="825"
 alt="Screenshot 2024-12-04 at 19 26 01" src="https://github.com/user-attachments/assets/a8921ccc-bd05-45da-bf04-fc2d7eb44725">

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
