### PR TITLE
[TRS][8083] - Client and Settings

### DIFF
--- a/app/lib/trs/client.rb
+++ b/app/lib/trs/client.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Trs
+  class Client
+    class Request
+      include HTTParty
+      base_uri Settings.trs.base_url
+      headers "Accept" => "application/json",
+              "Content-Type" => "application/json;odata.metadata=minimal",
+              "X-Api-Version" => Settings.trs.version,
+              "Authorization" => "Bearer #{Settings.trs.api_key}"
+    end
+
+    class HttpError < StandardError; end
+
+    GET_SUCCESSES = [200].freeze
+    PUT_SUCCESSES = [200, 201].freeze
+    PATCH_SUCCESSES = [204].freeze
+
+    def self.get(...)
+      response = Request.get(...)
+
+      handle_response(response: response, statuses: GET_SUCCESSES)
+    end
+
+    def self.put(...)
+      response = Request.put(...)
+
+      handle_response(response: response, statuses: PUT_SUCCESSES)
+    end
+
+    def self.patch(...)
+      response = Request.patch(...)
+
+      handle_response(response: response, statuses: PATCH_SUCCESSES)
+    end
+
+    def self.handle_response(response:, statuses:)
+      return JSON.parse(response.body || "{}") if statuses.include?(response.code)
+
+      raise(HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}")
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,7 +34,7 @@ dqt:
   api_key: <get from secrets>
 
 trs:
-  base_url: https://teacher-qualifications-api.education.gov.uk/
+  base_url: https://teacher-qualifications-api.education.gov.uk
   api_key: <get from secrets>
   version: Next
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,8 +30,13 @@ hesa:
   password: <get from secrets>
 
 dqt:
-  base_url: https://qualified-teachers-api-dev.london.cloudapps.digital
+  base_url: https://teacher-qualifications-api.education.gov.uk/
   api_key: <get from secrets>
+
+trs:
+  base_url: https://teacher-qualifications-api.education.gov.uk/
+  api_key: <get from secrets>
+  version: Next
 
 azure:
   storage:

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -15,6 +15,9 @@ dfe_sign_in:
 dqt:
   base_url: https://teacher-qualifications-api.education.gov.uk/
 
+trs:
+  base_url: https://teacher-qualifications-api.education.gov.uk/
+
 features:
   sign_in_method: dfe-sign-in
   basic_auth: false

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -8,6 +8,9 @@ dttp:
 dqt:
   base_url: https://preprod.teacher-qualifications-api.education.gov.uk
 
+trs:
+  base_url: https://preprod.teacher-qualifications-api.education.gov.uk/
+
 dfe_sign_in:
   # URL that the users are redirected to for signing in
   issuer: https://oidc.signin.education.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -9,6 +9,9 @@ dttp:
 dqt:
   base_url: https://test.teacher-qualifications-api.education.gov.uk/
 
+trs:
+  base_url: https://test.teacher-qualifications-api.education.gov.uk/
+
 features:
   home_text: true
   sign_in_method: persona

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -1,6 +1,9 @@
 dqt:
   base_url: https://test.teacher-qualifications-api.education.gov.uk/
 
+trs:
+  base_url: https://test.teacher-qualifications-api.education.gov.uk/
+
 features:
   home_text: true
   sign_in_method: persona

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -4,6 +4,9 @@ base_url: https://sandbox.register-trainee-teachers.service.gov.uk
 dqt:
   base_url: https://preprod.teacher-qualifications-api.education.gov.uk
 
+trs:
+  base_url: https://preprod.teacher-qualifications-api.education.gov.uk/
+
 dfe_sign_in:
   # URL that the users are redirected to for signing in
   issuer: https://oidc.signin.education.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -15,6 +15,9 @@ dfe_sign_in:
 dqt:
   base_url: https://preprod.teacher-qualifications-api.education.gov.uk
 
+trs:
+  base_url: https://preprod.teacher-qualifications-api.education.gov.uk/
+
 features:
   sign_in_method: dfe-sign-in
   basic_auth: false

--- a/spec/lib/trs/client_spec.rb
+++ b/spec/lib/trs/client_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Trs::Client, type: :model do
+  describe "Request" do
+    it "has the correct base_uri" do
+      expect(Trs::Client::Request.base_uri).to eq(Settings.trs.base_url)
+    end
+
+    it "includes the correct headers" do
+      headers = Trs::Client::Request.headers
+      expect(headers["Accept"]).to eq("application/json")
+      expect(headers["Content-Type"]).to eq("application/json;odata.metadata=minimal")
+      expect(headers["X-Api-Version"]).to eq(Settings.trs.version)
+      expect(headers["Authorization"]).to eq("Bearer #{Settings.trs.api_key}")
+    end
+  end
+
+  describe "handle_response" do
+    let(:success_response) { double("response", code: 200, body: '{"key":"value"}', headers: {}) }
+    let(:failure_response) { double("response", code: 500, body: "Internal Server Error", headers: {}) }
+
+    it "parses the response body on success" do
+      result = Trs::Client.handle_response(response: success_response, statuses: [200])
+      expect(result).to eq({ "key" => "value" })
+    end
+
+    it "raises an error on failure" do
+      expect {
+        Trs::Client.handle_response(response: failure_response, statuses: [200])
+      }.to raise_error(Trs::Client::HttpError, /status: 500/)
+    end
+  end
+
+  describe "self methods" do
+    let(:success_response) { double("response", code: 200, body: '{"key":"value"}', headers: {}) }
+    let(:failure_response) { double("response", code: 500, body: "Internal Server Error", headers: {}) }
+    let(:url) { "/test_endpoint" }
+    let(:options) { { query: { param1: "value1" } } }
+
+    before do
+      allow(Trs::Client::Request).to receive(:get).with(url, options).and_return(success_response)
+      allow(Trs::Client::Request).to receive(:put).with(url, options).and_return(success_response)
+      allow(Trs::Client::Request).to receive(:patch).with(url, options).and_return(failure_response)
+    end
+
+    it "calls get method and handles response" do
+      expect(Trs::Client::Request).to receive(:get).with(url, options)
+      result = Trs::Client.get(url, options)
+      expect(result).to eq({ "key" => "value" })
+    end
+
+    it "calls put method and handles response" do
+      expect(Trs::Client::Request).to receive(:put).with(url, options)
+      result = Trs::Client.put(url, options)
+      expect(result).to eq({ "key" => "value" })
+    end
+
+    it "calls patch method and raises error on failure" do
+      expect(Trs::Client::Request).to receive(:patch).with(url, options)
+      expect {
+        Trs::Client.patch(url, options)
+      }.to raise_error(Trs::Client::HttpError, /status: 500/)
+    end
+  end
+end


### PR DESCRIPTION
### Context
The transition from DQT to TRS requires new client. This ticket covers the creation of a new client.

### Changes proposed in this pull request
Adds a new namespace and offers new client for `TRS`

### Guidance to review

Can be tested locally:

Add to `config/settings/development.local.yml`:

```yml
trs:
  base_url: https://preprod.teacher-qualifications-api.education.gov.uk
  api_key: <get from staging secrets or ask @d-a-v-e >
```

In console run:

```ruby
Trs::Client.get("/v3/persons/1234567")
```

Can expect back:

<img width="1168" alt="Screenshot 2025-01-23 at 14 36 07" src="https://github.com/user-attachments/assets/729b976e-413e-4f9b-a81d-60451c6c332c" />

### Notes

* The specs for `client.rb` are heavily stubbed - test for the endpoint files we will create later may be more useful.
* Trello: https://trello.com/c/hIZrG9qE/8083-trs-client
