### PR TITLE
[7908] Rename the namespace of BulkUpdate::Trainees

### DIFF
--- a/app/components/bulk_update/trainee_uploads/row/view.rb
+++ b/app/components/bulk_update/trainee_uploads/row/view.rb
@@ -31,9 +31,9 @@ module BulkUpdate
 
         def upload_path
           {
-            "succeeded" => bulk_update_trainees_details_path(upload),
-            "in_progress" => bulk_update_trainees_submission_path(upload),
-            "failed" => bulk_update_trainees_review_error_path(upload),
+            "succeeded" => bulk_update_add_trainees_details_path(upload),
+            "in_progress" => bulk_update_add_trainees_submission_path(upload),
+            "failed" => bulk_update_add_trainees_review_error_path(upload),
           }[upload.status]
         end
 

--- a/app/controllers/bulk_update/add_trainees/details_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/details_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BulkUpdate
-  module Trainees
+  module AddTrainees
     class DetailsController < ApplicationController
       before_action { require_feature_flag(:bulk_add_trainees) }
 

--- a/app/controllers/bulk_update/add_trainees/review_errors_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/review_errors_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BulkUpdate
-  module Trainees
+  module AddTrainees
     class ReviewErrorsController < ApplicationController
       before_action { require_feature_flag(:bulk_add_trainees) }
 

--- a/app/controllers/bulk_update/add_trainees/submissions_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/submissions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BulkUpdate
-  module Trainees
+  module AddTrainees
     class SubmissionsController < ApplicationController
       before_action { require_feature_flag(:bulk_add_trainees) }
 
@@ -25,7 +25,7 @@ module BulkUpdate
         # TODO: Handle failures/errors when saving
         SendCsvSubmittedForProcessingEmailService.call(user: current_user, upload: bulk_update_trainee_upload)
 
-        redirect_to(bulk_update_trainees_submission_path(bulk_update_trainee_upload))
+        redirect_to(bulk_update_add_trainees_submission_path(bulk_update_trainee_upload))
       end
 
     private

--- a/app/controllers/bulk_update/add_trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/uploads_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BulkUpdate
-  module Trainees
+  module AddTrainees
     class UploadsController < ApplicationController
       before_action { require_feature_flag(:bulk_add_trainees) }
 
@@ -37,7 +37,7 @@ module BulkUpdate
           # TODO: Dry run method
           upload = @bulk_add_trainee_upload_form.save
 
-          redirect_to(bulk_update_trainees_upload_path(upload), flash: { success: t(".success") })
+          redirect_to(bulk_update_add_trainees_upload_path(upload), flash: { success: t(".success") })
         else
           render(:new)
         end

--- a/app/services/send_csv_submitted_for_processing_email_service.rb
+++ b/app/services/send_csv_submitted_for_processing_email_service.rb
@@ -16,7 +16,7 @@ class SendCsvSubmittedForProcessingEmailService
       first_name: user.first_name,
       email: user.email,
       file_name: upload.file.name,
-      file_link: bulk_update_trainees_upload_url(upload),
+      file_link: bulk_update_add_trainees_upload_url(upload),
       submitted_at: upload.created_at.strftime("%d.%M.%Y, %l%p"),
     ).deliver_later
   end

--- a/app/views/bulk_update/add_trainees/details/show.html.erb
+++ b/app/views/bulk_update/add_trainees/details/show.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: t(:back),
-    href: bulk_update_trainees_uploads_path
+    href: bulk_update_add_trainees_uploads_path
   ) %>
 <% end %>
 
@@ -29,7 +29,7 @@
     <% end %>
 
     <p class="govuk-body">
-      You can also check the <%= govuk_link_to("status of new trainee files", bulk_update_trainees_uploads_path) %>.
+      You can also check the <%= govuk_link_to("status of new trainee files", bulk_update_add_trainees_uploads_path) %>.
     </p>
 
     <p class="govuk-heading-s">

