### PR TITLE
[7905] ITT performance profile sign off for the 2023 to 2024 academic year page

### DIFF
--- a/app/components/performance_profile_banner/view.html.erb
+++ b/app/components/performance_profile_banner/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_notification_banner(title_text: "Important") do |banner| %>
   <% banner.with_heading(text: banner_heading_text) %>
 
-  <%= govuk_link_to("Sign off your performance profile", performance_profiles_reports_path)%> by the <%= deadline_date %> deadline.
+  <%= govuk_link_to("Sign off your performance profile", reports_performance_profiles_path) %> by the <%= deadline_date %> deadline.
 <% end %>

--- a/app/components/performance_profile_banner/view.rb
+++ b/app/components/performance_profile_banner/view.rb
@@ -11,7 +11,7 @@ module PerformanceProfileBanner
     end
 
     def render?
-      performance_period? && provider_awaiting_sign_off?
+      performance_period? && provider.performance_profile_awaiting_sign_off?
     end
 
     def banner_heading_text
@@ -27,10 +27,6 @@ module PerformanceProfileBanner
   private
 
     attr_reader :previous_academic_cycle, :provider, :sign_off_period
-
-    def provider_awaiting_sign_off?
-      !provider.performance_profile_signed_off?
-    end
 
     def performance_period?
       sign_off_period == :performance_period

--- a/app/controllers/reports/performance_profiles_controller.rb
+++ b/app/controllers/reports/performance_profiles_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Reports
+  class PerformanceProfilesController < ApplicationController
+    def index
+      authorize(current_user, :reports?)
+
+      @previous_academic_cycle = AcademicCycle.previous
+      @previous_academic_cycle_label = @previous_academic_cycle.label
+
+      respond_to do |format|
+        format.html do
+          @trainee_count = performance_profiles_trainees.count
+        end
+
+        format.csv do
+          authorize(:trainee, :export?)
+          headers["X-Accel-Buffering"] = "no"
+          headers["Cache-Control"] = "no-cache"
+          headers["Content-Type"] = "text/csv; charset=utf-8"
+          headers["Content-Disposition"] =
+            %(attachment; filename="#{performance_profiles_filename}")
+          headers["Last-Modified"] = Time.zone.now.ctime.to_s
+
+          response.status = 200
+
+          self.response_body = Exports::ReportCsvEnumeratorService.call(performance_profiles_trainees)
+        end
+      end
+    end
+
+    private
+
+    def time_now
+      Time.now.in_time_zone("London").strftime("%F_%H-%M-%S")
+    end
+
+    def performance_profiles_filename
+      "#{time_now}_#{@previous_academic_cycle.label('-')}_trainees_performance-profiles-sign-off_register-trainee-teachers.csv"
+    end
+
+    def performance_profiles_trainees
+      Trainees::Filter.call(trainees: base_trainee_scope, filters: { academic_year: [@previous_academic_cycle.start_year] })
+    end
+
+    def base_trainee_scope
+      policy_scope(Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :end_academic_cycle).not_draft)
+    end
+  end
+end

--- a/app/controllers/reports/performance_profiles_controller.rb
+++ b/app/controllers/reports/performance_profiles_controller.rb
@@ -56,7 +56,7 @@ module Reports
   private
 
     def applicable_to_user?
-      current_user.accredited_provider? && current_user.organisation.performance_profile_awaiting_sign_off? && DetermineSignOffPeriod.call == :performance_period
+      current_user.provider? && current_user.organisation.performance_profile_awaiting_sign_off? && DetermineSignOffPeriod.call == :performance_period
     end
 
     def time_now

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -42,30 +42,6 @@ class ReportsController < BaseTraineeController
     end
   end
 
