### PR TITLE
[8067] Separate the validation background job from BulkUpdate::BulkAddTraineesUploadForm

### DIFF
--- a/app/components/bulk_update/trainee_uploads/row/view.rb
+++ b/app/components/bulk_update/trainee_uploads/row/view.rb
@@ -31,6 +31,7 @@ module BulkUpdate
 
         def upload_path
           {
+            "uploaded" => bulk_update_add_trainees_upload_path(upload),
             "pending" => bulk_update_add_trainees_upload_path(upload),
             "validated" => bulk_update_add_trainees_upload_path(upload),
             "succeeded" => bulk_update_add_trainees_details_path(upload),

--- a/app/forms/bulk_update/bulk_add_trainees_import_rows_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_import_rows_form.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  class BulkAddTraineesImportRowsForm
+    attr_reader :upload
+
+    def initialize(upload:)
+      @upload = upload
+    end
+
+    def save
+      upload.import!
+
+      BulkUpdate::AddTrainees::ImportRowsJob.perform_later(upload)
+
+      upload
+    end
+  end
+end

--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -5,9 +5,6 @@ module BulkUpdate
     attr_reader :provider, :file, :upload
 
     include ActiveModel::Model
-    include ActiveModel::AttributeAssignment
-    include ActiveModel::Validations::Callbacks
-
     include BulkUpdate::AddTrainees::Config
 
     validate :validate_file!
@@ -25,9 +22,7 @@ module BulkUpdate
       upload.attributes = upload_attributes
       upload.save!
 
-      BulkUpdate::AddTrainees::ImportRowsJob.perform_later(upload)
-
-      upload
+      BulkUpdate::BulkAddTraineesImportRowsForm.new(upload:).save
     end
 
     def csv

--- a/app/models/bulk_update/trainee_upload.rb
+++ b/app/models/bulk_update/trainee_upload.rb
@@ -27,6 +27,7 @@
 
 class BulkUpdate::TraineeUpload < ApplicationRecord
   enum :status, {
+    uploaded: "uploaded",
     pending: "pending",
     validated: "validated",
     in_progress: "in_progress",
@@ -34,6 +35,10 @@ class BulkUpdate::TraineeUpload < ApplicationRecord
     cancelled: "cancelled",
     failed: "failed",
   } do
+    event :import do
+      transition %i[uploaded] => :pending
+    end
+
     event :process do
       transition %i[pending] => :validated
     end

--- a/app/views/bulk_update/add_trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/add_trainees/uploads/show.html.erb
@@ -38,11 +38,7 @@
       </h1>
 
       <p class="govuk-body">
-      <% if @bulk_update_trainee_upload.trainee_upload_rows.present? %>
-        You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.trainee_upload_rows.size, "trainee") %>.
-      <% else %>
         You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.number_of_trainees, "trainee") %>.
-      <% end %>
       </p>
 
       <p class="govuk-body">

--- a/app/views/bulk_update/add_trainees/uploads/show.html.erb
+++ b/app/views/bulk_update/add_trainees/uploads/show.html.erb
@@ -38,7 +38,11 @@
       </h1>
 
       <p class="govuk-body">
+      <% if @bulk_update_trainee_upload.trainee_upload_rows.present? %>
         You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.trainee_upload_rows.size, "trainee") %>.
+      <% else %>
+        You uploaded a CSV file with details of <%= pluralize(@bulk_update_trainee_upload.number_of_trainees, "trainee") %>.
+      <% end %>
       </p>
 
       <p class="govuk-body">

--- a/db/migrate/20250122151655_change_bulk_update_trainee_uploads_status_default.rb
+++ b/db/migrate/20250122151655_change_bulk_update_trainee_uploads_status_default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeBulkUpdateTraineeUploadsStatusDefault < ActiveRecord::Migration[7.2]
   def change
     change_column_default :bulk_update_trainee_uploads, :status, from: "pending", to: "uploaded"

--- a/db/migrate/20250122151655_change_bulk_update_trainee_uploads_status_default.rb
+++ b/db/migrate/20250122151655_change_bulk_update_trainee_uploads_status_default.rb
@@ -1,0 +1,5 @@
+class ChangeBulkUpdateTraineeUploadsStatusDefault < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default :bulk_update_trainee_uploads, :status, from: "pending", to: "uploaded"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_20_170132) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_22_151655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -259,7 +259,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_20_170132) do
 
   create_table "bulk_update_trainee_uploads", force: :cascade do |t|
     t.bigint "provider_id", null: false
-    t.string "status", default: "pending"
+    t.string "status", default: "uploaded"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "submitted_at"