--- a/app/views/bulk_update/add_trainees/review_errors/show.html.erb
+++ b/app/views/bulk_update/add_trainees/review_errors/show.html.erb
@@ -4,15 +4,15 @@
   <%= render(
     GovukComponent::BackLinkComponent.new(
       text: "Back",
-      href: request.referrer.present? && request.referrer.match?(bulk_update_trainees_uploads_path) ?
-        request.referrer : bulk_update_trainees_upload_path(@bulk_update_trainee_upload)
+      href: request.referrer.present? && request.referrer.match?(bulk_update_add_trainees_uploads_path) ?
+        request.referrer : bulk_update_add_trainees_upload_path(@bulk_update_trainee_upload)
     )
   )%>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @bulk_add_trainee_upload_form, url: bulk_update_trainees_uploads_path) do |f| %>
+    <%= register_form_with(model: @bulk_add_trainee_upload_form, url: bulk_update_add_trainees_uploads_path) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
@@ -29,7 +29,7 @@
         <li>
           <%= govuk_link_to(
             "Download your CSV file with errors indicated",
-            bulk_update_trainees_review_error_path(@bulk_update_trainee_upload, format: :csv),
+            bulk_update_add_trainees_review_error_path(@bulk_update_trainee_upload, format: :csv),
           ) %>
         </li>
 
@@ -50,7 +50,7 @@
     <p class="govuk-body">
       <%= register_form_with(
         model: @bulk_update_trainee_upload,
-        url: bulk_update_trainees_upload_path(@bulk_update_trainee_upload),
+        url: bulk_update_add_trainees_upload_path(@bulk_update_trainee_upload),
         method: :delete
       ) do |f| %>
         <%= f.submit "Cancel bulk updates to records", class: "govuk-link app-button--link govuk-body" %>

--- a/app/views/bulk_update/add_trainees/submissions/show.html.erb
+++ b/app/views/bulk_update/add_trainees/submissions/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <% if request.referrer.match?(bulk_update_add_trainees_uploads_path) %>
+  <% if request.referrer.present? && request.referrer.match?(bulk_update_add_trainees_uploads_path) %>
     <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: bulk_update_add_trainees_uploads_path) %>
   <% else %>
     <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>

--- a/app/views/bulk_update/add_trainees/submissions/show.html.erb
+++ b/app/views/bulk_update/add_trainees/submissions/show.html.erb
@@ -1,8 +1,8 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <% if request.referrer.match?(bulk_update_trainees_uploads_path) %>
-    <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: bulk_update_trainees_uploads_path) %>
+  <% if request.referrer.match?(bulk_update_add_trainees_uploads_path) %>
+    <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: bulk_update_add_trainees_uploads_path) %>
   <% else %>
     <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>
   <% end %>

--- a/app/views/bulk_update/add_trainees/uploads/index.html.erb
+++ b/app/views/bulk_update/add_trainees/uploads/index.html.erb
@@ -3,7 +3,11 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: t(:back),
-    href: (request.referrer.present? && request.referrer.match?(/#{bulk_update_trainees_uploads_path}\/\d+$/)) ? request.referrer : bulk_update_path) %>
+    href: (
+      request.referrer.present? && request.referrer.match?(/#{bulk_update_add_trainees_uploads_path}\/\d+$/)) ?
+        request.referrer : bulk_update_path
+    )
+  %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_update/add_trainees/uploads/new.html.erb
+++ b/app/views/bulk_update/add_trainees/uploads/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @bulk_add_trainee_upload_form, url: bulk_update_trainees_uploads_path) do |f| %>
+    <%= register_form_with(model: @bulk_add_trainee_upload_form, url: bulk_update_add_trainees_uploads_path) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">

--- a/app/views/bulk_update/add_trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/add_trainees/uploads/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: new_bulk_update_trainees_upload_path) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: new_bulk_update_add_trainees_upload_path) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -25,7 +25,7 @@
       </p>
 
       <p class="govuk-body">
