### PR TITLE
[7925] Bulk CSV trainee upload - handle errors after submission

### DIFF
--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -46,7 +46,7 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
         self.submitted_at = Time.current
       end
 
-      transition %i[validated] => :in_progress
+      transition %i[validated failed] => :in_progress
     end
 
     event :succeed do
@@ -54,7 +54,7 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
     end
 
     event :cancel do
-      transition %i[validated] => :cancelled
+      transition %i[validated failed] => :cancelled
     end
 
     event :fail do

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -46,7 +46,7 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
         self.submitted_at = Time.current
       end
 
-      transition %i[validated failed] => :in_progress
+      transition %i[validated] => :in_progress
     end
 
     event :succeed do

--- a/app/policies/bulk_update/submissions/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/submissions/trainee_upload_policy.rb
@@ -4,11 +4,11 @@ module BulkUpdate
   module Submissions
     class TraineeUploadPolicy < BulkUpdate::TraineeUploadPolicy
       def show?
-        super && (trainee_upload.in_progress? || trainee_upload.succeeded?)
+        super && (trainee_upload.in_progress? || trainee_upload.succeeded? || trainee_upload.failed?)
       end
 
       def create?
-        super && trainee_upload.validated?
+        super && (trainee_upload.validated? || trainee_upload.failed?)
       end
     end
   end

--- a/app/policies/bulk_update/submissions/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/submissions/trainee_upload_policy.rb
@@ -8,7 +8,7 @@ module BulkUpdate
       end
 
       def create?
-        super && (trainee_upload.validated? || trainee_upload.failed?)
+        super && trainee_upload.validated?
       end
     end
   end

--- a/app/views/bulk_update/add_trainees/submissions/show.html.erb
+++ b/app/views/bulk_update/add_trainees/submissions/show.html.erb
@@ -29,34 +29,88 @@
       </p>
 
       <p class="govuk-body">
-        You can also check the <%= link_to "status of new trainee files" %>.
+        You can also check the <%= govuk_link_to "status of new trainee files", bulk_update_add_trainees_uploads_path %>.
       </p>
 
       <p class="govuk-body">
         <%= link_to "Back to bulk updates page", bulk_update_path %>
       </p>
     <% else %>
-      <%= govuk_panel(
-        title_text: "Trainees submitted",
-        classes: "govuk-!-margin-bottom-7"
-      ) %>
+        <%= govuk_panel(
+          title_text: "Trainees submitted",
+          classes: "govuk-!-margin-bottom-7"
+        ) %>
 
-      <p class="govuk-body govuk-body-lead">You can view your trainee records to check if they are correct.</p>
-      <p class="govuk-body">There are 3 ways to check trainee data in Register.</p>
-      <p class="govuk-body">Choose whichever one of the following that suits you:</p>
+        <% if @bulk_update_trainee_upload.succeeded? %>
+          <p class="govuk-body govuk-body-lead">You can view your trainee records to check if they are correct.</p>
+          <p class="govuk-body">There are 3 ways to check trainee data in Register.</p>
+          <p class="govuk-body">Choose whichever one of the following that suits you:</p>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <li><%= govuk_link_to("View your trainee records", trainees_path) %> to check your trainees directly in the service one by one</li>
-       <li><%= govuk_link_to("Use the ‘Reports’ section", reports_path) %> and export a CSV of your new trainees for the current academic year</li>
-        <li>Export a CSV of your trainees in the <%= govuk_link_to("'Registered trainees' section", trainees_path) %>, using the 'start year' filter to select the current academic year</li>
-      </ul>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><%= govuk_link_to("view your trainee records", trainees_path) %> to check your trainees directly in the service one by one</li>
+            <li><%= govuk_link_to("use the 'Reports' section", reports_path) %> and export a CSV of your new trainees for the current academic year</li>
+            <li>export a CSV of your trainees in the <%= govuk_link_to("'Registered trainees' section", trainees_path) %>, using the 'start year' filter to select the current academic year</li>
+          </ul>
 
