### PR TITLE
[7917] - add page for future interest

### DIFF
--- a/app/controllers/trainees/withdrawal/extra_informations_controller.rb
+++ b/app/controllers/trainees/withdrawal/extra_informations_controller.rb
@@ -14,7 +14,7 @@ module Trainees
       end
 
       def next_page
-        edit_trainee_withdrawal_confirm_detail_path(trainee)
+        edit_trainee_withdrawal_future_interest_path(trainee)
       end
     end
   end

--- a/app/controllers/trainees/withdrawal/future_interests_controller.rb
+++ b/app/controllers/trainees/withdrawal/future_interests_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Withdrawal
+    class FutureInterestsController < Base
+    private
+
+      def form_class
+        ::Withdrawal::FutureInterestForm
+      end
+
+      def attribute_names
+        :future_interest
+      end
+
+      def next_page
+        edit_trainee_withdrawal_confirm_detail_path(trainee)
+      end
+    end
+  end
+end

--- a/app/forms/withdrawal/future_interest_form.rb
+++ b/app/forms/withdrawal/future_interest_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Withdrawal
+  class FutureInterestForm < TraineeForm
+    FIELDS = %i[future_interest].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :future_interest, presence: true, inclusion: { in: %w[yes no unknown] }
+
+  private
+
+    def form_store_key
+      :withdrawal_future_interest
+    end
+
+    def compute_fields
+      trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+
+    def new_attributes
+      fields_from_store.merge(params).symbolize_keys.slice(*FIELDS)
+    end
+  end
+end

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -17,6 +17,7 @@ class FormStore
     withdraw
     withdrawal_date
     withdrawal_trigger
+    withdrawal_future_interest
     placement_detail
     withdrawal_reasons
     withdrawal_extra_information

--- a/app/views/trainees/withdrawal/future_interests/edit.html.erb
+++ b/app/views/trainees/withdrawal/future_interests/edit.html.erb
@@ -1,0 +1,49 @@
+<% heading = t("trainees.withdrawals.future_interests.edit.heading") %>
+
+<%= render PageTitle::View.new(text: heading, has_errors: form.errors.present?) %>
+
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t("back"),
+    href: edit_trainee_withdrawal_reason_path(trainee),
+    ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: form, url: trainee_withdrawal_future_interest_path(trainee), local: true, method: :put) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">
+        <%= trainee_name(trainee) %>
+      </span>
+
+      <%= f.govuk_radio_buttons_fieldset(:future_interest, legend: { text: t("views.forms.withdrawal_future_interest.title"), hint: t("views.forms.withdrawal_future_interest.hint"), size: "m" }) do %>
+      <%= f.govuk_radio_button(
+        :future_interest,
+        :yes,
+        label: { text: t("views.forms.withdrawal_future_interest.yes.label") },
+        link_errors: true,
+      ) %>
+
+      <%= f.govuk_radio_button(
+        :future_interest,
+        :no,
+        label: { text: t("views.forms.withdrawal_future_interest.no.label") },
+      ) %>
+
+      <%= f.govuk_radio_button(
+        :future_interest,
+        :unknown,
+        label: { text: t("views.forms.withdrawal_future_interest.unknown.label") },
+      ) %>
+  <% end %>
+
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(trainee)) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -957,6 +957,15 @@ en:
           label: We had to withdraw the trainee
         trainee:
           label: The trainee chose to withdraw
+      withdrawal_future_interest:
+        title: Would this trainee be interested in becoming a teacher in the future?
+        hint: Choose an option
+        "yes":
+          label: "Yes"
+        "no":
+          label: "No"
+        unknown:
+          label: I don't know
       withdrawal_reasons:
         labels:
           additional_reason: Enter the reason for withdrawal
@@ -1314,6 +1323,9 @@ en:
       triggers:
         edit:
           heading: Why are you withdrawing the trainee?
+      future_interests:
+        edit:
+          heading: Would this trainee be interested in becoming a teacher in the future?
   activerecord:
     attributes:
       trainee:
