### PR TITLE
[8038] Fix API withdrawals endpoint params

### DIFF
--- a/app/controllers/api/trainees/withdraw_controller.rb
+++ b/app/controllers/api/trainees/withdraw_controller.rb
@@ -26,7 +26,7 @@ module Api
       end
 
       def withdrawal_params
-        params.permit(:withdraw_date, :withdraw_reasons_details, :withdraw_reasons_dfe_details, reasons: [])
+        params.require(:data).permit(:withdraw_date, :withdraw_reasons_details, :withdraw_reasons_dfe_details, reasons: [])
       end
     end
   end

--- a/app/models/api/v0_1/withdrawal_attributes.rb
+++ b/app/models/api/v0_1/withdrawal_attributes.rb
@@ -46,7 +46,7 @@ module Api
         elsif parsed_withdraw_date.blank?
           errors.add(:withdraw_date, :invalid)
         elsif date_before_itt_start_date?(parsed_withdraw_date, trainee.itt_start_date)
-          errors.add(:date, :not_before_itt_start_date)
+          errors.add(:withdraw_date, :not_before_itt_start_date)
         end
       end
 

--- a/spec/requests/api/v0_1/audit_trail_attribution_spec.rb
+++ b/spec/requests/api/v0_1/audit_trail_attribution_spec.rb
@@ -11,10 +11,12 @@ describe "audit trail attribution" do
     let(:unknown) { create(:withdrawal_reason, :unknown) }
     let(:params) do
       {
-        reasons: [unknown.name],
-        withdraw_date: Time.zone.now.to_s,
-        withdraw_reasons_details: Faker::JapaneseMedia::CowboyBebop.quote,
-        withdraw_reasons_dfe_details: Faker::JapaneseMedia::StudioGhibli.quote,
+        data: {
+          reasons: [unknown.name],
+          withdraw_date: Time.zone.now.to_s,
+          withdraw_reasons_details: Faker::JapaneseMedia::CowboyBebop.quote,
+          withdraw_reasons_dfe_details: Faker::JapaneseMedia::StudioGhibli.quote,
+        },
       }
     end
 

--- a/spec/requests/api/v0_1/trainees/post_withdraw_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_withdraw_spec.rb
@@ -27,10 +27,12 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
       let(:unknown) { create(:withdrawal_reason, :unknown) }
       let(:params) do
         {
-          reasons: [unknown.name],
-          withdraw_date: Time.zone.now.to_s,
-          withdraw_reasons_details: Faker::JapaneseMedia::CowboyBebop.quote,
-          withdraw_reasons_dfe_details: Faker::JapaneseMedia::StudioGhibli.quote,
+          data: {
+            reasons: [unknown.name],
+            withdraw_date: Time.zone.now.to_s,
+            withdraw_reasons_details: Faker::JapaneseMedia::CowboyBebop.quote,
+            withdraw_reasons_dfe_details: Faker::JapaneseMedia::StudioGhibli.quote,
+          },
         }
       end
       let(:slug) { trainee.slug }
@@ -53,7 +55,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
             headers: { Authorization: "Bearer #{token}", **json_headers },
             params: params.to_json,
           )
-        } .to change { trainee.reload.withdraw_reasons_details }.from(nil).to(params[:withdraw_reasons_details])
+        } .to change { trainee.reload.withdraw_reasons_details }.from(nil).to(params[:data][:withdraw_reasons_details])
         .and change { trainee.reload.withdraw_date }.from(nil)
         .and change { trainee.reload.state }.from("trn_received").to("withdrawn")
       end
@@ -79,7 +81,15 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
       end
 
       context "with invalid params" do
-        let(:params) { { withdraw_reasons_details: nil, withdraw_date: nil } }
+        let(:params) do
+          {
+            data:
+              {
+                withdraw_reasons_details: nil,
+                withdraw_date: nil,
+              },
+          }
+        end
 
         it "returns status code 422 with a valid JSON response" do
           post(
@@ -107,11 +117,23 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
     context "with a non-withdrawable trainee" do
       let(:trainee) { create(:trainee, :itt_start_date_in_the_future, provider:) }
       let(:slug) { trainee.slug }
+      let(:unknown) { create(:withdrawal_reason, :unknown) }
+      let(:params) do
+        {
+          data: {
+            reasons: [unknown.name],
+            withdraw_date: Time.zone.now.to_s,
+            withdraw_reasons_details: Faker::JapaneseMedia::CowboyBebop.quote,
+            withdraw_reasons_dfe_details: Faker::JapaneseMedia::StudioGhibli.quote,
+          },
+        }
+      end
 
       it "returns status code 422 with a valid JSON response" do
         post(
           "/api/v0.1/trainees/#{slug}/withdraw",
           headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
         )
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body[:errors]).to contain_exactly({ error: "StateTransitionError", message: "It's not possible to perform this action while the trainee is in its current state" })

--- a/spec/requests/api/v1_0_pre/audit_trail_attribution_spec.rb
+++ b/spec/requests/api/v1_0_pre/audit_trail_attribution_spec.rb
@@ -11,10 +11,12 @@ describe "audit trail attribution" do
     let(:unknown) { create(:withdrawal_reason, :unknown) }
     let(:params) do
       {
-        reasons: [unknown.name],
-        withdraw_date: Time.zone.now.to_s,
-        withdraw_reasons_details: Faker::JapaneseMedia::CowboyBebop.quote,
-        withdraw_reasons_dfe_details: Faker::JapaneseMedia::StudioGhibli.quote,
+        data: {
+          reasons: [unknown.name],
+          withdraw_date: Time.zone.now.to_s,
+          withdraw_reasons_details: Faker::JapaneseMedia::CowboyBebop.quote,
+          withdraw_reasons_dfe_details: Faker::JapaneseMedia::StudioGhibli.quote,
+        },
       }
     end
 


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/uYJU07Y2/8038-fix-api-withdrawals-endpoint-params)

### Changes proposed in this pull request

* Fix withdrawals endpoint params data structure to match the docs and other endpoints
* Fix an incorrect field name in `WithdrawalAttributes`
* Update tests

### Guidance to review

Anything missing?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
