### PR TITLE
[7928] API duplicate checking for trainees includes soft deleted trainees

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -347,7 +347,8 @@ class Trainee < ApplicationRecord
   scope :without_trn, -> { where(trn: nil) }
 
   scope :potential_duplicates_of, lambda { |trainee|
-    trainee.provider.trainees.not_withdrawn.or(Trainee.not_awarded)
+    trainee.provider.trainees.kept
+      .and(Trainee.not_withdrawn.or(Trainee.not_awarded))
       .where(date_of_birth: trainee.date_of_birth)
       .where("last_name ILIKE ?", trainee.last_name)
       .where("id != ?", trainee.id)

--- a/app/services/find_duplicates_base.rb
+++ b/app/services/find_duplicates_base.rb
@@ -2,7 +2,8 @@
 
 module FindDuplicatesBase
   def potential_duplicates(provider)
-    provider.trainees.not_withdrawn.or(provider.trainees.not_awarded)
+    provider.trainees.kept
+      .and(Trainee.not_withdrawn.or(Trainee.not_awarded))
       .includes([:start_academic_cycle])
       .where(date_of_birth:)
       .where("last_name ILIKE ?", last_name)

--- a/app/services/trainees/find_duplicates_of_apply_application.rb
+++ b/app/services/trainees/find_duplicates_of_apply_application.rb
@@ -20,7 +20,8 @@ module Trainees
     attr_reader :application_record, :raw_trainee, :raw_course, :course
 
     def potential_duplicates
-      application_record.provider.trainees.not_withdrawn.or(Trainee.not_awarded)
+      application_record.provider.trainees.kept
+        .and(Trainee.not_withdrawn.or(Trainee.not_awarded))
         .where(date_of_birth: raw_trainee["date_of_birth"])
         .where("last_name ILIKE ?", raw_trainee["last_name"])
     end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -144,7 +144,8 @@ describe Trainee do
 
     describe ".potential_duplicates_of and .not_marked_as_duplicate" do
       let(:trainee1) { create(:trainee, :in_progress, :with_training_route) }
-      let!(:trainee2) { create(:trainee, :in_progress, last_name: trainee1.last_name, date_of_birth: trainee1.date_of_birth, training_route: trainee1.training_route, start_academic_cycle: trainee1.start_academic_cycle) }
+      let(:provider) { trainee1.provider }
+      let!(:trainee2) { create(:trainee, :in_progress, provider: provider, last_name: trainee1.last_name, date_of_birth: trainee1.date_of_birth, training_route: trainee1.training_route, start_academic_cycle: trainee1.start_academic_cycle) }
 
       it "returns trainees with the same last_name, date_of_birth, training_route and start_academic_cycle" do
         expect(described_class.potential_duplicates_of(trainee1).not_marked_as_duplicate).to contain_exactly(trainee2)

--- a/spec/requests/api/v1_0_pre/duplicate_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/duplicate_trainees_spec.rb
@@ -85,16 +85,13 @@ describe "Trainees API" do
       let!(:trainee) do
         create(
           :trainee,
+          :discarded,
           :male,
           :provider_led_undergrad,
           :in_progress,
           itt_start_date: academic_cycle.start_date,
           course_subject_one: CourseSubjects::BIOLOGY,
         )
-      end
-
-      before do
-        trainee.discard!
       end
 
       it "returns status code 201 and creates the trainee record" do

--- a/spec/services/trainees/find_duplicates_of_apply_application_spec.rb
+++ b/spec/services/trainees/find_duplicates_of_apply_application_spec.rb
@@ -34,6 +34,7 @@ module Trainees
 
     let(:trainee_attributes) do
       {
+        provider: application_record.provider,
         provider_trainee_id: nil,
         first_names: candidate_info["first_name"],
         last_name: candidate_info["last_name"],
@@ -195,7 +196,7 @@ module Trainees
 
     context "deleted trainee with matching attributes" do
       before do
-        create(:trainee, duplicate_trainee_attributes).discard
+        create(:trainee, :discarded, duplicate_trainee_attributes)
       end
 
       it "returns no duplicates" do

--- a/spec/services/trainees/find_duplicates_of_apply_application_spec.rb
+++ b/spec/services/trainees/find_duplicates_of_apply_application_spec.rb
@@ -192,5 +192,15 @@ module Trainees
         expect(duplicate_trainees).to be_present
       end
     end
+
+    context "deleted trainee with matching attributes" do
+      before do
+        create(:trainee, duplicate_trainee_attributes).discard
+      end
+
+      it "returns no duplicates" do
+        expect(duplicate_trainees).to be_empty
+      end
+    end
   end
 end

--- a/spec/services/trainees/find_duplicates_of_hesa_trainee_spec.rb
+++ b/spec/services/trainees/find_duplicates_of_hesa_trainee_spec.rb
@@ -7,9 +7,11 @@ module Trainees
     let!(:current_academic_cycle) { create(:academic_cycle) }
     let!(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
     let!(:after_next_academic_cycle) { create(:academic_cycle, one_after_next_cycle: true) }
+    let!(:provider) { create(:provider) }
 
     let(:trainee_attributes) do
       {
+        provider: provider,
         provider_trainee_id: "1234567",
         first_names: "Bob",
         last_name: "Roberts",


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/LMxf20Yd/7928-api-duplicate-checking-for-trainees-includes-soft-deleted-trainees)

It appears that our duplicate checking is not filtering out discarded trainees.
We shouldn't include discarded trainees in our duplicate checking.

### Changes proposed in this pull request

* Added `.kept` to duplicate scope and duplicate methods
* Added a couple of tests which check desired behaviour

### Guidance to review

* Any other duplicate checks that need to be updated?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
