### PR TITLE
[7961] Fix dead link from CSV docs to empty template

### DIFF
--- a/app/views/bulk_update/add_trainees/uploads/new.html.erb
+++ b/app/views/bulk_update/add_trainees/uploads/new.html.erb
@@ -31,7 +31,10 @@
       </h2>
 
       <p class="govuk-body">
-        <%= govuk_link_to("Download empty CSV file to add new trainees", BulkUpdate::AddTrainees::ImportRows::EMPTY_CSV_TEMPLATE_PATH) %>
+        <%= govuk_link_to(
+          "Download empty CSV file to add new trainees",
+          bulk_update_add_trainees_empty_template_path(format: :csv),
+        ) %>
       </p>
 
       <h3 class="govuk-heading-s">If you're adapting the CSV file template for a direct extract from your student record system</h3>

--- a/app/views/csv_docs/pages/add_trainees.html.erb
+++ b/app/views/csv_docs/pages/add_trainees.html.erb
@@ -31,7 +31,10 @@
 </p>
 
 <p class="govuk-body">
-  <a class="govuk-link" href="#">Download empty bulk add new trainees CSV template</a>
+  <%= govuk_link_to(
+    "Download empty bulk add new trainees CSV template",
+    bulk_update_add_trainees_empty_template_path(format: :csv),
+  ) %>
 </p>
 
 <h2 class="govuk-heading-m">Use this guidance to complete the CSV file template</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
         end
       end
       resources :review_errors, path: "review-errors", only: %i[show]
+      resource :empty_template, only: %i[show], path: "empty-template"
     end
   end
 

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -101,6 +101,9 @@ feature "bulk add trainees" do
         when_i_click_the_guidance_link
         then_i_see_the_bulk_add_trainees_guidance_page
 
+        when_i_click_the_documentation_empty_csv_link
+        then_i_receive_the_empty_csv_file
+
         when_i_attach_an_empty_file
         and_i_click_the_upload_button
         then_i_see_the_upload_page_with_errors(empty: true)
@@ -689,7 +692,10 @@ private
   def then_i_see_the_bulk_add_trainees_guidance_page
     expect(page).to have_current_path(csv_docs_home_path)
     expect(page).to have_content("How to add trainee information to the bulk add new trainee CSV template")
-    visit new_bulk_update_add_trainees_upload_path
+  end
+
+  def when_i_click_the_documentation_empty_csv_link
+    click_on "Download empty bulk add new trainees CSV template"
   end
 
   def when_i_attach_an_empty_file


### PR DESCRIPTION
### Context
The link from the CSV reference docs to the empty CSV template for bulk add trainee is broken (was never implemented).

Also addresses issues with `content-disposition` to ensure that the empty CSV is always served as a download.

### Changes proposed in this pull request

- Add a missing route to the `BulkUpdate::AddTrainees::EmptyTemplatesController#show` action.
- Use the above route for the links on the new upload page as well as the CSV reference docs.
- Extend the feature spec that covers this area to assert that the link of the CSV reference docs works.

### Guidance to review

Anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