-  def performance_profiles
-    authorize(current_user, :reports?)
-
-    respond_to do |format|
-      format.html do
-        @trainee_count = performance_profiles_trainees.count
-      end
-
-      format.csv do
-        authorize(:trainee, :export?)
-        headers["X-Accel-Buffering"] = "no"
-        headers["Cache-Control"] = "no-cache"
-        headers["Content-Type"] = "text/csv; charset=utf-8"
-        headers["Content-Disposition"] =
-          %(attachment; filename="#{performance_profiles_filename}")
-        headers["Last-Modified"] = Time.zone.now.ctime.to_s
-
-        response.status = 200
-
-        self.response_body = Exports::ReportCsvEnumeratorService.call(performance_profiles_trainees)
-      end
-    end
-  end
-
   def bulk_recommend_export
     authorize(current_user, :bulk_recommend?)
 
@@ -92,10 +68,6 @@ private
     @itt_new_starter_trainees ||= policy_scope(FindNewStarterTrainees.new(census_date(@current_academic_cycle.start_year)).call)
   end
 
-  def performance_profiles_trainees
-    Trainees::Filter.call(trainees: base_trainee_scope, filters: { academic_year: [@previous_academic_cycle.start_year] })
-  end
-
   def bulk_recommend_trainees
     policy_scope(FindBulkRecommendTrainees.call).order(last_name: :asc)
   end
@@ -106,10 +78,6 @@ private
 
   def itt_new_starter_filename
     "#{time_now}_New-trainees-#{@current_academic_cycle.label('-')}-sign-off-Register-trainee-teachers_exported_records.csv"
-  end
-
-  def performance_profiles_filename
-    "#{time_now}_#{@previous_academic_cycle.label('-')}_trainees_performance-profiles-sign-off_register-trainee-teachers.csv"
   end
 
   def bulk_recommend_export_filename

--- a/app/forms/performance_profile_sign_off_form.rb
+++ b/app/forms/performance_profile_sign_off_form.rb
@@ -5,7 +5,7 @@ class PerformanceProfileSignOffForm
 
   validates :sign_off, presence: true, inclusion: { in: ["confirmed"] }
 
-  def initialize(sign_off: "not_confirmed", provider: nil, user:)
+  def initialize(sign_off: "not_confirmed", provider: nil, user: nil)
     @sign_off = sign_off
     @provider = provider
     @user = user

--- a/app/forms/performance_profile_sign_off_form.rb
+++ b/app/forms/performance_profile_sign_off_form.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class PerformanceProfileSignOffForm
+  include ActiveModel::Model
+
+  validates :sign_off, presence: true, inclusion: { in: ["confirmed"] }
+
+  def initialize(sign_off: "not_confirmed", provider: nil, user:)
+    @sign_off = sign_off
+    @provider = provider
+    @user = user
+  end
+
+  def save!
+    return false unless valid?
+
+    performance_profile_sign_off = provider.sign_offs.find_or_initialize_by(academic_cycle: AcademicCycle.previous, sign_off_type: :performance_profile)
+    performance_profile_sign_off.user = user
+
+    performance_profile_sign_off.save!
+  end
+
+private
+
+  attr_reader :sign_off, :provider, :user
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -118,6 +118,10 @@ class Provider < ApplicationRecord
     sign_offs.performance_profile.previous_academic_cycle.exists?
   end
 
+  def performance_profile_awaiting_sign_off?
+    !performance_profile_signed_off?
+  end
+
 private
 
   def update_courses

--- a/app/views/guidance/performance_profiles.html.erb
+++ b/app/views/guidance/performance_profiles.html.erb
@@ -32,7 +32,7 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>
         downloading a
-        <a href=<%= performance_profiles_reports_path %> class="govuk-link">report with the data you need to check</a>
+        <a href=<%= reports_performance_profiles_path %> class="govuk-link">report with the data you need to check</a>
       </li>
       <li>
         exporting a

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -113,7 +113,8 @@
               end %>
         <% else %>
           <%= render(YearChangeBanner::View.new) %>
