### PR TITLE
[7938] - Send confirmation emails after performance profile sign off

### DIFF
--- a/app/controllers/reports/performance_profiles_controller.rb
+++ b/app/controllers/reports/performance_profiles_controller.rb
@@ -50,6 +50,7 @@ module Reports
       @performance_profile_sign_off_form = PerformanceProfileSignOffForm.new(sign_off: sign_off, provider: current_user.organisation, user: current_user)
 
       if @performance_profile_sign_off_form.save!
+        email_provider_users
         redirect_to(confirmation_reports_performance_profiles_path)
       else
         @previous_academic_cycle = AcademicCycle.previous
@@ -84,6 +85,10 @@ module Reports
 
     def base_trainee_scope
       policy_scope(Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :end_academic_cycle).not_draft)
+    end
+
+    def email_provider_users
+      SendPerformanceProfileSubmittedEmailService.call(provider: current_user.organisation, submitted_at: Time.zone.now)
     end
 
     def sign_off

--- a/app/mailers/performance_profile_submitted_email_mailer.rb
+++ b/app/mailers/performance_profile_submitted_email_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class PerformanceProfileSubmittedEmailMailer < GovukNotifyRails::Mailer
+  def generate(user:, submitted_at:)
+    set_template(Settings.govuk_notify.performance_profile_submitted_email_template_id)
+
+    set_personalisation(
+      first_name: user.first_name,
+      submitted_at: submitted_at.to_fs(:govuk_date_and_time),
+    )
+
+    mail(to: user.email)
+  end
+end

--- a/app/services/send_performance_profile_submitted_email_service.rb
+++ b/app/services/send_performance_profile_submitted_email_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SendPerformanceProfileSubmittedEmailService
+  include ServicePattern
+
+  def initialize(provider:, submitted_at:)
+    @provider = provider
+    @submitted_at = submitted_at
+  end
+
+  def call
+    return unless FeatureService.enabled?(:send_emails)
+
+    provider.users.each do |user|
+      PerformanceProfileSubmittedEmailMailer.generate(
+        user:,
+        submitted_at:,
+      ).deliver_later
+    end
+  end
+
+private
+
+  attr_reader :provider, :submitted_at
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -155,6 +155,7 @@ govuk_notify:
     in_progress_template_id: 66682854-a9f1-43b3-85e9-0e168fc42b0c
     succeeded_template_id: 8ff06d35-8960-462e-aa6e-9942a7fd713d
     failed_template_id: 3344fd46-7f33-4762-a350-d02a88f863b0
+  performance_profile_submitted_email_template_id: 21879652-3975-4a0a-b0b4-9fe6a5353090
 
 google_tag_manager:
   tracking_id: GTM-PD8MFNL

--- a/spec/mailers/performance_profile_submitted_email_mailer_spec.rb
+++ b/spec/mailers/performance_profile_submitted_email_mailer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PerformanceProfileSubmittedEmailMailer do
+  context "sending an email to a user" do
+    let(:user) { create(:user) }
+    let(:submitted_at) { Time.new(2025, 1, 12, 12, 30) }
+    let(:mail) { described_class.generate(user:, submitted_at:) }
+
+    before { mail }
+
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.performance_profile_submitted_email_template_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "includes the first name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:first_name]).to eq(user.first_name)
+    end
+
+    it "includes the submitted at time in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:submitted_at]).to eq("12 January 2025 at 12:30pm")
+    end
+  end
+end

--- a/spec/services/send_performance_profile_submitted_email_service_spec.rb
+++ b/spec/services/send_performance_profile_submitted_email_service_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SendPerformanceProfileSubmittedEmailService do
+  let(:user) { create(:user, :hei) }
+  let(:provider) { user.providers.first }
+  let(:submitted_at) { Time.zone.now }
+
+  context "when the 'send_emails' feature is enabled", feature_send_emails: true do
+    it "sends the performance profile submitted email" do
+      Timecop.freeze do
+        expect {
+          described_class.call(provider:, submitted_at:)
+        }.to have_enqueued_job.with(
+          "PerformanceProfileSubmittedEmailMailer", "generate", "deliver_now", args: [user:, submitted_at:]
+        )
+      end
+    end
+  end
+
+  context "when the 'send_emails' feature is not enabled" do
+    it "does not send the performance profile submitted email" do
+      Timecop.freeze do
+        expect {
+          described_class.call(provider:, submitted_at:)
+        }.not_to have_enqueued_job.with(
+          "PerformanceProfileSubmittedEmailMailer", "generate", "deliver_now", args: [user:, submitted_at:]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/7kwr2Udf/7938-send-email-confirmation-upon-successful-sign-off

### Changes proposed in this pull request

Send an email to all provider users when performance profile has been submitted

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
