### PR TITLE
[8046] Make CSV template download available without signing in

### DIFF
--- a/app/controllers/bulk_update/add_trainees/empty_templates_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/empty_templates_controller.rb
@@ -2,9 +2,7 @@
 
 module BulkUpdate
   module AddTrainees
-    class EmptyTemplatesController < ApplicationController
-      before_action { require_feature_flag(:bulk_add_trainees) }
-
+    class EmptyTemplatesController < CsvDocs::BaseController
       def show
         respond_to do |format|
           format.csv do

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -441,6 +441,14 @@ feature "bulk add trainees" do
         then_i_see_the_review_errors_page_with_one_error
       end
     end
+
+    context "when the User is not authenticated" do
+      scenario "view guidance docs" do
+        when_i_visit_the_csv_docs_home_path
+        and_i_click_the_documentation_empty_csv_link
+        then_i_receive_the_empty_csv_file
+      end
+    end
   end
 
 private
@@ -691,6 +699,10 @@ private
   def then_i_see_the_bulk_add_trainees_guidance_page
     expect(page).to have_current_path(csv_docs_home_path)
     expect(page).to have_content("How to add trainee information to the bulk add new trainee CSV template")
+  end
+
+  def when_i_visit_the_csv_docs_home_path
+    visit csv_docs_home_path
   end
 
   def when_i_click_the_documentation_empty_csv_link
@@ -1118,4 +1130,5 @@ private
   alias_method :and_the_background_job_is_run, :when_the_background_job_is_run
   alias_method :and_i_return_to_the_review_errors_page, :when_i_return_to_the_review_errors_page
   alias_method :and_i_visit_the_bulk_update_trainee_upload_page, :when_i_try_resubmit_the_same_upload
+  alias_method :and_i_click_the_documentation_empty_csv_link, :when_i_click_the_documentation_empty_csv_link
 end


### PR DESCRIPTION
### Context

[8046-make-csv-template-download-available-without-signing-in](https://trello.com/c/GAduUJHG/8046-make-csv-template-download-available-without-signing-in)

### Changes proposed in this pull request

* Remove authentication for CSV template file by inheriting from `CsvDocs::BaseController`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