-          <%= render(PerformanceProfileBanner::View.new(previous_academic_cycle: AcademicCycle.previous, sign_off_period: :performance_period, provider: @current_user.organisation)) if @current_user&.accredited_provider? && request.path == root_path %>
+          <%= render(PerformanceProfileBanner::View.new(previous_academic_cycle: AcademicCycle.previous, sign_off_period: DetermineSignOffPeriod.call, provider: @current_user.organisation)) if @current_user&.provider? && request.path == root_path %>
+
         <% end %>
 
         <%= render(FlashBanner::View.new(flash: flash, trainee: @trainee)) %>

--- a/app/views/reports/_performance_period.html.erb
+++ b/app/views/reports/_performance_period.html.erb
@@ -4,7 +4,7 @@
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
-      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year report", performance_profiles_reports_path, class: "performance-profiles" %> - for performance profiles sign off with a deadline of <%= @previous_academic_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) %>.
+      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year report", reports_performance_profiles_path, class: "performance-profiles" %> - for performance profiles sign off with a deadline of <%= @previous_academic_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) %>.
     </p>
   </li>
 </ul>

--- a/app/views/reports/performance_profiles/index.html.erb
+++ b/app/views/reports/performance_profiles/index.html.erb
@@ -72,6 +72,6 @@
     <p class="govuk-body">
       If you have checked your data.
     </p>
-    <%= govuk_button_link_to("Continue to performance profile sign off", "#")%>
+    <%= govuk_button_link_to("Continue to performance profile sign off", new_reports_performance_profile_path)%>
   </div>
 </div>

--- a/app/views/reports/performance_profiles/index.html.erb
+++ b/app/views/reports/performance_profiles/index.html.erb
@@ -31,7 +31,7 @@
       You need to check all registered trainees who studied in the previous <%= @previous_academic_cycle_label %> academic year.
     </p>
     <p class="govuk-body">
-      <%= govuk_link_to "Export #{@previous_academic_cycle_label} trainee data (#{@trainee_count} #{"trainee".pluralize(@trainee_count)})", performance_profiles_reports_path(:csv) %>
+      <%= govuk_link_to "Export #{@previous_academic_cycle_label} trainee data (#{@trainee_count} #{"trainee".pluralize(@trainee_count)})", reports_performance_profiles_path(:csv) %>
     </p>
 
     <h2 class="govuk-heading-m">

--- a/app/views/reports/performance_profiles/new.html.erb
+++ b/app/views/reports/performance_profiles/new.html.erb
@@ -1,0 +1,38 @@
+<% page_title = "ITT performance profile sign off for the #{@previous_academic_cycle_label} academic year" %>
+<%= render PageTitle::View.new(text: page_title, has_errors: @performance_profile_sign_off_form.errors.any?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Reports",
+    href: reports_path,
+    ) %>
+<% end %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @performance_profile_sign_off_form, url: reports_performance_profiles_path) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <%= page_title %>
+      </h1>
+      <p class="govuk-body">
+        Once you've checked your data is correct, you can sign off on behalf of your organisation.
+      </p>
+
+      <%= govuk_summary_card(title: "Performance profile information") do |card|
+            card.with_summary_list(rows: [
+            { key: { text: "Provider name" }, value: { text: current_user.organisation.name } },
+            { key: { text: "UKPRN" }, value: { text: @current_user.organisation.ukprn } },
+            { key: { text: "Approver name" }, value: { text: @current_user.name } },
+          ],)
+          end %>
+
+      <%= f.govuk_check_boxes_fieldset(:sign_off, multiple: false, legend: { text: "Confirm you have checked the trainee data is correct in Register, and you’re signing it off.", size: "s" }) do %>
+        <%= f.govuk_check_box(:sign_off, "confirmed", "not_confirmed", multiple: false, link_errors: true, label: { text: "Yes, the trainee data is correct to the best of my knowledge" }) %>
+      <% end %>
+
+      <%= f.govuk_submit("Sign off performance profile") %>
+    <%- end -%>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1528,6 +1528,11 @@ en:
             email:
               blank: Enter an email address
               invalid: Enter an email address in the correct format, like name@example.com