-        You can also check the <%= govuk_link_to "status of new trainee files", bulk_update_trainees_uploads_path %>.
+        You can also check the <%= govuk_link_to "status of new trainee files", bulk_update_add_trainees_uploads_path %>.
       </p>
 
       <p class="govuk-body">
@@ -71,13 +71,13 @@
 
         <%= render GovukButtonLinkTo::View.new(
           body: "Review errors",
-          url: bulk_update_trainees_review_error_path(id: @bulk_update_trainee_upload.id),
+          url: bulk_update_add_trainees_review_error_path(@bulk_update_trainee_upload),
           class_option: "govuk-button"
         ) %>
       <% else %>
         <%= register_form_with(
           model: @bulk_update_trainee_upload,
-          url: bulk_update_trainees_submissions_path(@bulk_update_trainee_upload),
+          url: bulk_update_add_trainees_submissions_path(@bulk_update_trainee_upload),
           method: :post
         ) do |f| %>
           <%= f.govuk_submit("Submit") %>
@@ -86,7 +86,7 @@
       <p class="govuk-body">
         <%= register_form_with(
           model: @bulk_update_trainee_upload,
-          url: bulk_update_trainees_upload_path(@bulk_update_trainee_upload),
+          url: bulk_update_add_trainees_upload_path(@bulk_update_trainee_upload),
           method: :delete
         ) do |f| %>
           <%= f.submit "Cancel bulk updates to records", class: "govuk-link app-button--link govuk-body" %>

--- a/app/views/bulk_update/bulk_updates/index.html.erb
+++ b/app/views/bulk_update/bulk_updates/index.html.erb
@@ -29,11 +29,11 @@
       <p class="govuk-body">You can bulk add new trainees.</p>
 
       <p class="govuk-body">
-        <%= govuk_link_to("Bulk add new trainees", new_bulk_update_trainees_upload_path) %>
+        <%= govuk_link_to("Bulk add new trainees", new_bulk_update_add_trainees_upload_path) %>
       </p>
 
       <p class="govuk-body">
-        <%= govuk_link_to("View status of previously uploaded new trainee files", bulk_update_trainees_uploads_path) %>
+        <%= govuk_link_to("View status of previously uploaded new trainee files", bulk_update_add_trainees_uploads_path) %>
       </p>
     <% else %>
       <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1990,7 +1990,7 @@ en:
       contents: Contents
 
   bulk_update:
-    trainees:
+    add_trainees:
       uploads:
         create:
           success: File uploaded

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Rails.application.routes.draw do
           resource :details, only: :show
         end
       end
-      resources :review_errors, path: "review-errors", only: %i[show], as: :review_errors
+      resources :review_errors, path: "review-errors", only: %i[show]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,14 +87,14 @@ Rails.application.routes.draw do
       member { get :cancel, path: "cancel" }
     end
 
-    namespace :trainees do
+    namespace :add_trainees, path: "add-trainees" do
       resources :uploads, only: %i[index show new create destroy] do
         member do
           resources :submissions, only: %i[show create]
           resource :details, only: :show
         end
       end
-      resources :review_errors, path: "review_errors", only: %i[show], as: :review_errors
+      resources :review_errors, path: "review-errors", only: %i[show], as: :review_errors
     end
   end
 

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -37,7 +37,7 @@ feature "bulk add trainees" do
         when_i_visit_the_bulk_update_index_page
         then_i_cannot_see_the_bulk_add_trainees_link
 
-        when_i_visit_the_new_bulk_update_trainees_upload_path
+        when_i_visit_the_new_bulk_update_add_trainees_upload_path
         then_i_see_the_unauthorized_message
       end
 
@@ -45,7 +45,7 @@ feature "bulk add trainees" do
         when_i_visit_the_bulk_update_index_page
         then_i_cannot_see_the_bulk_view_status_link
 
-        when_i_visit_the_bulk_trainee_uploads_page
+        when_i_visit_the_bulk_update_add_trainees_uploads_page
         then_i_see_the_unauthorized_message
       end
     end
@@ -59,7 +59,7 @@ feature "bulk add trainees" do
         when_i_visit_the_bulk_update_index_page
         then_i_cannot_see_the_bulk_add_trainees_link
 