-      <h2 class="govuk-heading-m">View trainees' teacher reference number (TRN)</h2>
+          <h2 class="govuk-heading-m">View trainees' teacher reference number (TRN)</h2>
 
-      <p class="govuk-body">Once a trainee is registered, a TRN is created for each trainee record.</p>
-      <p class="govuk-body">This is when the trainee becomes registered with the Department for Education (DfE).</p>
-      <p class="govuk-body">You can view trainee TRNs in the Register service. This may take several minutes to appear after the bulk upload.</p>
-      <p class="govuk-body">Trainees will receive their TRN by email.</p>
+          <p class="govuk-body">Once a trainee is registered, a TRN is created for each trainee record.</p>
+          <p class="govuk-body">This is when the trainee becomes registered with the Department for Education (DfE).</p>
+          <p class="govuk-body">You can view trainee TRNs in the Register service. This may take several minutes to appear after the bulk upload.</p>
+          <p class="govuk-body">Trainees will receive their TRN by email.</p>
+        <% else %>
+          <p class="govuk-body">
+            Your submitted <%= @bulk_update_trainee_upload.filename %>
+            on <%= @bulk_update_trainee_upload.submitted_at.to_fs(:govuk_date_and_time) %> has failed because:
+          </p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li>you have errors in the CSV file, or</li>
+            <li>we could not process the CSV file</li>
+          </ul>
+
+          <h2 class="govuk-heading-m">What you can do next</h2>
+
+          <p class="govuk-body">
+            Check for errors in the CSV file by viewing <%= govuk_link_to "status of new trainee files", bulk_update_add_trainees_uploads_path %>.
+          </p>
+
+          <p class="govuk-body">
+            Errors are indicated in the CSV row. If you find errors then you can:
+          </p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li>fix the errors in your data</li>
+            <li>if you cannot fix the error, you can delete the row and the trainee will not be included</li>
+          </ul>
+
+          <p class="govuk-body">
+            Upload the updated CSV file.
+          </p>
+
+          <p class="govuk-body">
+            If there are no errors in the CSV file, it means we could not process the CSV file.
+          </p>
+
+          <p class="govuk-body">
+            You can:
+          </p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li>wait for an email from the Becoming a Teacher support team asking you to re-submit your CSV file, if we’re not able to fix the issue, or</li>
+            <li><%= govuk_link_to "re-submit the CSV file", bulk_update_add_trainees_upload_path(@bulk_update_trainee_upload) %> now</li>
+          </ul>
+
+          <p class="govuk-body">
+            You can check your trainee data once it has been submitted into Register. At any time you can:
+          </p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li><%= govuk_link_to("view your trainee records", trainees_path) %> to check your trainees directly in the service one by one</li>
+            <li><%= govuk_link_to("use the 'Reports' section", reports_path) %> and export a CSV of your new trainees for the current academic year</li>
+            <li>export a CSV of your trainees in the <%= govuk_link_to("'Registered trainees' section", trainees_path) %>, using the 'start year' filter to select the current academic year</li>
+          </ul>
+        <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/bulk_update/add_trainees/submissions/show.html.erb
+++ b/app/views/bulk_update/add_trainees/submissions/show.html.erb
@@ -97,8 +97,10 @@
           </p>
 
           <ul class="govuk-list govuk-list--bullet">
-            <li>wait for an email from the Becoming a Teacher support team asking you to re-submit your CSV file, if we’re not able to fix the issue, or</li>
-            <li><%= govuk_link_to "re-submit the CSV file", bulk_update_add_trainees_upload_path(@bulk_update_trainee_upload) %> now</li>
+            <li>
+              wait for an email from the Becoming a Teacher support team asking you to
+              <%= govuk_link_to "re-submit the CSV file", bulk_update_add_trainees_upload_path(@bulk_update_trainee_upload) %>
+            </li>
           </ul>
 
           <p class="govuk-body">