+        performance_profile_sign_off_form:
+          attributes:
+            sign_off:
+              inclusion: Please confirm sign off
+              blank: Please confirm sign off
         language_specialisms_form:
           attributes:
             course_subject_one:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1531,8 +1531,8 @@ en:
         performance_profile_sign_off_form:
           attributes:
             sign_off:
-              inclusion: Please confirm sign off
-              blank: Please confirm sign off
+              inclusion: Confirm sign off
+              blank: Confirm sign off
         language_specialisms_form:
           attributes:
             course_subject_one:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,11 +64,11 @@ Rails.application.routes.draw do
   resources :drafts, only: :index
 
   resources :reports, only: :index do
-    get "itt-new-starter-data-sign-off", to: "reports#itt_new_starter_data_sign_off", on: :collection
-    get :bulk_recommend_export, on: :collection
-    get :bulk_recommend_empty_export, on: :collection
-    get :bulk_placement_export, on: :collection
     collection do
+      get "itt-new-starter-data-sign-off", to: "reports#itt_new_starter_data_sign_off"
+      get :bulk_recommend_export
+      get :bulk_recommend_empty_export
+      get :bulk_placement_export
       scope module: :reports, as: :reports do
         resources :performance_profiles, path: "performance-profiles", only: %i[index new create]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
     get :bulk_placement_export, on: :collection
     collection do
       scope module: :reports, as: :reports do
-        resources :performance_profiles, only: %i[index]
+        resources :performance_profiles, path: "performance-profiles", only: %i[index new create]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,10 +65,14 @@ Rails.application.routes.draw do
 
   resources :reports, only: :index do
     get "itt-new-starter-data-sign-off", to: "reports#itt_new_starter_data_sign_off", on: :collection
-    get "performance-profiles", to: "reports#performance_profiles", on: :collection
     get :bulk_recommend_export, on: :collection
     get :bulk_recommend_empty_export, on: :collection
     get :bulk_placement_export, on: :collection
+    collection do
+      scope module: :reports, as: :reports do
+        resources :performance_profiles, only: %i[index]
+      end
+    end
   end
 
   namespace :bulk_update, path: "bulk-update" do

--- a/spec/controllers/reports/performance_profiles_controller_spec.rb
+++ b/spec/controllers/reports/performance_profiles_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Reports::PerformanceProfilesController do
+  let(:user) { build_current_user }
+
+  before do
+    create(:academic_cycle, previous_cycle: true)
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(DetermineSignOffPeriod).to receive(:call).and_return(:performance_period)
+  end
+
+  describe "#index" do
+    it "returns a 200 status code" do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the application template" do
+      get :index
+      expect(response).to render_template("application")
+    end
+
+    it "renders a csv" do
+      get :index, params: { format: :csv }
+      expect(response.content_type).to eq("text/csv; charset=utf-8")
+    end
+  end
+end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -40,23 +40,6 @@ describe ReportsController do
     end
   end
 
-  describe "#performance_profiles" do
-    it "returns a 200 status code" do
-      get :performance_profiles
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "renders the application template" do
-      get :performance_profiles
-      expect(response).to render_template("application")
-    end
-
-    it "renders a csv" do
-      get :performance_profiles, params: { format: :csv }
-      expect(response.content_type).to eq("text/csv; charset=utf-8")
-    end
-  end
-
   describe "#bulk_recommend_export" do
     it "renders a csv" do
       get :bulk_recommend_export, params: { format: :csv }

--- a/spec/features/performance_profile_banner_spec.rb
+++ b/spec/features/performance_profile_banner_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 feature "performance profile banner" do
   context "within the performance profile date range" do
     background do
+      allow(DetermineSignOffPeriod).to receive(:call).and_return(:performance_period)
       Timecop.freeze(AcademicCycle.previous.performance_profile_date_range.to_a.sample)
     end
 

--- a/spec/features/reports/performance_profile_spec.rb
+++ b/spec/features/reports/performance_profile_spec.rb
@@ -39,7 +39,7 @@ feature "performance profile sign off" do
         and_i_can_see_the_performance_profile_information
         and_i_click_on("Sign off performance profile")
         and_i_see_there_is_a_problem
