### PR TITLE
[7902] Update funding uploads to support 2024 trainee summary CSVs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,8 @@ module ApplicationHelper
 
   def register_form_with(*args, &)
     options = args.extract_options!
+    options[:model] ||= false
+
     defaults = {
       html: {
         novalidate: true,

--- a/app/lib/funding/parsers/lead_partner_trainee_summaries.rb
+++ b/app/lib/funding/parsers/lead_partner_trainee_summaries.rb
@@ -5,14 +5,14 @@ module Funding
     class LeadPartnerTraineeSummaries < Base
       class << self
         def id_column
-          "Lead school URN"
+          "Provider"
         end
 
         def expected_headers
           [
             "Academic year",
-            "Lead school URN",
-            "Lead school name",
+            "Provider",
+            "Provider name",
             "Subject",
             "Description",
             "Funding/trainee",

--- a/app/services/funding/lead_partner_trainee_summaries_importer.rb
+++ b/app/services/funding/lead_partner_trainee_summaries_importer.rb
@@ -34,7 +34,7 @@ module Funding
     end
 
     def payable(id)
-      School.find_by(urn: id)
+      Provider.find_by(accreditation_id: id)
     end
 
     def amount_maps

--- a/spec/lib/funding/parsers/lead_partner_trainee_summaries_spec.rb
+++ b/spec/lib/funding/parsers/lead_partner_trainee_summaries_spec.rb
@@ -11,8 +11,8 @@ module Funding
           [
             {
               "Academic year" => "2021/22",
-              "Lead school URN" => "1111",
-              "Lead school name" => "Lead school 1",
+              "Provider" => "1111",
+              "Provider name" => "Provider 1",
               "Subject" => "Physics",
               "Description" => "School Direct salaried",
               "Funding/trainee" => "24000",
@@ -21,8 +21,8 @@ module Funding
             },
             {
               "Academic year" => "2021/22",
-              "Lead school URN" => "1111",
-              "Lead school name" => "Lead school 1",
+              "Provider" => "1111",
+              "Provider name" => "Provider 1",
               "Subject" => "Modern Languages",
               "Description" => "Post Graduate Teaching Apprenticeship",
               "Funding/trainee" => "10000",
@@ -35,8 +35,8 @@ module Funding
           [
             {
               "Academic year" => "2021/22",
-              "Lead school URN" => "2222",
-              "Lead school name" => "Lead school 2",
+              "Provider" => "2222",
+              "Provider name" => "Provider 2",
               "Subject" => "Mathematics",
               "Description" => "School Direct salaried",
               "Funding/trainee" => "24000",

--- a/spec/services/funding/lead_partner_trainee_summaries_importer_spec.rb
+++ b/spec/services/funding/lead_partner_trainee_summaries_importer_spec.rb
@@ -23,8 +23,8 @@ module Funding
           "1111" => [
             {
               "Academic year" => "2021/22",
-              "Lead school URN" => "1111",
-              "Lead school name" => "Lead School 1",
+              "Provider" => "1111",
+              "Provider name" => "Provider 1",
               "Subject" => "Physics",
               "Description" => "School Direct salaried",
               "Funding/trainee" => "24,000",
@@ -33,8 +33,8 @@ module Funding
             },
             {
               "Academic year" => "2021/22",
-              "Lead school URN" => "1111",
-              "Lead school name" => "Lead School 1",
+              "Provider" => "1111",
+              "Provider name" => "Provider 1",
               "Subject" => "Modern Languages",
               "Description" => "School Direct salaried",
               "Funding/trainee" => "10000",
@@ -43,8 +43,8 @@ module Funding
             },
             {
               "Academic year" => "2021/22",
-              "Lead school URN" => "1111",
-              "Lead school name" => "Lead School 1",
+              "Provider" => "1111",
+              "Provider name" => "Provider 1",
               "Subject" => "History",
               "Description" => "School Direct salaried",
               "Funding/trainee" => "0",
@@ -55,8 +55,8 @@ module Funding
           "2222" => [
             {
               "Academic year" => "2021/22",
-              "Lead school URN" => "2222",
-              "Lead school name" => "Lead School 2",
+              "Provider" => "2222",
+              "Provider name" => "Provider 2",
               "Subject" => "Physics",
               "Description" => " School Direct salaried ",
               "Funding/trainee" => "24000",
@@ -67,16 +67,16 @@ module Funding
         }
       end
 
-      let!(:lead_school_one) { create(:school, urn: "1111") }
-      let!(:lead_school_two) { create(:school, urn: "2222") }
+      let!(:provider_one) { create(:provider, accreditation_id: "1111") }
+      let!(:provider_two) { create(:provider, accreditation_id: "2222") }
 
-      let(:lead_school_one_summary) { lead_school_one.funding_trainee_summaries.last }
-      let(:lead_school_two_summary) { lead_school_two.funding_trainee_summaries.last }
+      let(:provider_one_summary) { provider_one.funding_trainee_summaries.last }
+      let(:provider_two_summary) { provider_two.funding_trainee_summaries.last }
 
-      let(:lead_school_one_first_row) { lead_school_one_summary.rows.first }
-      let(:lead_school_one_second_row) { lead_school_one_summary.rows.second }
-      let(:lead_school_one_third_row) { lead_school_one_summary.rows.last }
-      let(:lead_school_two_first_row) { lead_school_two_summary.rows.first }
+      let(:provider_one_first_row) { provider_one_summary.rows.first }
+      let(:provider_one_second_row) { provider_one_summary.rows.second }
+      let(:provider_one_third_row) { provider_one_summary.rows.last }
+      let(:provider_two_first_row) { provider_two_summary.rows.first }
 
       subject { described_class.call(attributes: summaries_attributes) }
 
@@ -84,65 +84,61 @@ module Funding
         subject
       end
 
-      it "creates a TraineeSummary for each lead school" do
-        expect(lead_school_one.funding_trainee_summaries.count).to eq(1)
-        expect(lead_school_two.funding_trainee_summaries.count).to eq(1)
+      it "creates a TraineeSummary for each provider" do
+        expect(provider_one.funding_trainee_summaries.count).to eq(1)
+        expect(provider_two.funding_trainee_summaries.count).to eq(1)
       end
 
       it "creates a TraineeSummary for the academic year" do
-        expect(lead_school_one_summary.academic_year).to eq("2021/22")
-        expect(lead_school_two_summary.academic_year).to eq("2021/22")
+        expect(provider_one_summary.academic_year).to eq("2021/22")
+        expect(provider_two_summary.academic_year).to eq("2021/22")
       end
 
       describe "TraineeSummaryRow" do
-        let(:lead_school_one_expected_attibutes) {
+        let(:provider_one_expected_attributes) {
           {
             "route" => "School Direct salaried",
             "training_route" => "school_direct_salaried",
-            "lead_school_name" => "Lead School 1",
-            "lead_school_urn" => "1111",
           }
         }
 
-        let(:lead_school_two_expected_attibutes) {
+        let(:provider_two_expected_attributes) {
           {
             "subject" => "Physics",
             "route" => "School Direct salaried",
             "training_route" => "school_direct_salaried",
-            "lead_school_name" => "Lead School 2",
-            "lead_school_urn" => "2222",
           }
         }
 
         it "creates the correct number of TraineeSummaryRows" do
-          expect(lead_school_one_summary.rows.count).to eq(3)
-          expect(lead_school_two_summary.rows.count).to eq(1)
+          expect(provider_one_summary.rows.count).to eq(3)
+          expect(provider_two_summary.rows.count).to eq(1)
         end
 
         it "creates TraineeSummaryRows with the correct attributes" do
-          expect(lead_school_one_first_row.attributes).to include(
-            lead_school_one_expected_attibutes.merge({ "subject" => "Physics" }),
+          expect(provider_one_first_row.attributes).to include(
+            provider_one_expected_attributes.merge({ "subject" => "Physics" }),
           )
-          expect(lead_school_one_second_row.attributes).to include(
-            lead_school_one_expected_attibutes.merge({ "subject" => "Modern Languages" }),
+          expect(provider_one_second_row.attributes).to include(
+            provider_one_expected_attributes.merge({ "subject" => "Modern Languages" }),
           )
-          expect(lead_school_one_third_row.attributes).to include(
-            lead_school_one_expected_attibutes.merge({ "subject" => "History" }),
+          expect(provider_one_third_row.attributes).to include(
+            provider_one_expected_attributes.merge({ "subject" => "History" }),
           )
-          expect(lead_school_two_first_row.attributes).to include(lead_school_two_expected_attibutes)
+          expect(provider_two_first_row.attributes).to include(provider_two_expected_attributes)
         end
       end
 
       describe "TraineeSummaryRowAmount" do
         it "creates the correct number of TraineeSummaryRowAmounts" do
-          expect(lead_school_one_first_row.amounts.count).to eq(1)
-          expect(lead_school_one_second_row.amounts.count).to eq(0)
-          expect(lead_school_one_third_row.amounts.count).to eq(0)
-          expect(lead_school_two_first_row.amounts.count).to eq(0)
+          expect(provider_one_first_row.amounts.count).to eq(1)
+          expect(provider_one_second_row.amounts.count).to eq(0)
+          expect(provider_one_third_row.amounts.count).to eq(0)
+          expect(provider_two_first_row.amounts.count).to eq(0)
         end
 
         it "creates TraineeSummaryRowAmounts with the correct attributes" do
-          expect(lead_school_one_first_row.amounts.first.attributes).to include(
+          expect(provider_one_first_row.amounts.first.attributes).to include(
             {
               "amount_in_pence" => 2_400_000,
               "number_of_trainees" => 2,
@@ -154,14 +150,14 @@ module Funding
       end
     end
 
-    context "unknown school" do
+    context "unknown provider" do
       let(:invalid_summaries_attributes) do
         {
           "4444" => [
             {
               "Academic year" => "2021/22",
-              "Lead school URN" => "4444",
-              "Lead school name" => "Lead School 4",
+              "Provider" => "4444",
+              "Provider name" => "Provider 4",
               "Subject" => "Physics",
               "Description" => "School Direct salaried",
               "Funding/trainee" => "24000",
@@ -174,7 +170,7 @@ module Funding
 
       subject { described_class.call(attributes: invalid_summaries_attributes) }
 
-      it "returns a list of missing lead school urns" do
+      it "returns a list of missing provider accreditation_ids" do
         expect(subject).to eq(["4444"])
       end
     end

--- a/spec/support/fixtures/invalid_lead_partner_trainee_summaries.csv
+++ b/spec/support/fixtures/invalid_lead_partner_trainee_summaries.csv
@@ -1,4 +1,4 @@
-Academic year,Lead school URN,Lead school name,Pubject,Description,Funding/trainee,Trainees,Tootal Funding
-2021/22,1111,Lead school 1,Physics,School Direct salaried,24000,0,0
-2021/22,1111,Lead School 1,Modern Languages,Post Graduate Teaching Apprenticeship,10000,2,20000
-2021/22,2222,Lead School 2,Mathematics,School Direct salaried,24000,1,24000
+Academic year,Provider,Provider name,Pubject,Description,Funding/trainee,Trainees,Tootal Funding
+2021/22,1111,Provider 1,Physics,School Direct salaried,24000,0,0
+2021/22,1111,Provider 1,Modern Languages,Post Graduate Teaching Apprenticeship,10000,2,20000
+2021/22,2222,Provider 2,Mathematics,School Direct salaried,24000,1,24000

--- a/spec/support/fixtures/lead_partner_trainee_summaries.csv
+++ b/spec/support/fixtures/lead_partner_trainee_summaries.csv
@@ -1,4 +1,4 @@
-Academic year,Lead school URN,Lead school name,Subject,Description,Funding/trainee,Trainees,Total Funding
-2021/22,1111,Lead school 1,Physics,School Direct salaried,24000,0,0
-2021/22,1111,Lead school 1,Modern Languages,Post Graduate Teaching Apprenticeship,10000,2,20000
-2021/22,2222,Lead school 2,Mathematics,School Direct salaried,24000,1,24000
+Academic year,Provider,Provider name,Subject,Description,Funding/trainee,Trainees,Total Funding
+2021/22,1111,Provider 1,Physics,School Direct salaried,24000,0,0
+2021/22,1111,Provider 1,Modern Languages,Post Graduate Teaching Apprenticeship,10000,2,20000
+2021/22,2222,Provider 2,Mathematics,School Direct salaried,24000,1,24000


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/qiLsHmS9/7902-update-funding-uploads-to-support-2024-trainee-summary-csvs)

Funding payment has changed for 2024 due to ITT Reform. Payments now all go to APs, rather than being split between APs and Lead Schools, as previously.

The funding team have produced a CSV for SDS and PGTA routes which should now be allocated to Providers rather than Lead Partners (see [Trello card](https://trello.com/c/qiLsHmS9/7902-update-funding-uploads-to-support-2024-trainee-summary-csvs)).

We need to support this and process the funding CSV correctly. We will revisit the funding uploads more generally separately to this.

### Changes proposed in this pull request

* Amend the `LeadPartnerTraineeSummaries` to support the new funding CSV format for SDS and PGTA routes
* Update tests and fixtures
* Fix a [deprecation warning for `for_with`](https://github.com/rails/rails/pull/50931)

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