--- a/app/views/bulk_update/add_trainees/submissions/show.html.erb
+++ b/app/views/bulk_update/add_trainees/submissions/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(text: "Upload summary") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <% if request.referrer.present? && request.referrer.match?(bulk_update_add_trainees_uploads_path) %>
+  <% if request.referrer.present? && request.referrer.match?(/#{bulk_update_add_trainees_uploads_path}$/) %>
     <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: bulk_update_add_trainees_uploads_path) %>
   <% else %>
     <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>

--- a/app/views/bulk_update/add_trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/add_trainees/uploads/show.html.erb
@@ -77,7 +77,7 @@
       <% else %>
         <%= register_form_with(
           model: @bulk_update_trainee_upload,
-          url: bulk_update_add_trainees_submissions_path(@bulk_update_trainee_upload),
+          url: bulk_update_add_trainees_submission_path(@bulk_update_trainee_upload),
           method: :post
         ) do |f| %>
           <%= f.govuk_submit("Submit") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
     namespace :add_trainees, path: "add-trainees" do
       resources :uploads, only: %i[index show new create destroy] do
         member do
-          resources :submissions, only: %i[show create]
+          resource :submission, only: %i[show create]
           resource :details, only: :show
         end
       end

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -97,6 +97,12 @@ FactoryBot.define do
       end
     end
 
+    trait :failed_without_errors do
+      status { "failed" }
+      submitted_by { association(:user) }
+      submitted_at { Time.current }
+    end
+
     trait :failed_with_validation_errors do
       status { "failed" }
 

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -746,9 +746,8 @@ private
       expect(page).not_to have_content("Upload the updated CSV file.")
       expect(page).not_to have_content("If there are no errors in the CSV file, it means we could not process the CSV file.")
       expect(page).not_to have_content("You can:")
-      expect(page).not_to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit your CSV file, if we’re not able to fix the issue, or")
+      expect(page).not_to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit the CSV file")
       expect(page).not_to have_link("re-submit the CSV file", href: bulk_update_add_trainees_upload_path(upload))
-      expect(page).not_to have_content("now")
       expect(page).not_to have_content("You can check your trainee data once it has been submitted into Register. At any time you can:")
     else
       within(".govuk-panel") do
@@ -780,9 +779,8 @@ private
         expect(page).not_to have_content("Upload the updated CSV file.")
         expect(page).not_to have_content("If there are no errors in the CSV file, it means we could not process the CSV file.")
         expect(page).not_to have_content("You can:")
-        expect(page).not_to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit your CSV file, if we’re not able to fix the issue, or")
+        expect(page).not_to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit the CSV file")
         expect(page).not_to have_link("re-submit the CSV file", href: bulk_update_add_trainees_upload_path(upload))
-        expect(page).not_to have_content("now")
         expect(page).not_to have_content("You can check your trainee data once it has been submitted into Register. At any time you can:")
       else
         expect(page).to have_content("Your submitted #{upload.filename} on #{upload.submitted_at.to_fs(:govuk_date_and_time)} has failed because:")
@@ -797,9 +795,8 @@ private
         expect(page).to have_content("Upload the updated CSV file.")
         expect(page).to have_content("If there are no errors in the CSV file, it means we could not process the CSV file.")
         expect(page).to have_content("You can:")
-        expect(page).to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit your CSV file, if we’re not able to fix the issue, or")
+        expect(page).to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit the CSV file")
         expect(page).to have_link("re-submit the CSV file", href: bulk_update_add_trainees_upload_path(upload))
-        expect(page).to have_content("now")
         expect(page).to have_content("You can check your trainee data once it has been submitted into Register. At any time you can:")
         expect(page).to have_content("view your trainee records to check your trainees directly in the service one by on")
         expect(page).to have_content("use the 'Reports' section and export a CSV of your new trainees for the current academic year")

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -189,6 +189,10 @@ feature "bulk add trainees" do
 
         and_i_see_the_summary_page
         and_i_dont_see_the_review_errors_message