-        and_i_click_on("Please confirm sign off")
+        and_i_click_on("Confirm sign off")
         and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
         and_i_click_on("Sign off performance profile")
 

--- a/spec/features/reports/performance_profile_spec.rb
+++ b/spec/features/reports/performance_profile_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "performance profile sign off" do
+  context "outside period" do
+    background do
+      allow(DetermineSignOffPeriod).to receive(:call).and_return(:outside_period)
+    end
+
+    scenario "navigate to the sign off your performance profile page" do
+      given_i_am_authenticated
+      when_i_visit_the_sign_off_your_performance_profile_page
+      then_i_am_redirected_to_the_reports_page
+    end
+
+    scenario "navigate to the itt performance profile sign off for the academic year page" do
+      given_i_am_authenticated
+      when_i_visit_the_itt_performance_profile_sign_off_for_the_academic_year_page
+      then_i_am_redirected_to_the_reports_page
+    end
+  end
+
+  context "performance period" do
+    background do
+      allow(DetermineSignOffPeriod).to receive(:call).and_return(:performance_period)
+    end
+
+    context "accredited provider user" do
+      scenario "user signing off the performance profile from banner" do
+        given_i_am_authenticated
+        and_i_am_on_the_root_page
+        and_i_can_see_the_performance_profile_banner
+        and_i_click_on("Sign off your performance profile")
+        and_i_am_on_the_sign_off_your_performance_profile_page
+
+        when_i_click_on("Continue to performance profile sign off")
+        and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
+        and_i_can_see_the_performance_profile_information
+        and_i_click_on("Sign off performance profile")
+        and_i_see_there_is_a_problem
+        and_i_click_on("Please confirm sign off")
+        and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
+        and_i_click_on("Sign off performance profile")
+
+        then_i_am_redirected_to_the_reports_page
+        and_the_provider_has_performance_profile_signed_off
+      end
+
+      scenario "user signing off the performance profile from reports page" do
+        given_i_am_authenticated
+        and_i_am_on_the_reports_page
+        and_i_click_on("Trainees who studied in the #{previous_academic_cycle_label} academic year report")
+        and_i_am_on_the_sign_off_your_performance_profile_page
+
+        when_i_click_on("Continue to performance profile sign off")
+        and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
+        and_i_can_see_the_performance_profile_information
+        and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
+        and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
+        and_i_click_on("Sign off performance profile")
+
+        then_i_am_redirected_to_the_reports_page
+        and_the_provider_has_performance_profile_signed_off
+      end
+
+      context "performance profile signed off" do
+        scenario "sign off your performance profile page" do
+          given_i_am_authenticated
+          and_provider_has_performance_profile_signed_off
+
+          when_i_visit_the_sign_off_your_performance_profile_page
+          then_i_am_redirected_to_the_reports_page
+        end
+
+        scenario "itt performance profile sign off for the academic year page" do
+          given_i_am_authenticated
+          and_provider_has_performance_profile_signed_off
+
+          when_i_visit_the_itt_performance_profile_sign_off_for_the_academic_year_page
+          then_i_am_redirected_to_the_reports_page
+        end
+      end
+    end
+
+    context "lead provider user" do
+      scenario "unauthorized message is shown" do
+        given_i_am_authenticated_as_a_lead_partner_user
+        when_i_visit_the_sign_off_your_performance_profile_page
+        then_i_see_the_unauthorized_message
+      end
+    end
+  end
+
+private
+
+  def previous_academic_cycle_label
+    AcademicCycle.previous.label
+  end
+
+  def and_the_provider_has_performance_profile_signed_off
+    expect(SignOff.exists?(academic_cycle: AcademicCycle.previous, sign_off_type: :performance_profile, user: current_user, provider: current_user.providers.first)).to be_truthy
+  end
+
+  def and_provider_has_performance_profile_signed_off
+    SignOff.new(academic_cycle: AcademicCycle.previous, sign_off_type: :performance_profile, user: current_user, provider: current_user.providers.first).save!
+  end
+
+  def and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
+    expect(page).to have_current_path("/reports/performance-profiles/new")
+  end
+
+  def and_i_can_see_the_performance_profile_information
+    expect(page).to have_css(".govuk-summary-card__title", text: "Performance profile information")
+
+    expect(page).to have_css(".govuk-summary-list__key", text: "Provider name")
+    expect(page).to have_css(".govuk-summary-list__value", text: current_user.providers.first.name)
+
+    expect(page).to have_css(".govuk-summary-list__key", text: "UKPRN")
+    expect(page).to have_css(".govuk-summary-list__value", text: current_user.providers.first.ukprn)
+
+    expect(page).to have_css(".govuk-summary-list__key", text: "Approver name")
+    expect(page).to have_css(".govuk-summary-list__value", text: current_user.name)
+  end
+
+  def and_i_am_on_the_root_page
+    visit "/"
+  end
+
+  def and_i_am_on_the_reports_page
+    visit "/reports"
+  end
+
+  def and_i_can_see_the_performance_profile_banner
+    expect(page).to have_css("#govuk-notification-banner-title", text: "Important")
+    expect(page).to have_css(".govuk-notification-banner__heading", text: "The #{previous_academic_cycle_label} ITT performance profile sign off is due")
+  end
+
+  def previous_academic_cycle_label
+    AcademicCycle.previous.label
+  end
+
+  def and_i_am_on_the_sign_off_your_performance_profile_page
+    expect(page).to have_current_path("/reports/performance-profiles")
+  end
+
+  def when_i_visit_the_itt_performance_profile_sign_off_for_the_academic_year_page
+    visit("/reports/performance-profiles/new")
+  end
+
+  def when_i_visit_the_sign_off_your_performance_profile_page
+    visit "/reports/performance-profiles"
+  end
+
+  def then_i_am_redirected_to_the_reports_page
+    expect(page).to have_current_path("/reports")
+  end
+
+  def then_i_see_the_unauthorized_message
+    expect(page).to have_content("You do not have permission to perform this action")
+  end
+
+  def and_i_see_there_is_a_problem
+    expect(page).to have_css(".govuk-error-summary__title", text: "There is a problem")
+  end
+
+  alias_method :and_i_check_on, :check
+  alias_method :and_i_click_on, :click_on
+  alias_method :when_i_click_on, :click_on
+end

