### PR TITLE
[8049] Fix 500 error in bulk trainee csv upload

### DIFF
--- a/app/services/bulk_update/add_trainees/validate_csv.rb
+++ b/app/services/bulk_update/add_trainees/validate_csv.rb
@@ -18,7 +18,8 @@ module BulkUpdate
       attr_reader :csv, :record
 
       def header_row!
-        return if headers.sort == BulkUpdate::AddTrainees::ImportRows::ALL_HEADERS.keys.sort
+        return if headers.all? { |value| value.is_a?(String) } &&
+          headers.sort == BulkUpdate::AddTrainees::ImportRows::ALL_HEADERS.keys.sort
 
         record.errors.add(:file, :invalid_headers, headers: BulkUpdate::AddTrainees::ImportRows::ALL_HEADERS.keys.join(", "))
       end

--- a/spec/services/bulk_update/add_trainees/validate_csv_spec.rb
+++ b/spec/services/bulk_update/add_trainees/validate_csv_spec.rb
@@ -35,7 +35,7 @@ module BulkUpdate
         end
         let(:csv) { CSVSafe.new(file_content, headers: true).read }
 
-        it { expect(record.errors).to be_empty }
+        it { expect(record.errors.first.message).to eql "CSV header must include: #{BulkUpdate::AddTrainees::ImportRows::ALL_HEADERS.keys.join(', ')}" }
       end
 
       context "given a CSV file with no data (just a header)" do


### PR DESCRIPTION
### Context

When reviewing https://github.com/DFE-Digital/register-trainee-teachers/pull/4935 we found that certain inputs lead to a crash. If you delete column heading label, without deleting any commas we are seeing a `500` status.

### Changes proposed in this pull request

We need to ensure that all headers are strings before sorting. Otherwise gaps in the headers (empty string columns) cause sorting to crash on the next line.

### Guidance to review

Are there any other potential inputs that could trip up the validation?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