-        when_i_visit_the_new_bulk_update_trainees_upload_path
+        when_i_visit_the_new_bulk_update_add_trainees_upload_path
         then_i_see_the_unauthorized_message
       end
 
@@ -67,13 +67,13 @@ feature "bulk add trainees" do
         when_i_visit_the_bulk_update_index_page
         then_i_cannot_see_the_bulk_view_status_link
 
-        when_i_visit_the_bulk_trainee_uploads_page
+        when_i_visit_the_bulk_update_add_trainees_uploads_page
         then_i_see_the_unauthorized_message
       end
 
       scenario "attempts to visit the upload details page" do
         when_an_upload_exist
-        and_i_visit_the_bulk_update_trainee_upload_details_page
+        and_i_visit_the_bulk_update_add_trainees_upload_details_page
 
         then_i_see_the_unauthorized_message
       end
@@ -157,13 +157,13 @@ feature "bulk add trainees" do
 
         when_i_visit_the_bulk_update_index_page
         and_i_click_on_view_status_of_uploaded_trainee_files
-        then_i_see_the_uploads_index_page
+        then_i_see_the_bulk_update_add_trainees_uploads_index_page
 
         when_i_click_on_an_upload
-        then_i_see_the_upload_details_page
+        then_i_see_the_bulk_update_add_trainees_upload_details_page
 
         when_i_click_on_back_link
-        then_i_see_the_uploads_index_page
+        then_i_see_the_bulk_update_add_trainees_uploads_index_page
 
         when_i_try_resubmit_the_same_upload
         and_i_click_the_submit_button
