### PR TITLE
[7936] Performance profiles sign off in register guidance update

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -41,11 +41,9 @@ class GuidanceController < ApplicationController
   def performance_profiles
     case sign_off_period
     when :performance_period
-      @current_academic_cycle_label = current_academic_cycle.label
       @previous_academic_cycle_label = previous_academic_cycle.label
       @academic_cycle_for_filter = previous_academic_cycle.start_year
       @sign_off_deadline = performance_profile_sign_off_date.strftime("%d %B %Y")
-      @sign_off_url = Settings.sign_off_performance_profiles_url
       @fix_mistakes_email_link = "mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in #{@previous_academic_cycle_label} data for performance profiles publication"
       render(layout: "application")
     when :census_period, :outside_period
@@ -61,10 +59,6 @@ private
 
   def performance_profile_sign_off_date
     @performance_profile_sign_off_date ||= previous_academic_cycle.performance_profile_date_range.end
-  end
-
-  def current_academic_cycle
-    @current_academic_cycle ||= AcademicCycle.current
   end
 
   def valid_tabs

--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -44,6 +44,7 @@ class GuidanceController < ApplicationController
       @previous_academic_cycle_label = previous_academic_cycle.label
       @academic_cycle_for_filter = previous_academic_cycle.start_year
       @sign_off_deadline = performance_profile_sign_off_date.to_fs(:govuk)
+      @sign_off_period_start = previous_academic_cycle.performance_profile_date_range.begin.to_fs(:govuk)
       @fix_mistakes_email_link = "mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in #{@previous_academic_cycle_label} data for performance profiles publication"
       render(layout: "application")
     when :census_period, :outside_period

--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -46,6 +46,7 @@ class GuidanceController < ApplicationController
       @academic_cycle_for_filter = previous_academic_cycle.start_year
       @sign_off_deadline = performance_profile_sign_off_date.strftime("%d %B %Y")
       @sign_off_url = Settings.sign_off_performance_profiles_url
+      @fix_mistakes_email_link = "mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in #{@previous_academic_cycle_label} data for performance profiles publication"
       render(layout: "application")
     when :census_period, :outside_period
       render(:performance_profiles_outside, layout: "application")

--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -28,7 +28,7 @@ class GuidanceController < ApplicationController
   end
 
   def dates_and_deadlines
-    @performance_profile_sign_off_full_deadline = performance_profile_sign_off_date.strftime("%d %B %Y")
+    @performance_profile_sign_off_full_deadline = performance_profile_sign_off_date.to_fs(:govuk)
     render(layout: "application")
   end
 
@@ -43,7 +43,7 @@ class GuidanceController < ApplicationController
     when :performance_period
       @previous_academic_cycle_label = previous_academic_cycle.label
       @academic_cycle_for_filter = previous_academic_cycle.start_year
-      @sign_off_deadline = performance_profile_sign_off_date.strftime("%d %B %Y")
+      @sign_off_deadline = performance_profile_sign_off_date.to_fs(:govuk)
       @fix_mistakes_email_link = "mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in #{@previous_academic_cycle_label} data for performance profiles publication"
       render(layout: "application")
     when :census_period, :outside_period

--- a/app/views/guidance/performance_profiles.html.erb
+++ b/app/views/guidance/performance_profiles.html.erb
@@ -10,17 +10,28 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">
-      Sign off your list of trainees from <%= @previous_academic_cycle_label %> for the performance profiles publication
+      Signing off trainees for the performance profiles publication
     </h1>
+
     <p class="govuk-body">
-      You need to sign off your list of trainee teachers from the
-      <%= @previous_academic_cycle_label %> academic year by
-      <%= @sign_off_deadline %> at 11:59pm.
+      Each year, you need to sign off your teacher trainee data from the previous
+      academic year in Register teacher trainees (Register).
     </p>
     <p class="govuk-body">