+
+        when_i_click_on_home_link
+        then_i_see_the_root_page
+
         and_i_visit_the_trainees_page
         then_i_can_see_the_new_trainees
 
@@ -517,8 +521,8 @@ private
     )
   end
 
-  def when_i_try_resubmit_the_same_upload
-    visit bulk_update_add_trainees_upload_path(BulkUpdate::TraineeUpload.last)
+  def when_i_try_resubmit_the_same_upload(upload: BulkUpdate::TraineeUpload.last)
+    visit bulk_update_add_trainees_upload_path(upload)
   end
 
   def then_i_see_the_unauthorized_message
@@ -961,8 +965,8 @@ private
     )
   end
 
-  def and_i_visit_the_bulk_update_trainee_upload_page(upload: BulkUpdate::TraineeUpload.last)
-    visit bulk_update_add_trainees_upload_path(upload)
+  def when_i_click_on_home_link
+    find(".govuk-back-link", text: "Home").click
   end
 
   alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file
@@ -978,4 +982,5 @@ private
   alias_method :and_a_job_is_queued_to_process_the_upload, :then_a_job_is_queued_to_process_the_upload
   alias_method :and_the_background_job_is_run, :when_the_background_job_is_run
   alias_method :and_i_return_to_the_review_errors_page, :when_i_return_to_the_review_errors_page
+  alias_method :and_i_visit_the_bulk_update_trainee_upload_page, :when_i_try_resubmit_the_same_upload
 end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -215,6 +215,13 @@ feature "bulk add trainees" do
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
+      scenario "attempt to resubmit a failed upload" do
+        when_a_failed_upload_without_row_errors_exist
+        and_i_visit_the_bulk_update_trainee_upload_page
+        and_i_click_the_submit_button
+        then_i_see_the_unauthorized_message
+      end
+
       scenario "view the upload summary page with errors" do
         when_the_upload_has_failed_with_validation_errors
         and_i_dont_see_that_the_upload_is_processing
@@ -940,6 +947,19 @@ private
 
   def when_i_click_on_resubmit_the_file_link
     click_on "re-submit the CSV file"
+  end
+
+  def when_a_failed_upload_without_row_errors_exist
+    create(
+      :bulk_update_trainee_upload,
+      :failed_without_errors,
+      provider: current_user.organisation,
+      submitted_by: current_user,
+    )
+  end
+
+  def and_i_visit_the_bulk_update_trainee_upload_page(upload: BulkUpdate::TraineeUpload.last)
+    visit bulk_update_add_trainees_upload_path(upload)
   end
 
   alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "bulk add trainees" do
   include ActiveJob::TestHelper
+  include ActionView::Helpers::TextHelper
 
   before do
     and_there_is_a_current_academic_cycle
@@ -144,12 +145,48 @@ feature "bulk add trainees" do
         and_i_refresh_the_page
         then_i_see_the_review_page_without_validation_errors
 
