### PR TITLE
[8058] - remove feature flag from mailers

### DIFF
--- a/app/services/send_csv_submitted_for_processing_email_service.rb
+++ b/app/services/send_csv_submitted_for_processing_email_service.rb
@@ -9,8 +9,6 @@ class SendCsvSubmittedForProcessingEmailService
   end
 
   def call
-    return unless FeatureService.enabled?(:send_emails)
-
     CsvSubmittedForProcessingEmailMailer.generate(
       upload:,
     ).deliver_later(wait: 30.seconds)

--- a/app/services/send_performance_profile_submitted_email_service.rb
+++ b/app/services/send_performance_profile_submitted_email_service.rb
@@ -9,8 +9,6 @@ class SendPerformanceProfileSubmittedEmailService
   end
 
   def call
-    return unless FeatureService.enabled?(:send_emails)
-
     provider.users.each do |user|
       PerformanceProfileSubmittedEmailMailer.generate(
         user:,

--- a/spec/services/send_csv_submitted_for_processing_email_service_spec.rb
+++ b/spec/services/send_csv_submitted_for_processing_email_service_spec.rb
@@ -6,27 +6,13 @@ describe SendCsvSubmittedForProcessingEmailService do
   let(:wait_time) { 30.seconds }
   let(:upload) { create(:bulk_update_trainee_upload, :in_progress) }
 
-  context "when the 'send_emails' feature is enabled", feature_send_emails: true do
-    it "sends the csv submitted for processing email" do
-      Timecop.freeze do
-        expect {
-          described_class.call(upload:)
-        }.to have_enqueued_job.with(
-          "CsvSubmittedForProcessingEmailMailer", "generate", "deliver_now", args: [upload:]
-        ).at(wait_time.from_now)
-      end
-    end
-  end
-
-  context "when the 'send_emails' feature is not enabled" do
-    it "sends the csv submitted for processing email" do
-      Timecop.freeze do
-        expect {
-          described_class.call(upload:)
-        }.not_to have_enqueued_job.with(
-          "CsvSubmittedForProcessingEmailMailer", "generate", "deliver_now", args: [upload:]
-        ).at(wait_time.from_now)
-      end
+  it "sends the csv submitted for processing email" do
+    Timecop.freeze do
+      expect {
+        described_class.call(upload:)
+      }.to have_enqueued_job.with(
+        "CsvSubmittedForProcessingEmailMailer", "generate", "deliver_now", args: [upload:]
+      ).at(wait_time.from_now)
     end
   end
 end

--- a/spec/services/send_performance_profile_submitted_email_service_spec.rb
+++ b/spec/services/send_performance_profile_submitted_email_service_spec.rb
@@ -7,23 +7,11 @@ describe SendPerformanceProfileSubmittedEmailService do
   let(:provider) { user.providers.first }
   let(:submitted_at) { Time.zone.now }
 
-  context "when the 'send_emails' feature is enabled", feature_send_emails: true do
-    it "sends the performance profile submitted email" do
-      expect {
-        described_class.call(provider:, submitted_at:)
-      }.to have_enqueued_job.with(
-        "PerformanceProfileSubmittedEmailMailer", "generate", "deliver_now", args: [user:, submitted_at:]
-      )
-    end
-  end
-
-  context "when the 'send_emails' feature is not enabled" do
-    it "does not send the performance profile submitted email" do
-      expect {
-        described_class.call(provider:, submitted_at:)
-      }.not_to have_enqueued_job.with(
-        "PerformanceProfileSubmittedEmailMailer", "generate", "deliver_now", args: [user:, submitted_at:]
-      )
-    end
+  it "sends the performance profile submitted email" do
+    expect {
+      described_class.call(provider:, submitted_at:)
+    }.to have_enqueued_job.with(
+      "PerformanceProfileSubmittedEmailMailer", "generate", "deliver_now", args: [user:, submitted_at:]
+    )
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/BISN0iEr/8058-provider-has-not-received-sign-off-confirmation

### Changes proposed in this pull request

The `send_emails` feature flag is not needed for these mailers.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