@@ -1692,6 +1704,10 @@ en:
           attributes:
             trigger:
               blank: Choose a reason for withdrawal
+        withdrawal/future_interest_form:
+          attributes:
+            future_interest:
+              blank: Please select an option
         withdrawal/date_form:
           attributes:
             date_string:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,6 +172,7 @@ Rails.application.routes.draw do
         resource :date, only: %i[edit update]
         resource :reason, only: %i[edit update]
         resource :trigger, only: %i[edit update]
+        resource :future_interest, only: %i[edit update]
         resource :extra_information, only: %i[edit update], path: "extra-information"
         resource :confirm_detail, only: %i[edit update], path: "confirm"
       end

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -38,6 +38,12 @@ feature "Withdrawing a trainee" do
       then_i_see_the_error_message_for_trigger_not_chosen
     end
 
+    scenario "no future interest provided" do
+      when_i_am_on_the_future_interest_page
+      and_i_continue(:future_interest)
+      then_i_see_the_error_message_for_future_interest_not_chosen
+    end
+
     scenario "reason given with 'unknown' also selected" do
       when_i_am_on_the_reason_page
       when_i_check_a_reason(withdrawal_reason_unknown.name)
@@ -84,6 +90,8 @@ feature "Withdrawing a trainee" do
         when_i_add_detail(:withdraw_reasons_details, details)
         when_i_add_detail(:withdraw_reasons_dfe_details, details_dfe)
         and_i_continue(:extra_information)
+        when_i_choose_future_interest
+        and_i_continue(:future_interest)
         then_i_am_redirected_to_withdrawal_confirmation_page
         and_i_see_the_summary_card(start_date:, withdrawal_date:, details:, details_dfe:, reason:)
         and_i_continue(:confirm_detail)
@@ -105,6 +113,8 @@ feature "Withdrawing a trainee" do
         when_i_add_detail(:withdraw_reasons_details, details)
         when_i_add_detail(:withdraw_reasons_dfe_details, details_dfe)
         and_i_continue(:extra_information)
+        when_i_choose_future_interest
+        and_i_continue(:future_interest)
         then_i_am_redirected_to_withdrawal_confirmation_page
         and_i_see_the_summary_card(start_date:, withdrawal_date:, details:, details_dfe:, reason:)
         and_i_continue(:confirm_detail)
@@ -127,6 +137,8 @@ feature "Withdrawing a trainee" do
         when_i_add_detail(:withdraw_reasons_details, details)
         when_i_add_detail(:withdraw_reasons_dfe_details, details_dfe)
         and_i_continue(:extra_information)
+        when_i_choose_future_interest
+        and_i_continue(:future_interest)
         then_i_am_redirected_to_withdrawal_confirmation_page
         and_i_see_the_summary_card(start_date:, withdrawal_date:, details:, details_dfe:, reason:)
         and_i_continue(:confirm_detail)
@@ -144,6 +156,8 @@ feature "Withdrawing a trainee" do
       when_i_check_a_reason(withdrawal_reason.name)
       and_i_continue(:reason)
       and_i_continue(:extra_information)
+      when_i_choose_future_interest
+      and_i_continue(:future_interest)
       and_i_continue(:confirm_detail)
       and_a_withdrawal_job_has_been_queued
     end
@@ -176,7 +190,9 @@ feature "Withdrawing a trainee" do
     and_i_continue(:trigger)
     when_i_check_a_reason(withdrawal_reason.name)
     and_i_continue(:reason)
-    when_i_cancel_my_changes(:extra_information)
+    and_i_continue(:extra_information)
+    when_i_choose_future_interest
+    when_i_cancel_my_changes(:future_interest)
     then_i_am_redirected_to_the_record_page
     and_the_withdrawal_information_i_set_is_cleared
   end
@@ -192,6 +208,8 @@ feature "Withdrawing a trainee" do
     when_i_check_a_reason(withdrawal_reason.name)
     and_i_continue(:reason)
     and_i_continue(:extra_information)