--- a/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
+++ b/spec/components/bulk_update/trainee_uploads/row/view_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
 
     let(:statuses) do
       {
+        "uploaded" => "Uploaded",
         "pending" => "Pending",
         "validated" => "Validated",
         "in_progress" => "In progress",
@@ -61,6 +62,7 @@ RSpec.describe BulkUpdate::TraineeUploads::Row::View, type: :component do
 
       def upload_path(upload)
         {
+          "uploaded" => bulk_update_add_trainees_upload_path(upload),
           "pending" => bulk_update_add_trainees_upload_path(upload),
           "validated" => bulk_update_add_trainees_upload_path(upload),
           "in_progress" => bulk_update_add_trainees_submission_path(upload),

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -44,6 +44,10 @@ FactoryBot.define do
       end
     end
 
+    trait :uploaded do
+      status { "uploaded" }
+    end
+
     trait :pending do
       status { "pending" }
     end

--- a/spec/factories/bulk_update/trainee_uploads.rb
+++ b/spec/factories/bulk_update/trainee_uploads.rb
@@ -13,19 +13,26 @@ FactoryBot.define do
     provider
 
     after(:build) do |upload|
+      file = Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees.csv").open
+
       upload.file.attach(
-        io: Rails.root.join(
-          "spec/fixtures/files/bulk_update/trainee_uploads/five_trainees.csv",
-        ).open,
-        filename: "five_trainees.csv",
+        io: file,
+        filename: File.basename(file.path),
       )
     end
 
+    after(:create) do |upload|
+      upload.number_of_trainees = CSV.parse(upload.file.download, headers: true).count
+      upload.save!
+    end
+
     trait(:with_errors) do
-      after(:build) do |bulk_update_trainee_upload|
-        bulk_update_trainee_upload.attach(
-          io: Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open,
-          filename: "five_trainees_with_two_errors.csv",
+      after(:build) do |upload|
+        file = Rails.root.join("spec/fixtures/files/bulk_update/trainee_uploads/five_trainees_with_two_errors.csv").open
+
+        upload.file.attach(
+          io: file,
+          filename: File.basename(file.path),
         )
       end
     end

--- a/spec/forms/bulk_update/bulk_add_trainees_import_rows_form_spec.rb
+++ b/spec/forms/bulk_update/bulk_add_trainees_import_rows_form_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::BulkAddTraineesImportRowsForm, type: :model do
+  subject { described_class.new(upload:) }
+
+  context "when the BulkUpdate::TraineeUpload status is 'uploaded'" do
+    let(:upload) { create(:bulk_update_trainee_upload) }
+
+    it "changes the BulkUpdate::TraineeUpload status to 'pending'" do
+      expect {
+        subject.save
+      }
+      .to change { upload.status }.to("pending")
+      .and have_enqueued_job(BulkUpdate::AddTrainees::ImportRowsJob).once.with(upload)
+    end
+  end
+
+  context "when the BulkUpdate::TraineeUpload status is not 'uploaded'" do
+    let(:upload) { create(:bulk_update_trainee_upload, :validated) }
+
+    before do
+      allow(BulkUpdate::AddTrainees::ImportRowsJob).to receive(:perform_later)
+    end
+
+    it "does not change the BulkUpdate::TraineeUpload status to 'pending'" do
+      expect {
+        subject.save
+      } .to raise_error(RuntimeError, "Invalid transition")
+
+      expect(BulkUpdate::AddTrainees::ImportRowsJob).not_to have_received(:perform_later)
+    end
+  end
+end

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BulkUpdate::TraineeUpload do
   end
 
   describe "events" do
-    subject { create(:bulk_update_trainee_upload, :uploaded) }
+    subject { create(:bulk_update_trainee_upload) }
 
     let!(:user) { create(:user) }
 

--- a/spec/services/bulk_update/add_trainees/import_rows_spec.rb
+++ b/spec/services/bulk_update/add_trainees/import_rows_spec.rb
@@ -90,6 +90,10 @@ module BulkUpdate
             let(:trainee_upload) { create(:bulk_update_trainee_upload, :with_errors) }
 
             before do
+              trainee_upload.import!
+            end
+
+            before do
               allow(ImportRow).to receive(:call).and_return(
                 BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
                 BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),

--- a/spec/services/bulk_update/add_trainees/import_rows_spec.rb
+++ b/spec/services/bulk_update/add_trainees/import_rows_spec.rb
@@ -91,9 +91,6 @@ module BulkUpdate
 
             before do
               trainee_upload.import!
-            end
-
-            before do
               allow(ImportRow).to receive(:call).and_return(
                 BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
                 BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),


### PR DESCRIPTION
### Context

[8067-separate-the-validation-background-job-from-bulkupdatebulkaddtraineesuploadform](https://trello.com/c/nuZnB0jk/8067-separate-the-validation-background-job-from-bulkupdatebulkaddtraineesuploadform)

There is the requirement to split the upload of the CSV file into two steps by first uploading the file and then validating the actual trainee records. This PR extracts the creation of `BulkUpdate::TraineeUploadRow` and `BulkUpdate::RowError` records to a form object. Because we have dependent tests on the current flow, the newly introduced form object `BulkUpdate:: BulkAddTraineesImportRowsForm` will be temporarily called in `BulkUpdate::TraineeUploadForm`. 

### Changes proposed in this pull request

* Change default value of `BulkUpdate::TraineeUpload#status` to `uploaded`
* Move `BulkUpdate::AddTrainees::ImportRowsJob` to `BulkUpdate:: BulkAddTraineesImportRowsForm`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