-        when_i_click_the_submit_button
+        when_an_unexpected_duplicate_error_is_setup
+        and_i_click_the_submit_button
+        and_a_job_is_queued_to_process_the_upload
+        and_the_send_csv_processing_email_has_been_sent
+        and_the_background_job_is_run
+        and_i_refresh_the_summary_page
+        and_i_see_the_summary_page
+
+        when_i_click_on_resubmit_the_file_link
+        and_i_see_the_number_of_trainees_that_can_be_added(number: 4)
+        and_i_dont_see_any_validation_errors
+        and_i_see_the_duplicate_errors(number: 1)
+        and_i_see_the_review_errors_message
+        and_i_see_the_review_errors_link
+        and_i_dont_see_the_submit_button
+
+        when_i_click_the_review_errors_link
+        then_i_see_the_review_errors_page_with_one_error
+
+        when_the_unexpected_duplicate_error_is_been_reverted
+        and_i_return_to_the_review_errors_page
+        and_i_attach_a_valid_file
+        and_i_click_the_upload_button
+        then_i_see_that_the_upload_is_processing
+        then_a_job_is_queued_to_process_the_upload
+
+        when_the_background_job_is_run
+        and_i_refresh_the_page
+        and_i_see_the_review_page_without_validation_errors
+        and_i_dont_see_the_review_errors_link
+        and_i_dont_see_the_back_to_bulk_updates_link
+
+        Timecop.travel 1.hour.from_now do
+          and_i_click_the_submit_button
+        end
+
         then_a_job_is_queued_to_process_the_upload
         and_the_send_csv_processing_email_has_been_sent
 
         when_the_background_job_is_run
         and_i_refresh_the_summary_page
+
         and_i_see_the_summary_page
         and_i_dont_see_the_review_errors_message
         and_i_visit_the_trainees_page
@@ -598,7 +635,7 @@ private
   def then_i_see_that_there_is_one_duplicate_error
     expect(page).to have_content("You uploaded a CSV file")
     expect(page).to have_content("It included:")
-    expect(page).to have_content("1 trainee who will not be added, as they already exist in Register")
+    and_i_see_the_duplicate_errors(number: 1)
   end
 
   def and_i_see_the_number_of_trainees_that_can_be_added(number:)
@@ -614,7 +651,7 @@ private
   end
 
   def and_i_see_the_duplicate_errors(number:)
-    expect(page).to have_content("#{number} trainees who will not be added, as they already exist in Register")
+    expect(page).to have_content("#{pluralize(number, 'trainee')} who will not be added, as they already exist in Register")
   end
 
   def and_i_see_the_review_errors_message
@@ -661,14 +698,99 @@ private
     )
 
     if upload.in_progress?
+      expect(page).to have_content("Your file is being processed")
       expect(page).to have_content(
         "We're currently processing #{upload.filename}",
       )
+      expect(page).to have_content("This could take several minutes if there are a large number of trainees.")
+      expect(page).to have_content("You'll receive and email to tell you when this is complete.")
+      expect(page).to have_content("You can also check the")
+      expect(page).to have_link("status of new trainee files", href: bulk_update_add_trainees_uploads_path)
+      expect(page).to have_link("Back to bulk updates page", href: bulk_update_path)
+
+      expect(page).not_to have_content("Trainees submitted")
+      expect(page).not_to have_content("You can view your trainee records to check if they are correct.")
+      expect(page).not_to have_content("There are 3 ways to check trainee data in Register.")
+      expect(page).not_to have_content("Choose whichever one of the following that suits you:")
+      expect(page).not_to have_content("view your trainee records to check your trainees directly in the service one by on")
+      expect(page).not_to have_content("use the 'Reports' section and export a CSV of your new trainees for the current academic year")
+      expect(page).not_to have_content("export a CSV of your trainees in the 'Registered trainees' section, using the 'start year' filter to select the current academic year")
+      expect(page).not_to have_content("View trainees' teacher reference number (TRN)")
+      expect(page).not_to have_content("Once a trainee is registered, a TRN is created for each trainee record.")
+      expect(page).not_to have_content("This is when the trainee becomes registered with the Department for Education (DfE).")
+      expect(page).not_to have_content("You can view trainee TRNs in the Register service. This may take several minutes to appear after the bulk upload.")
+      expect(page).not_to have_content("Trainees will receive their TRN by email.")
+
+      expect(page).not_to have_content("Your submitted #{upload.filename} on #{upload.submitted_at.to_fs(:govuk_date_and_time)} has failed because:")
+      expect(page).not_to have_content("you have errors in the CSV file, or")
+      expect(page).not_to have_content("we could not process the CSV file")
+      expect(page).not_to have_content("What you can do next")
+      expect(page).not_to have_content("Check for errors in the CSV file by viewing")
+      expect(page).not_to have_content("Errors are indicated in the CSV row. If you find errors then you can:")
+      expect(page).not_to have_content("fix the errors in your data")
+      expect(page).not_to have_content("if you cannot fix the error, you can delete the row and the trainee will not be included")
+      expect(page).not_to have_content("Upload the updated CSV file.")
+      expect(page).not_to have_content("If there are no errors in the CSV file, it means we could not process the CSV file.")
+      expect(page).not_to have_content("You can:")
+      expect(page).not_to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit your CSV file, if we’re not able to fix the issue, or")
+      expect(page).not_to have_link("re-submit the CSV file", href: bulk_update_add_trainees_upload_path(upload))
+      expect(page).not_to have_content("now")
+      expect(page).not_to have_content("You can check your trainee data once it has been submitted into Register. At any time you can:")
     else
       within(".govuk-panel") do
         expect(page).to have_content("Trainees submitted")
       end