-      This is so that the data can be included in the annual initial teacher
-      training performance profiles publication. This will be published on
-      GOV.UK.
+      You’ll be asked to sign off performance profile data for registered trainees
+      with a course outcome in the 2023 to 2024 academic year, if you were an
+      accredited provider at this time.
+    </p>
+    <p class="govuk-body">
+      Registered trainees with a course outcome are trainees awarded qualified
+      teacher status (QTS) or who have withdrawn.
+    </p>
+    <p class="govuk-body">
+      This performance profile sign off period’s deadline is <%= @sign_off_deadline %>.
+    </p>
+    <p class="govuk-body">
+      You can sign off your trainee data from the
+      <%= @previous_academic_cycle_label %> academic year from <%= @sign_off_deadline %>.
     </p>
 
     <h2 class="govuk-heading-m">Find your trainee data</h2>
@@ -31,12 +42,11 @@
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        downloading a
-        <a href=<%= reports_performance_profiles_path %> class="govuk-link">report with the data you need to check</a>
+        downloading a <%= govuk_link_to("report with the data you need to check", reports_performance_profiles_path) %>
       </li>
       <li>
-        exporting a
-        <a href=<%= trainees_path(academic_year: [@academic_cycle_for_filter]) %> class="govuk-link">list of registered trainees filtered to show the <%= @previous_academic_cycle_label %> academic year</a>
+        exporting a <%= govuk_link_to("list of registered trainees filtered to show the
+           #{@previous_academic_cycle_label} academic year", trainees_path(academic_year: [@academic_cycle_for_filter])) %>
       </li>
     </ul>
 
@@ -48,31 +58,79 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>course details</li>
       <li>status</li>
-      <li>the date they were awarded qualified teacher status (QTS) or early years teacher status (EYTS), or deferred or withdrew from the course - unless they're still studying</li>
-      <li>a minimum of 2 placements for trainees that were QTS or EYTS awarded in the <%= @previous_academic_cycle_label %> academic year</li>
+      <li>the date they were awarded qualified teacher status (QTS) or early years
+        teacher status (EYTS), or deferred or withdrew from the course - unless
+        they're still studying</li>
+      <li>2 placements for trainees that were QTS awarded</li>
     </ul>
+    <p class="govuk-body">
+      If you’re an accredited provider who offered International qualified teacher
+      status (iQTS) in the 2023 to 2024 academic year, you need to include at least
+      one placement school in your iQTS trainee records.
+    </p>
+    <p class="govuk-body">
+      Find out more information about how to <%= govuk_link_to("manage your placement data in Register", manage_placements_guidance_path) %>.
+    </p>
 
     <h2 class="govuk-heading-m">Fix mistakes in your trainee data</h2>
-    <p class="govuk-body">You need to fix any mistakes before you sign off the data. How you do this depends on the type of organisation you work for.</p>
-
     <p class="govuk-body">
-      If the trainee is shown in this service as awarded or withdrawn, you should email
-      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>.
+      You need to fix any mistakes before you sign off the data.
+      How you do this depends on the type of organisation you work for.
     </p>
-    <p class="govuk-body">If the trainee is shown in this service as actively training or deferred, you should make the change in this service.</p>
+
+    <h3 class="govuk-heading-s">School centred initial teacher training (SCITT) providers</h3>
+    <p class="govuk-body">
+      If you notice a mistake, and the trainee is shown in this service as awarded or withdrawn,
+      you should email <%= govuk_link_to("becomingateacher@digital.education.gov.uk", @fix_mistakes_email_link) %>.
+      Only the Becoming a Teacher team can edit this record for you.
+    </p>
+    <p class="govuk-body">
+      If you notice a mistake, for example, an incorrect start date,
+      and the trainee is shown in this service as actively training or deferred,
+      you should make the change in this service.
+    </p>
+
+    <h3 class="govuk-heading-s">Higher education institution (HEI) providers </h3>
+    <p class="govuk-body">
+      If you notice a mistake, and the trainee is shown in this service as awarded or withdrawn,
+      you should email <%= govuk_link_to("becomingateacher@digital.education.gov.uk", @fix_mistakes_email_link) %>.
+      Only the Becoming a Teacher team can edit this record for you.
+    </p>
+    <p class="govuk-body">
+      If you notice a mistake, for example, an incorrect start date,
+      and the trainee is shown in this service as actively training or deferred,
+      you should:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        make the change through the Higher Education Statistics Agency (HESA)
+        if the trainee was registered through HESA and is in the 2023 to 2024
+        initial teacher training (ITT) collection
+      </li>
+      <li>
+        email <%= govuk_link_to("becomingateacher@digital.education.gov.uk", @fix_mistakes_email_link) %>
+        if the trainee was registered through HESA but is not in the 2023 to 2024 ITT collection
+      </li>
+      <li>
+        make the change in this service if the trainee was not registered through HESA
+      </li>
+    </ul>
 
     <h2 class="govuk-heading-m">Sign off your trainee data</h2>
     <p class="govuk-body">
-      You will need to complete
-      <a href=<%= @sign_off_url %> class="govuk-link" rel="noreferrer noopener" target="_blank">a form to sign off
-      the data</a> on behalf of your organisation.
+      A person from your organisation must <%= govuk_link_to("complete a form to sign off the data", new_reports_performance_profile_path) %>
     </p>
 
     <h2 class="govuk-heading-m">How your trainee data will be used</h2>
     <p class="govuk-body">
-      Read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-performance-profiles-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">ITT performance profiles methodology (opens in a new tab)</a> to find out how your trainee data will be used.
+      Read the <%= govuk_link_to("ITT performance profiles methodology",
+        "https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-performance-profiles-methodology",
+        new_tab: true) %> to find out how your trainee data will be used.
     </p>
-    <p class="govuk-body">Some trainees will not be included in the ITT performance profiles publication. For example, trainees who withdrew within 90 days of the course start will not be included.</p>
+    <p class="govuk-body">
+      Some trainees will not be included in the ITT performance profiles publication.
+      For example, trainees who withdrew within 90 days of the course start will not be included.
+    </p>
   </div>
   </div>
 </div>

--- a/app/views/guidance/performance_profiles.html.erb
+++ b/app/views/guidance/performance_profiles.html.erb
@@ -30,8 +30,8 @@
       This performance profile sign off period’s deadline is <%= @sign_off_deadline %>.
     </p>
     <p class="govuk-body">
-      You can sign off your trainee data from the
-      <%= @previous_academic_cycle_label %> academic year from <%= @sign_off_deadline %>.
+      You can sign off your trainee data for the
+      <%= @previous_academic_cycle_label %> academic year from <%= @sign_off_period_start %>.
     </p>
 
     <h2 class="govuk-heading-m">Find your trainee data</h2>

--- a/app/views/guidance/performance_profiles_outside.html.erb
+++ b/app/views/guidance/performance_profiles_outside.html.erb
@@ -8,26 +8,62 @@
 <% end %>
 
 <div class="govuk-grid-row">
-   <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h1 class="govuk-heading-l" id="signing-off-your-list-of-trainees-for-the-performance-profiles-publication">Signing off your list of trainees for the performance profiles publication</h1>
-      <p class="govuk-body">Each year, as an accredited provider you need to sign off your teacher trainee data from the previous academic year. You’ll be told by email when you need to do this.</p>
-      <p class="govuk-body">The data you sign off will be included in the annual initial teacher training performance profiles publication. This will be published on GOV.UK.</p>
-      <h2 class="govuk-heading-m" id="finding-your-trainee-data">Finding your trainee data</h2>
-      <p class="govuk-body">You’ll need a list of all registered trainees who studied in the previous academic year. A report will be available showing the data you need to check.</p>
-      <h2 class="govuk-heading-m" id="checking-your-trainee-data">Checking your trainee data</h2>
-      <p class="govuk-body">You’ll need to check that all your trainees for the previous academic year are listed. For each trainee you’ll need to check:</p>
-      <ul class="govuk-list govuk-list--bullet">
-         <li>course details</li>
-         <li>status</li>
-         <li>the date they were awarded qualified teacher status (QTS) or early years teacher status (EYTS), or deferred or withdrew from the course - unless they’re still studying</li>
-         <li>2 placements for trainees that were QTS awarded</li>
-      </ul>
-      <h2 class="govuk-heading-m" id="fixing-mistakes-in-your-trainee-data">Fixing mistakes in your trainee data</h2>
-      <p class="govuk-body">You’ll need to fix any mistakes before you sign off the data. How you’ll do this depends on whether you’re a provider of school centred initial teacher training (SCITT) or a higher education institution (HEI).</p>
-      <h2 class="govuk-heading-m" id="signing-off-your-trainee-data">Signing off your trainee data</h2>
-      <p class="govuk-body">You will need to complete a form to sign off the data on behalf of your organisation.</p>
-      <h2 class="govuk-heading-m" id="how-your-trainee-data-will-be-used">How your trainee data will be used</h2>
-     <p class="govuk-body"><a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-performance-profiles-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">Read the ITT performance profiles methodology (opens in a new tab)</a> to find out how your trainee data will be used.</p>
-      <p class="govuk-body">Some trainees will not be included in the ITT performance profiles publication. For example, trainees who withdrew within 90 days of the course start will not be included.</p>
-   </div>
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l" id="signing-off-your-list-of-trainees-for-the-performance-profiles-publication">
+      Signing off your list of trainees for the performance profiles publication
+    </h1>
+
+    <p class="govuk-body">
+      Each year, as an accredited provider you need to sign off your teacher trainee
+      data from the previous academic year. You’ll be told by email when you need to do this.
+    </p>
+    <p class="govuk-body">
+      The data you sign off will be included in the annual initial teacher training
+      performance profiles publication. This will be published on GOV.UK.
+    </p>
+
+    <h2 class="govuk-heading-m" id="finding-your-trainee-data">Finding your trainee data</h2>
+    <p class="govuk-body">
+      You’ll need a list of all registered trainees who studied in the previous
+      academic year. A report will be available showing the data you need to check.
+    </p>
+
+    <h2 class="govuk-heading-m" id="checking-your-trainee-data">Checking your trainee data</h2>
+    <p class="govuk-body">
+      You’ll need to check that all your trainees for the previous academic
+      year are listed. For each trainee you’ll need to check:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>course details</li>
+      <li>status</li>
+      <li>the date they were awarded qualified teacher status (QTS) or early
+        years teacher status (EYTS), or deferred or withdrew from the course
+        - unless they’re still studying</li>
+      <li>2 placements for trainees that were QTS awarded</li>
+    </ul>
+
+    <h2 class="govuk-heading-m" id="fixing-mistakes-in-your-trainee-data">Fixing mistakes in your trainee data</h2>
+    <p class="govuk-body">
+      You’ll need to fix any mistakes before you sign off the data. How you’ll
+      do this depends on whether you’re a provider of school centred initial
+      teacher training (SCITT) or a higher education institution (HEI).
+    </p>
+
+    <h2 class="govuk-heading-m" id="signing-off-your-trainee-data">Signing off your trainee data</h2>
+    <p class="govuk-body">
+      You will need to complete a form to sign off the data on behalf of
+      your organisation.
+    </p>
+
+    <h2 class="govuk-heading-m" id="how-your-trainee-data-will-be-used">How your trainee data will be used</h2>
+    <p class="govuk-body">
+      Read the <%= govuk_link_to("ITT performance profiles methodology",
+        "https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-performance-profiles-methodology",
+        new_tab: true) %> to find out how your trainee data will be used.
+    </p>
+    <p class="govuk-body">
+      Some trainees will not be included in the ITT performance profiles publication.
+      For example, trainees who withdrew within 90 days of the course start will not be included.
+    </p>
+  </div>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -171,7 +171,6 @@ google:
     entity_table_checks_enabled: true
 
 sign_off_trainee_data_url: https://forms.office.com/e/TB5dcbCJuF
-sign_off_performance_profiles_url: https://forms.office.com/e/ATXmqJusud)
 sign_off_period: outside_period # census_period, performance_period, outside_period. See app/services/determine_sign_off_period.rb
 
 trainee_export:


### PR DESCRIPTION
### Context

Feedback from testing has highlighted the need for some guidance to be updated.

[Trello card (comment)](https://trello.com/c/E4iFMH77/7936-performance-profiles-sign-off-in-register-testing#comment-67643b834698bab47864de5d)

### Changes proposed in this pull request

* Update guidance for inside performance profile period according to the [Word doc](https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/Shared%20Documents/Becoming%20a%20Teacher/TWD-REGISTER/Performance%20Profiles%20Sign%20off/2023-2024/Sign%20off%20your%20list%20of%20trainees%20for%20the%20performance%20profile%20publication.docx?d=w9d06b6175f4747e7893db4e9af5131be&csf=1&web=1&e=K5o3zO)
* Tidy up code that's now not used
* Reformat ERB in 'outside period' page

### Guidance to review

* Does it look right?
* Do dates display correctly?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