+    when_i_choose_future_interest
+    and_i_continue(:future_interest)
     then_i_am_redirected_to_withdrawal_confirmation_page
     and_the_deferral_date_is_used
     and_i_continue(:confirm_detail)
@@ -216,6 +234,8 @@ feature "Withdrawing a trainee" do
     when_i_check_a_reason(withdrawal_reason.name)
     and_i_continue(:reason)
     and_i_continue(:extra_information)
+    when_i_choose_future_interest
+    and_i_continue(:future_interest)
     then_i_am_redirected_to_withdrawal_confirmation_page
     and_i_click_change_start_date
     and_i_choose_they_have_started
@@ -261,6 +281,10 @@ feature "Withdrawing a trainee" do
     withdrawal_reason_page.load(id: trainee.slug)
   end
 
+  def when_i_am_on_the_future_interest_page
+    withdrawal_future_interest_page.load(id: trainee.slug)
+  end
+
   def when_i_am_on_the_extra_information_page
     withdrawal_extra_information_page.load(id: trainee.slug)
   end
@@ -281,6 +305,10 @@ feature "Withdrawing a trainee" do
 
   def when_i_choose_trainee_chose_to_withdraw
     when_i_choose(:trigger, "The trainee chose to withdraw")
+  end
+
+  def when_i_choose_future_interest
+    when_i_choose(:future_interest, "Yes")
   end
 
   def and_i_enter_a_valid_date
@@ -370,6 +398,10 @@ feature "Withdrawing a trainee" do
 
   def then_i_see_the_error_message_for_trigger_not_chosen
     expect(withdrawal_trigger_page).to have_content("Choose a reason for withdrawal")
+  end
+
+  def then_i_see_the_error_message_for_future_interest_not_chosen
+    expect(withdrawal_future_interest_page).to have_content("Please select an option")
   end
 
   def then_i_see_the_error_message_for_unknown_exclusivity

--- a/spec/forms/withdrawal/future_interest_form_spec.rb
+++ b/spec/forms/withdrawal/future_interest_form_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Withdrawal
+  describe FutureInterestForm, type: :model do
+    let(:params) { { future_interest: "yes" } }
+    let(:trainee) { create(:trainee) }
+    let(:form_store) { class_double(FormStore) }
+
+    subject { described_class.new(trainee, params: params, store: form_store) }
+
+    before do
+      allow(form_store).to receive(:get).and_return(nil)
+    end
+
+    describe "validations" do
+      let(:inclusion_values) do
+        %w[yes no unknown]
+      end
+
+      it { is_expected.to validate_inclusion_of(:future_interest).in_array(inclusion_values) }
+    end
+
+    describe "#stash" do
+      it "uses FormStore to temporarily save the fields under a key combination of trainee withdrawal ID and future interest" do
+        expect(form_store).to receive(:set).with(trainee.id, :withdrawal_future_interest, subject.fields)
+
+        subject.stash
+      end
+    end
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -278,6 +278,10 @@ module Features
       @withdrawal_trigger_page ||= PageObjects::Trainees::Withdrawal::Trigger.new
     end
 
+    def withdrawal_future_interest_page
+      @withdrawal_future_interest_page ||= PageObjects::Trainees::Withdrawal::FutureInterest.new
+    end
+
     def withdrawal_extra_information_page
       @withdrawal_extra_information_page ||= PageObjects::Trainees::Withdrawal::ExtraInformation.new
     end

--- a/spec/support/page_objects/trainees/withdrawal/future_interest.rb
+++ b/spec/support/page_objects/trainees/withdrawal/future_interest.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    module Withdrawal
+      class FutureInterest < PageObjects::Base
+        include PageObjects::Helpers
+
+        set_url "/trainees/{id}/withdrawal/future_interest/edit"
+
+        element :continue, "button[type='submit']"
+        element :cancel, "a", text: "Cancel and return to record"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/uhWRag0n/7917-create-would-this-trainee-be-interested-in-becoming-a-teacher-in-the-future-page

### Changes proposed in this pull request

Add page to determine if withdrawing trainee would have any interest in reapplying in the future

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
