### PR TITLE
[8051] Skip placement row that has been set ADDED MANUALLY

### DIFF
--- a/app/models/reports/bulk_placement_report.rb
+++ b/app/models/reports/bulk_placement_report.rb
@@ -18,6 +18,8 @@ module Reports
       "The URN of the trainee’s second placement school.\n\n\nURNs must be 6 digits long.\n\n\nIf you do not know the placement school’s URN, leave the cell empty.",
     ].freeze
 
+    ADDED_MANUALLY = "ADDED MANUALLY"
+
     def initialize(csv, scope:)
       @csv = csv
       @scope = scope
@@ -49,10 +51,9 @@ module Reports
 
     def placement(trainee, position)
       placement = trainee.placements.send(position)
-
       return unless placement
 
-      placement&.school&.urn.presence || "ADDED MANUALLY"
+      placement&.school&.urn.presence || ADDED_MANUALLY
     end
   end
 end

--- a/app/services/bulk_update/placements/create_placement_rows.rb
+++ b/app/services/bulk_update/placements/create_placement_rows.rb
@@ -18,6 +18,7 @@ module BulkUpdate
           # Row will provide us with a special method to loop over any/all URNS
           # present in the CSV row
           row = Row.new(row)
+
           csv_row_number = index + Config::FIRST_CSV_ROW_NUMBER
 
           create_bulk_placement_rows!(row, csv_row_number)
@@ -34,6 +35,8 @@ module BulkUpdate
       # so we loop over these to create an individual row for each.
       def create_bulk_placement_rows!(row, csv_row_number)
         row.urns.each do |urn|
+          next if row.trn == Reports::BulkPlacementReport::ADDED_MANUALLY
+
           bulk_placement.rows.create(
             trn: row.trn,
             urn: urn,

--- a/db/data/20250123124723_remove_failed_placement_with_urn_added_manually.rb
+++ b/db/data/20250123124723_remove_failed_placement_with_urn_added_manually.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveFailedPlacementWithUrnAddedManually < ActiveRecord::Migration[7.2]
+  def up
+    BulkUpdate::PlacementRow.failed.where(urn: "ADDED MANUALLY").delete_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -145,6 +145,11 @@ FactoryBot.define do
       placements { create_list(:placement, 2, :with_school) }
     end
 
+    trait :with_manual_placements do
+      has_placement_detail
+      placements { create_list(:placement, 2) }
+    end
+
     trait :submission_ready do
       submission_ready { true }
     end

--- a/spec/services/bulk_update/placements/create_placement_rows_spec.rb
+++ b/spec/services/bulk_update/placements/create_placement_rows_spec.rb
@@ -48,6 +48,22 @@ module BulkUpdate
             )
           end
         end
+
+        context "given a csv with urns set as `ADDED MANUALLY`" do
+          let(:trainees) { create_list(:trainee, 3, :trn_received, :with_manual_placements) }
+          let(:csv) { [] }
+          let(:generate_report) { ::Reports::BulkPlacementReport.new(csv, scope: trainees).generate_report }
+
+          before do
+            generate_report
+            service
+          end
+
+          it "does not create placement rows" do
+            expect(csv).not_to be_empty
+            expect(bulk_placement.rows).to be_empty
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
Pointless Placement rows
### Changes proposed in this pull request
Skip placement row that has been set `ADDED MANUALLY`

### Guidance to review
A csv with urn set to `ADDED MANUALLY` was attempted to be bulk uploaded.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