--- a/spec/features/reports/performance_profile_spec.rb
+++ b/spec/features/reports/performance_profile_spec.rb
@@ -64,6 +64,24 @@ feature "performance profile sign off" do
         and_the_provider_has_performance_profile_signed_off
       end
 
+      scenario "a previously accredited provider signing off the performance profile from reports page" do
+        given_i_am_authenticated(user: create(:user, providers: [build(:provider, :unaccredited)]))
+        and_i_am_on_the_reports_page
+
+        and_i_click_on("Trainees who studied in the #{previous_academic_cycle_label} academic year report")
+        and_i_am_on_the_sign_off_your_performance_profile_page
+
+        when_i_click_on("Continue to performance profile sign off")
+        and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
+        and_i_can_see_the_performance_profile_information
+        and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
+        and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
+        and_i_click_on("Sign off performance profile")
+
+        then_i_am_redirected_to_the_reports_page
+        and_the_provider_has_performance_profile_signed_off
+      end
+
       context "performance profile signed off" do
         scenario "sign off your performance profile page" do
           given_i_am_authenticated

--- a/spec/forms/performance_profile_sign_off_form_spec.rb
+++ b/spec/forms/performance_profile_sign_off_form_spec.rb
@@ -17,7 +17,7 @@ describe PerformanceProfileSignOffForm, type: :model do
 
       it "returns the correct error message" do
         expect(form.valid?).to be false
-        expect(error_message).to include "Please confirm sign off"
+        expect(error_message).to include "Confirm sign off"
       end
     end
 
