### PR TITLE
Match Bullet inclusion to bullet gem environments

### DIFF
--- a/app/lib/user_with_organisation_context.rb
+++ b/app/lib/user_with_organisation_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserWithOrganisationContext < SimpleDelegator
-  include Bullet::SimpleDelegatorHelpers unless Rails.env.production?
+  include Bullet::SimpleDelegatorHelpers if Rails.env.local?
 
   attr_reader :user
 


### PR DESCRIPTION
### Context

Deploys to `staging` and `review` envs are failing.

### Changes proposed in this pull request

* Bullet gem is only included in `:development, :test` envs so we should match those when loading `Bullet::SimpleDelegatorHelpers`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
