### PR TITLE
[7986] CSV bug party - No date for failed uploads (6)

### DIFF
--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,6 +1,10 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <%= govuk_link_to created_at, upload_path %>
+    <% if upload.cancelled? %>
+      <%= created_at %>
+    <% else %>
+      <%= govuk_link_to created_at, upload_path %>
+    <% end %>
   </td>
   <td class="govuk-table__cell">
     <%= filename %>

--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,6 +1,8 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <% unless upload.cancelled? %>
+    <% if upload.cancelled? %>
+      <%= created_at %>
+    <% else %>
       <%= govuk_link_to created_at, upload_path %>
     <% end %>
   </td>

--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,8 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <% if submitted_at %>
-      <%= govuk_link_to submitted_at, upload_path %>
-    <% end %>
+    <%= govuk_link_to created_at, upload_path %>
   </td>
   <td class="govuk-table__cell">
     <%= filename %>

--- a/app/components/bulk_update/trainee_uploads/row/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/row/view.html.erb
@@ -1,8 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <% if upload.cancelled? %>
-      <%= created_at %>
-    <% else %>
+    <% unless upload.cancelled? %>
       <%= govuk_link_to created_at, upload_path %>
     <% end %>
   </td>

--- a/app/components/bulk_update/trainee_uploads/row/view.rb
+++ b/app/components/bulk_update/trainee_uploads/row/view.rb
@@ -31,6 +31,8 @@ module BulkUpdate
 
         def upload_path
           {
+            "pending" => bulk_update_add_trainees_upload_path(upload),
+            "validated" => bulk_update_add_trainees_upload_path(upload),
             "succeeded" => bulk_update_add_trainees_details_path(upload),
             "in_progress" => bulk_update_add_trainees_submission_path(upload),
             "failed" => bulk_update_add_trainees_review_error_path(upload),

--- a/app/components/bulk_update/trainee_uploads/row/view.rb
+++ b/app/components/bulk_update/trainee_uploads/row/view.rb
@@ -37,8 +37,8 @@ module BulkUpdate
           }[upload.status]
         end
 
-        def submitted_at
-          upload.submitted_at&.to_fs(:govuk_date_and_time)
+        def created_at
+          upload.created_at.to_fs(:govuk_date_and_time)
         end
       end
     end

--- a/app/views/bulk_update/add_trainees/uploads/index.html.erb
+++ b/app/views/bulk_update/add_trainees/uploads/index.html.erb
@@ -27,7 +27,7 @@
       <caption class="govuk-table__caption govuk-visually-hidden">Trainee uploads</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header">Submitted</th>
+          <th class="govuk-table__header">Uploaded</th>
           <th class="govuk-table__header">Filename</th>
           <th class="govuk-table__header">Validation status</th>
         </tr>

--- a/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
+++ b/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
         it do
           expect(
             render_inline(subject),
-          ).to have_text(upload.created_at.to_fs(:govuk_date_and_time))
+          ).not_to have_text(upload.created_at.to_fs(:govuk_date_and_time))
         end
       end
     end

--- a/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
+++ b/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
         it do
           expect(
             render_inline(subject),
-          ).not_to have_text(upload.created_at.to_fs(:govuk_date_and_time))
+          ).to have_text(upload.created_at.to_fs(:govuk_date_and_time))
         end
       end
     end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -176,7 +176,9 @@ feature "bulk add trainees" do
         when_the_unexpected_duplicate_error_is_been_reverted
         and_i_return_to_the_review_errors_page
         and_i_attach_a_valid_file
-        and_i_click_the_upload_button
+        Timecop.travel 1.hour.from_now do
+          and_i_click_the_upload_button
+        end
         then_i_see_that_the_upload_is_processing
         then_a_job_is_queued_to_process_the_upload
 
@@ -185,10 +187,7 @@ feature "bulk add trainees" do
         and_i_see_the_review_page_without_validation_errors
         and_i_dont_see_the_review_errors_link
         and_i_dont_see_the_back_to_bulk_updates_link
-
-        Timecop.travel 1.hour.from_now do
-          and_i_click_the_submit_button
-        end
+        and_i_click_the_submit_button
 
         then_a_job_is_queued_to_process_the_upload
         and_the_send_csv_processing_email_has_been_sent
@@ -209,7 +208,7 @@ feature "bulk add trainees" do
         and_i_click_on_view_status_of_uploaded_trainee_files
         then_i_see_the_bulk_update_add_trainees_uploads_index_page
 
-        when_i_click_on_an_upload
+        when_i_click_on_an_upload(upload: BulkUpdate::TraineeUpload.succeeded.last)
         then_i_see_the_bulk_update_add_trainees_upload_details_page
 
         when_i_click_on_back_link
@@ -485,7 +484,7 @@ private
   end
 
   def when_i_click_on_an_upload(upload: BulkUpdate::TraineeUpload.last)
-    first(:link, upload.submitted_at.to_fs(:govuk_date_and_time)).click
+    first(:link, upload.created_at.to_fs(:govuk_date_and_time)).click
   end
 
   def then_i_see_the_bulk_update_add_trainees_upload_details_page


### PR DESCRIPTION
### Context

[7986-csv-bug-party-no-date-for-failed-uploads-6](https://trello.com/c/rDGW7LGc/7986-csv-bug-party-no-date-for-failed-uploads-6)

### Changes proposed in this pull request

* Use `BulkUpdate::TraineeUpload#created_at` instead of `submitted_at`
* Changing heading to `Uploaded`
* Hide `created_at` if the upload is `cancelled`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