-      expect(page).to have_content("There are 3 ways to check trainee data in Register.")
+
+      if upload.succeeded?
+        expect(page).to have_content("You can view your trainee records to check if they are correct.")
+        expect(page).to have_content("There are 3 ways to check trainee data in Register.")
+        expect(page).to have_content("Choose whichever one of the following that suits you:")
+        expect(page).to have_content("view your trainee records to check your trainees directly in the service one by on")
+        expect(page).to have_content("use the 'Reports' section and export a CSV of your new trainees for the current academic year")
+        expect(page).to have_content("export a CSV of your trainees in the 'Registered trainees' section, using the 'start year' filter to select the current academic year")
+        expect(page).to have_content("View trainees' teacher reference number (TRN)")
+        expect(page).to have_content("Once a trainee is registered, a TRN is created for each trainee record.")
+        expect(page).to have_content("This is when the trainee becomes registered with the Department for Education (DfE).")
+        expect(page).to have_content("You can view trainee TRNs in the Register service. This may take several minutes to appear after the bulk upload.")
+        expect(page).to have_content("Trainees will receive their TRN by email.")
+
+        expect(page).not_to have_content("Your submitted #{upload.filename} on #{upload.submitted_at.to_fs(:govuk_date_and_time)} has failed because:")
+        expect(page).not_to have_content("you have errors in the CSV file, or")
+        expect(page).not_to have_content("we could not process the CSV file")
+        expect(page).not_to have_content("What you can do next")
+        expect(page).not_to have_content("Check for errors in the CSV file by viewing")
+        expect(page).not_to have_link("status of new trainee files", href: bulk_update_add_trainees_uploads_path)
+        expect(page).not_to have_content("Errors are indicated in the CSV row. If you find errors then you can:")
+        expect(page).not_to have_content("fix the errors in your data")
+        expect(page).not_to have_content("if you cannot fix the error, you can delete the row and the trainee will not be included")
+        expect(page).not_to have_content("Upload the updated CSV file.")
+        expect(page).not_to have_content("If there are no errors in the CSV file, it means we could not process the CSV file.")
+        expect(page).not_to have_content("You can:")
+        expect(page).not_to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit your CSV file, if we’re not able to fix the issue, or")
+        expect(page).not_to have_link("re-submit the CSV file", href: bulk_update_add_trainees_upload_path(upload))
+        expect(page).not_to have_content("now")
+        expect(page).not_to have_content("You can check your trainee data once it has been submitted into Register. At any time you can:")
+      else
+        expect(page).to have_content("Your submitted #{upload.filename} on #{upload.submitted_at.to_fs(:govuk_date_and_time)} has failed because:")
+        expect(page).to have_content("you have errors in the CSV file, or")
+        expect(page).to have_content("we could not process the CSV file")
+        expect(page).to have_content("What you can do next")
+        expect(page).to have_content("Check for errors in the CSV file by viewing")
+        expect(page).to have_link("status of new trainee files", href: bulk_update_add_trainees_uploads_path)
+        expect(page).to have_content("Errors are indicated in the CSV row. If you find errors then you can:")
+        expect(page).to have_content("fix the errors in your data")
+        expect(page).to have_content("if you cannot fix the error, you can delete the row and the trainee will not be included")
+        expect(page).to have_content("Upload the updated CSV file.")
+        expect(page).to have_content("If there are no errors in the CSV file, it means we could not process the CSV file.")
+        expect(page).to have_content("You can:")
+        expect(page).to have_content("wait for an email from the Becoming a Teacher support team asking you to re-submit your CSV file, if we’re not able to fix the issue, or")
+        expect(page).to have_link("re-submit the CSV file", href: bulk_update_add_trainees_upload_path(upload))
+        expect(page).to have_content("now")
+        expect(page).to have_content("You can check your trainee data once it has been submitted into Register. At any time you can:")
+        expect(page).to have_content("view your trainee records to check your trainees directly in the service one by on")
+        expect(page).to have_content("use the 'Reports' section and export a CSV of your new trainees for the current academic year")
+        expect(page).to have_content("export a CSV of your trainees in the 'Registered trainees' section, using the 'start year' filter to select the current academic year")
+      end
     end
   end
 