@@ -174,7 +174,7 @@ feature "bulk add trainees" do
         when_there_is_a_bulk_update_trainee_upload
 
         expect {
-          when_i_visit_the_bulk_update_status_page_for_another_provider
+          when_i_visit_the_bulk_update_add_trainees_status_page_for_another_provider
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -271,10 +271,10 @@ feature "bulk add trainees" do
         then_i_dont_see_the_upload
 
         when_i_click_on_an_upload(upload: BulkUpdate::TraineeUpload.succeeded.first)
-        then_i_see_the_upload_details_page
+        then_i_see_the_bulk_update_add_trainees_upload_details_page
 
         when_i_click_on_back_link
-        then_i_see_the_bulk_trainees_uploads_index_page
+        then_i_see_the_bulk_update_add_trainees_uploads_index_page
 
         when_i_click_on_back_link
         then_i_see_the_bulk_update_index_page
@@ -284,7 +284,7 @@ feature "bulk add trainees" do
         then_i_see_the_summary_page(upload: BulkUpdate::TraineeUpload.in_progress.first)
 
         when_i_click_on_back_link
-        then_i_see_the_bulk_trainees_uploads_index_page
+        then_i_see_the_bulk_update_add_trainees_uploads_index_page
 
         when_i_click_on_back_link
         then_i_see_the_bulk_update_index_page
@@ -294,7 +294,7 @@ feature "bulk add trainees" do
         then_i_see_the_review_errors_page(upload: BulkUpdate::TraineeUpload.failed.first)
 
         when_i_click_on_back_link
-        then_i_see_the_bulk_trainees_uploads_index_page
+        then_i_see_the_bulk_update_add_trainees_uploads_index_page
 
         when_i_click_on_back_link
         then_i_see_the_bulk_update_index_page
@@ -358,7 +358,7 @@ private
     create(:academic_cycle, :previous)
   end
 
-  def then_i_see_the_uploads_index_page
+  def then_i_see_the_bulk_update_add_trainees_uploads_index_page
     expect(page).to have_content("Status of new trainee files")
   end
 
@@ -366,7 +366,7 @@ private
     first(:link, upload.submitted_at.to_fs(:govuk_date_and_time)).click
   end
 
-  def then_i_see_the_upload_details_page
+  def then_i_see_the_bulk_update_add_trainees_upload_details_page
     expect(page).to have_content("Your new trainees have been registered")
     expect(page).to have_content("Submitted by:#{current_user.name}")
     expect(page).to have_content("Number of registered trainees:5")
@@ -421,7 +421,7 @@ private
   end
 
   def and_i_visit_the_bulk_update_trainee_uploads_page
-    visit bulk_update_trainees_uploads_path
+    visit bulk_update_add_trainees_uploads_path
   end
 
   def and_i_click_on_view_status_of_uploaded_trainee_files
@@ -471,7 +471,7 @@ private
   end
 
   def when_i_try_resubmit_the_same_upload
-    visit bulk_update_trainees_upload_path(BulkUpdate::TraineeUpload.last)
+    visit bulk_update_add_trainees_upload_path(BulkUpdate::TraineeUpload.last)
   end
 
   def then_i_see_the_unauthorized_message
@@ -533,12 +533,12 @@ private
   end
 
   def and_i_cannot_navigate_directly_to_the_bulk_add_trainees_page
-    when_i_visit_the_new_bulk_update_trainees_upload_path
+    when_i_visit_the_new_bulk_update_add_trainees_upload_path
     expect(page).to have_current_path(not_found_path)
   end
 
-  def when_i_visit_the_new_bulk_update_trainees_upload_path
-    visit new_bulk_update_trainees_upload_path
+  def when_i_visit_the_new_bulk_update_add_trainees_upload_path
+    visit new_bulk_update_add_trainees_upload_path
   end
 
   def and_i_click_the_bulk_add_trainees_page
@@ -546,7 +546,7 @@ private
   end
 
   def then_i_see_how_instructions_on_how_to_bulk_add_trainees
-    expect(page).to have_current_path(new_bulk_update_trainees_upload_path)
+    expect(page).to have_current_path(new_bulk_update_add_trainees_upload_path)
     expect(page).to have_content("Bulk add new trainees")
   end
 
@@ -585,7 +585,7 @@ private
   end
 
   def then_i_see_the_upload_page_with_errors(empty:)
-    expect(page).to have_current_path(bulk_update_trainees_uploads_path)
+    expect(page).to have_current_path(bulk_update_add_trainees_uploads_path)
     expect(page).to have_content("There is a problem")
     expect(page).to have_content(empty ? "The selected file is empty" : "Select a CSV file")
   end
@@ -657,7 +657,7 @@ private
 
   def and_i_see_the_summary_page(upload: BulkUpdate::TraineeUpload.last)
     expect(page).to have_current_path(
-      bulk_update_trainees_submission_path(upload),
+      bulk_update_add_trainees_submission_path(upload),
     )
     within(".govuk-panel") do
       expect(page).to have_content("Trainees submitted")
@@ -669,12 +669,12 @@ private
     @upload_for_different_provider = create(:bulk_update_trainee_upload)
   end
 
-  def when_i_visit_the_bulk_update_status_page_for_another_provider
-    visit bulk_update_trainees_upload_path(@upload_for_different_provider)
+  def when_i_visit_the_bulk_update_add_trainees_status_page_for_another_provider
+    visit bulk_update_add_trainees_upload_path(@upload_for_different_provider)
   end
 
   def and_i_refresh_the_page
-    visit bulk_update_trainees_upload_path(BulkUpdate::TraineeUpload.last)
+    visit bulk_update_add_trainees_upload_path(BulkUpdate::TraineeUpload.last)
   end
 
   def and_i_refresh_the_summary_page
@@ -731,7 +731,7 @@ private
   end
 
   def and_i_visit_the_summary_page(upload:)
-    visit bulk_update_trainees_upload_path(upload)
+    visit bulk_update_add_trainees_upload_path(upload)
   end
 
   def then_i_see_the_review_page_with_validation_errors
@@ -743,12 +743,12 @@ private
   end
 
   def then_i_see_the_review_errors_page(upload: BulkUpdate::TraineeUpload.last)
-    expect(page).to have_current_path(bulk_update_trainees_review_error_path(upload))
+    expect(page).to have_current_path(bulk_update_add_trainees_review_error_path(upload))
     expect(page).to have_content("Review errors for #{upload.total_rows_with_errors} trainees in the CSV that you uploaded")
   end
 
   def then_i_see_the_review_errors_page_with_one_error
-    expect(page).to have_current_path(bulk_update_trainees_review_error_path(id: BulkUpdate::TraineeUpload.last.id))
+    expect(page).to have_current_path(bulk_update_add_trainees_review_error_path(id: BulkUpdate::TraineeUpload.last.id))
     expect(page).to have_content("Review errors for 1 trainee in the CSV that you uploaded")
   end
 
@@ -762,31 +762,31 @@ private
   end
 
   def when_i_return_to_the_review_errors_page
-    visit bulk_update_trainees_review_error_path(id: BulkUpdate::TraineeUpload.last.id)
+    visit bulk_update_add_trainees_review_error_path(BulkUpdate::TraineeUpload.last)
   end
 
   def then_i_see_the_bulk_update_index_page
     expect(page).to have_current_path(bulk_update_path, ignore_query: true)
   end
 
-  def then_i_see_the_bulk_trainees_uploads_index_page
-    expect(page).to have_current_path(bulk_update_trainees_uploads_path, ignore_query: true)
+  def then_i_see_the_bulk_add_trainees_uploads_index_page
+    expect(page).to have_current_path(bulk_update_add_trainees_uploads_path, ignore_query: true)
   end
 
   def then_i_cannot_see_the_bulk_view_status_link
     expect(page).not_to have_link("View status of previously uploaded new trainee files")
   end
 
-  def when_i_visit_the_bulk_trainee_uploads_page
-    visit bulk_update_trainees_uploads_path
+  def when_i_visit_the_bulk_update_add_trainees_uploads_page
+    visit bulk_update_add_trainees_uploads_path
   end
 
-  def and_i_visit_the_bulk_update_trainee_upload_details_page(upload: BulkUpdate::TraineeUpload.last)
-    visit bulk_update_trainees_details_path(upload)
+  def and_i_visit_the_bulk_update_add_trainees_upload_details_page(upload: BulkUpdate::TraineeUpload.last)
+    visit bulk_update_add_trainees_details_path(upload)
   end
 
   def when_i_visit_the_review_errors_page(upload: BulkUpdate::TraineeUpload.last)
-    visit bulk_update_trainees_review_error_path(upload)
+    visit bulk_update_add_trainees_review_error_path(upload)
   end
 
   alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -659,10 +659,17 @@ private
     expect(page).to have_current_path(
       bulk_update_add_trainees_submission_path(upload),
     )
-    within(".govuk-panel") do
-      expect(page).to have_content("Trainees submitted")
+
+    if upload.in_progress?
+      expect(page).to have_content(
+        "We're currently processing #{upload.filename}",
+      )
+    else
+      within(".govuk-panel") do
+        expect(page).to have_content("Trainees submitted")
+      end
+      expect(page).to have_content("There are 3 ways to check trainee data in Register.")
     end
-    expect(page).to have_content("There are 3 ways to check trainee data in Register.")
   end
 
   def when_there_is_a_bulk_update_trainee_upload
@@ -678,7 +685,7 @@ private
   end
 
   def and_i_refresh_the_summary_page
-    visit bulk_update_trainees_submission_path(BulkUpdate::TraineeUpload.last)
+    visit bulk_update_add_trainees_submission_path(BulkUpdate::TraineeUpload.last)
   end
 
   def when_the_background_job_is_run


### PR DESCRIPTION
### Context

[7908-rename-the-namespace-of-bulkupdatetrainees](https://trello.com/c/lwF6E8DK/7908-rename-the-namespace-of-bulkupdatetrainees)

### Changes proposed in this pull request

* Rename the controller namespace of `BulkUpdate::Trainees` to `BulkUpdate::AddTrainees`
* Change the paths from `/bulk-update/trainees` to `/bulk-update/add-trainees`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
