### PR TITLE
[7951] - Update undo withdrawals process

### DIFF
--- a/app/forms/undo_withdrawal_form.rb
+++ b/app/forms/undo_withdrawal_form.rb
@@ -19,7 +19,8 @@ class UndoWithdrawalForm
   def save
     return false unless valid?
 
-    trainee.withdrawal_reasons.clear
+    withdrawal = trainee.trainee_withdrawals.last
+    withdrawal.update(discarded_at: Time.zone.now)
     trainee.update(
       state: previous_state,
       withdraw_reasons_details: nil,

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -523,7 +523,8 @@ FactoryBot.define do
       withdraw_reasons_dfe_details { "withdraw dfe details" }
 
       after(:create) do |trainee|
-        create(:trainee_withdrawal_reason, trainee:)
+        trainee_withdrawal = create(:trainee_withdrawal, trainee:)
+        create(:trainee_withdrawal_reason, trainee:, trainee_withdrawal:)
       end
     end
 

--- a/spec/features/trainee_actions/undo_withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/undo_withdraw_trainee_spec.rb
@@ -12,6 +12,8 @@ feature "Undo trainee withdrawal" do
     when_i_am_on_the_undo_withdrawal_page
   end
 
+  let(:withdrawal) { trainee.trainee_withdrawals.last }
+
   context "validations" do
     context "comment validation" do
       scenario "no comment provided" do
@@ -85,10 +87,11 @@ feature "Undo trainee withdrawal" do
 
   def then_i_expect_the_trainee_to_have_been_updated
     expect(trainee.reload.state).not_to eql "withdrawn"
-    expect(trainee.withdrawal_reasons).to be_empty
+    expect(withdrawal.withdrawal_reasons).not_to be_empty
     expect(trainee.withdraw_date).to be_nil
     expect(trainee.withdraw_reasons_details).to be_nil
     expect(trainee.withdraw_reasons_dfe_details).to be_nil
+    expect(withdrawal.discarded_at).not_to be_nil
     expect(trainee.audits.last.comment).to have_text("https://google.com")
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/pNcirSIp/7951-undo-withdrawal?filter=member:chrisgannon23

### Changes proposed in this pull request

Undo withdrawal process will discard the current withdrawal whilst leaving the withdrawal reasons intact. It will leave an audit comment for and update the timeline. Previous timeline events for undoing a withdrawal should still be valid.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