@@ -754,7 +876,7 @@ private
 
   def then_i_see_the_review_errors_page(upload: BulkUpdate::TraineeUpload.last)
     expect(page).to have_current_path(bulk_update_add_trainees_review_error_path(upload))
-    expect(page).to have_content("Review errors for #{upload.total_rows_with_errors} trainees in the CSV that you uploaded")
+    expect(page).to have_content("Review errors for #{pluralize(upload.total_rows_with_errors, 'trainee')} in the CSV that you uploaded")
   end
 
   def then_i_see_the_review_errors_page_with_one_error
@@ -776,11 +898,11 @@ private
   end
 
   def then_i_see_the_bulk_update_index_page
-    expect(page).to have_current_path(bulk_update_path, ignore_query: true)
+    expect(page).to have_current_path(bulk_update_path)
   end
 
   def then_i_see_the_bulk_add_trainees_uploads_index_page
-    expect(page).to have_current_path(bulk_update_add_trainees_uploads_path, ignore_query: true)
+    expect(page).to have_current_path(bulk_update_add_trainees_uploads_path)
   end
 
   def then_i_cannot_see_the_bulk_view_status_link
@@ -799,6 +921,27 @@ private
     visit bulk_update_add_trainees_review_error_path(upload)
   end
 
+  def when_an_unexpected_duplicate_error_is_setup
+    file = Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees.csv")
+    row  = CSV.read(file, headers: true)[-1]
+
+    BulkUpdate::AddTrainees::ImportRow.call(
+      row: row,
+      current_provider: BulkUpdate::TraineeUpload.last.provider,
+    )
+  end
+
+  def when_the_unexpected_duplicate_error_is_been_reverted
+    Trainee.last.tap do |trainee|
+      trainee.hesa_trainee_detail.destroy!
+      trainee.destroy!
+    end
+  end
+
+  def when_i_click_on_resubmit_the_file_link
+    click_on "re-submit the CSV file"
+  end
+
   alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file
   alias_method :and_i_click_the_submit_button, :when_i_click_the_submit_button
   alias_method :when_i_click_the_upload_button, :and_i_click_the_upload_button
@@ -809,4 +952,7 @@ private
   alias_method :when_i_visit_the_bulk_update_index_page, :and_i_visit_the_bulk_update_index_page
   alias_method :and_i_click_on_an_upload, :when_i_click_on_an_upload
   alias_method :then_i_see_the_summary_page, :and_i_see_the_summary_page