@@ -26,7 +26,7 @@ describe PerformanceProfileSignOffForm, type: :model do
 
       it "returns the correct error message" do
         expect(form.valid?).to be false
-        expect(error_message).to include "Please confirm sign off"
+        expect(error_message).to include "Confirm sign off"
       end
     end
 

--- a/spec/forms/performance_profile_sign_off_form_spec.rb
+++ b/spec/forms/performance_profile_sign_off_form_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PerformanceProfileSignOffForm, type: :model do
+  let(:sign_off) { "confirmed" }
+  let(:error_message) { form.errors.full_messages.first }
+  let(:provider) { create(:provider) }
+  let(:user_context) { UserWithOrganisationContext.new(user: user, session: {}) }
+  let(:user) { create(:user, providers: [provider]) }
+
+  subject(:form) { described_class.new(sign_off: sign_off, provider: provider, user: user_context) }
+
+  describe "#valid?" do
+    context "with a blank sign off" do
+      let(:sign_off) { nil }
+
+      it "returns the correct error message" do
+        expect(form.valid?).to be false
+        expect(error_message).to include "Please confirm sign off"
+      end
+    end
+
+    context "with a invalid sign off" do
+      let(:sign_off) { "invalid" }
+
+      it "returns the correct error message" do
+        expect(form.valid?).to be false
+        expect(error_message).to include "Please confirm sign off"
+      end
+    end
+
+    context "with a valid sign_off" do
+      it "returns valid" do
+        expect(form.valid?).to be true
+      end
+    end
+  end
+
+  describe "#save!" do
+    context "with a blank sign off" do
+      let(:sign_off) { nil }
+
+      it "returns the correct error message" do
+        expect(form.save!).to be false
+      end
+    end
+
+    context "with a invalid sign off" do
+      let(:sign_off) { "invalid" }
+
+      it "returns the correct error message" do
+        expect(form.save!).to be false
+      end
+    end
+
+    context "with a valid sign_off" do
+      before do
+        create(:academic_cycle, :previous)
+      end
+
+      context "provider performance profile awaiting sign off" do
+        it "saves a new performance profile sign off" do
+          expect { form.save! }.to change { provider.performance_profile_awaiting_sign_off? }.from(true).to(false)
+          .and change { provider.sign_offs.count }.from(0).to(1)
+        end
+
+        it "returns true" do
+          expect(form.save!).to be true
+        end
+      end
+
+      context "provider performance profile signed off" do
+        let(:previous_performance_profile_sign_off) { build(:sign_off, academic_cycle: AcademicCycle.previous) }
+        let(:provider) { create(:provider, sign_offs: [previous_performance_profile_sign_off]) }
+
+        it "updates the previous performance profile sign off" do
+          expect {
+            form.save!
+          }.to change { previous_performance_profile_sign_off.reload.user }.to(user)
+        end
+
+        it "does not create a new performance profile sign off" do
+          expect {
+            form.save!
+          }.to not_change { provider.sign_offs.count }.from(1)
+        end
+
+        it "returns true" do
+          expect(form.save!).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
ITT performance profile sign off for the 2023 to 2024 academic year page

### Changes proposed in this pull request
Add ITT performance profile sign off for the 2023 to 2024 academic year page

### Guidance to review

Once signed off the performance profile flow is locked down, (Annie Bell is locked down, try one of the other personas)

#### Form
![image](https://github.com/user-attachments/assets/6d246344-88b4-4fd9-b615-fda6acfa03f8)

#### Form with validation
![image](https://github.com/user-attachments/assets/77e1a4a5-6636-4d2f-b454-9cea42786fb0)

#### Reports tab before performance profile sign off
![image](https://github.com/user-attachments/assets/9a0e479c-2911-42fb-9699-8e4e629f195f)


#### Reports tab after performance profile sign off
![image](https://github.com/user-attachments/assets/adde8efe-5bb0-4875-8972-88e2407a9d38)

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