+  alias_method :and_a_job_is_queued_to_process_the_upload, :then_a_job_is_queued_to_process_the_upload
+  alias_method :and_the_background_job_is_run, :when_the_background_job_is_run
+  alias_method :and_i_return_to_the_review_errors_page, :when_i_return_to_the_review_errors_page
 end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -233,6 +233,9 @@ feature "bulk add trainees" do
         and_i_see_the_review_errors_message
         and_i_see_the_review_errors_link
         and_i_dont_see_the_submit_button
+
+        when_i_click_the_cancel_bulk_updates_link
+        then_the_upload_is_cancelled
       end
 
       scenario "view the upload summary page with duplicate errors" do

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -76,14 +76,29 @@ RSpec.describe BulkUpdate::TraineeUpload do
     end
 
     describe "#cancel!" do
-      before do
-        subject.process!
+      context "when the status is 'validated'" do
+        before do
+          subject.process!
+        end
+
+        it do
+          expect {
+            subject.cancel!
+          }.to change(subject, :status).from("validated").to("cancelled")
+        end
       end
 
-      it do
-        expect {
-          subject.cancel!
-        }.to change(subject, :status).from("validated").to("cancelled")
+      context "when the status is 'failed'" do
+        before do
+          subject.process!
+          subject.fail!
+        end
+
+        it do
+          expect {
+            subject.cancel!
+          }.to change(subject, :status).from("failed").to("cancelled")
+        end
       end
     end
 

--- a/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
@@ -12,19 +12,13 @@ RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
   context "when the User's organisation is an HEI Provider" do
     let(:user) { UserWithOrganisationContext.new(user: create(:user, :hei), session: {}) }
 
-    %i[validated failed].each do |status|
+    %i[validated].each do |status|
       context "when the upload is #{status}" do
         let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 
         permissions :create? do
           it { is_expected.to permit(user, trainee_upload) }
         end
-      end
-    end
-
-    %i[validated].each do |status|
-      context "when the upload is #{status}" do
-        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 
         permissions :show? do
           it { is_expected.not_to permit(user, trainee_upload) }
@@ -32,7 +26,7 @@ RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
       end
     end
 
-    %i[in_progress succeeded].each do |status|
+    %i[in_progress succeeded failed].each do |status|
       context "when the upload is #{status}" do
         let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 

--- a/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/submissions/trainee_upload_policy_spec.rb
@@ -12,13 +12,19 @@ RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
   context "when the User's organisation is an HEI Provider" do
     let(:user) { UserWithOrganisationContext.new(user: create(:user, :hei), session: {}) }
 
-    %i[validated].each do |status|
+    %i[validated failed].each do |status|
       context "when the upload is #{status}" do
         let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 
         permissions :create? do
           it { is_expected.to permit(user, trainee_upload) }
         end
+      end
+    end
+
+    %i[validated].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 
         permissions :show? do
           it { is_expected.not_to permit(user, trainee_upload) }
@@ -40,7 +46,7 @@ RSpec.describe BulkUpdate::Submissions::TraineeUploadPolicy, type: :policy do
       end
     end
 
-    %i[pending failed cancelled].each do |status|
+    %i[pending cancelled].each do |status|
       context "when the upload is #{status}" do
         let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
 


### PR DESCRIPTION
### Context

[7925-bulk-csv-trainee-upload-handle-errors-after-submission
](https://trello.com/c/4x9Z8ELb/7925-bulk-csv-trainee-upload-handle-errors-after-submission)

Handle failed trainee creation uploads upon submission

### Changes proposed in this pull request

* Allow a failed upload to be cancelled
* Change paths to submissions to be in singular form
* Add links to status of trainee files
* Refactor `submissions/show` page

<img width="494" alt="Screenshot 2024-12-20 at 14 04 31" src="https://github.com/user-attachments/assets/7b3f0634-d733-47a3-94da-58c75f625db5" />


### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
