### PR TITLE
[8086] Add a separate screen to perform the validation of the CSV trainee records from the bulk upload

### DIFF
--- a/app/controllers/bulk_update/add_trainees/imports_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/imports_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module AddTrainees
+    class ImportsController < ApplicationController
+      before_action { require_feature_flag(:bulk_add_trainees) }
+
+      def create
+        BulkUpdate::BulkAddTraineesImportRowsForm.new(
+          upload: authorize(
+            bulk_update_trainee_upload,
+            policy_class: BulkUpdate::Imports::TraineeUploadPolicy,
+          ),
+        ).save
+
+        redirect_to(
+          bulk_update_add_trainees_upload_path(
+            bulk_update_trainee_upload,
+          ), flash: { success: t(".success") }
+        )
+      end
+
+    private
+
+      def bulk_update_trainee_upload
+        @bulk_update_trainee_upload ||= policy_scope(BulkUpdate::TraineeUpload)
+          .find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/bulk_update/add_trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/uploads_controller.rb
@@ -33,10 +33,10 @@ module BulkUpdate
 
         authorize(@bulk_add_trainee_upload_form.upload)
 
-        if @bulk_add_trainee_upload_form.valid?
-          upload = @bulk_add_trainee_upload_form.save
-
-          redirect_to(bulk_update_add_trainees_upload_path(upload), flash: { success: t(".success") })
+        if @bulk_add_trainee_upload_form.save
+          redirect_to(
+            bulk_update_add_trainees_upload_path(@bulk_add_trainee_upload_form.upload), flash: { success: t(".success") }
+          )
         else
           render(:new)
         end

--- a/app/forms/bulk_update/bulk_add_trainees_import_rows_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_import_rows_form.rb
@@ -13,7 +13,7 @@ module BulkUpdate
 
       BulkUpdate::AddTrainees::ImportRowsJob.perform_later(upload)
 
-      upload
+      true
     end
   end
 end

--- a/app/policies/bulk_update/imports/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/imports/trainee_upload_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module Imports
+    class TraineeUploadPolicy < TraineeUploads::BasePolicy
+      def create?
+        user.hei_provider? && trainee_upload.uploaded?
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2009,9 +2009,12 @@ en:
     add_trainees:
       uploads:
         create:
-          success: File uploaded
+          success: &file_uploaded File uploaded
         destroy:
           success: Bulk updates to records have been cancelled
+      imports:
+        create:
+          success: *file_uploaded
   system_admin:
     users:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
     namespace :add_trainees, path: "add-trainees" do
       resources :uploads, only: %i[index show new create destroy] do
         member do
+          resource :imports, only: :create
           resource :submission, only: %i[show create]
           resource :details, only: :show
         end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -443,6 +443,16 @@ feature "bulk add trainees" do
         when_i_click_the_review_errors_link
         then_i_see_the_review_errors_page_with_one_error
       end
+
+      context "with an upload with an uploaded status" do
+        let(:upload) { create(:bulk_update_trainee_upload, provider: current_user.organisation) }
+
+        scenario "attempt import the rows of an upload" do
+          when_a_request_is_made_to_the_imports_action(upload:)
+          and_i_visit_the_summary_page(upload:)
+          then_i_see_that_the_upload_is_processing(upload:)
+        end
+      end
     end
 
     context "when the User is not authenticated", js: true do
@@ -455,6 +465,10 @@ feature "bulk add trainees" do
   end
 
 private
+
+  def when_a_request_is_made_to_the_imports_action(upload:)
+    page.driver.post(bulk_update_add_trainees_imports_path(upload))
+  end
 
   def then_i_see_the_root_page
     expect(page).to have_content("Your trainee teachers")
@@ -630,20 +644,20 @@ private
     click_on "Back to bulk updates page"
   end
 
-  def then_i_see_that_the_upload_is_processing
+  def then_i_see_that_the_upload_is_processing(upload: BulkUpdate::TraineeUpload.last)
     expect(page).to have_content("File uploaded")
     expect(page).to have_content("Your file is being processed")
-    expect(page).to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.filename}.")
+    expect(page).to have_content("We're currently processing #{upload.filename}.")
     expect(page).to have_content("This is taking longer than usual")
     expect(page).to have_content("You'll receive an email to tell you when this is complete.")
     expect(page).to have_content("You can also check the status of new trainee files.")
     expect(page).to have_link("Back to bulk updates page")
   end
 
-  def and_i_dont_see_that_the_upload_is_processing
+  def and_i_dont_see_that_the_upload_is_processing(upload: BulkUpdate::TraineeUpload.last)
     expect(page).not_to have_content("File uploaded")
     expect(page).not_to have_content("Your file is being processed")
-    expect(page).not_to have_content("We're currently processing #{BulkUpdate::TraineeUpload.last.filename}.")
+    expect(page).not_to have_content("We're currently processing #{upload.filename}.")
     expect(page).not_to have_content("This is taking longer than usual")
     expect(page).not_to have_content("You'll receive an email to tell you when this is complete.")
     expect(page).not_to have_content("You can also check the status of new trainee files.")

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BulkUpdate::TraineeUpload do
   end
 
   describe "events" do
-    subject { create(:bulk_update_trainee_upload) }
+    subject { create(:bulk_update_trainee_upload, :uploaded) }
 
     let!(:user) { create(:user) }
 

--- a/spec/models/bulk_update/trainee_upload_spec.rb
+++ b/spec/models/bulk_update/trainee_upload_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BulkUpdate::TraineeUpload do
   end
 
   describe "events" do
-    subject { create(:bulk_update_trainee_upload, :uploaded) }
+    subject { create(:bulk_update_trainee_upload) }
 
     let!(:user) { create(:user) }
 

--- a/spec/policies/bulk_update/imports/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/imports/trainee_upload_policy_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkUpdate::Imports::TraineeUploadPolicy, type: :policy do
+  subject { described_class }
+
+  it { is_expected.to be < BulkUpdate::TraineeUploads::BasePolicy }
+
+  context "when the User's organisation is an HEI Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user, :hei), session: {}) }
+
+    context "when the upload is uploaded" do
+      let(:trainee_upload) { build(:bulk_update_trainee_upload, :uploaded) }
+
+      permissions :create? do
+        it { is_expected.to permit(user, trainee_upload) }
+      end
+    end
+
+    %i[pending validated in_progress succeeded cancelled failed].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+        permissions :create? do
+          it { is_expected.not_to permit(user, trainee_upload) }
+        end
+      end
+    end
+  end
+
+  context "when the User's organisation is not an HEI Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user), session: {}) }
+
+    %i[uploaded pending validated in_progress succeeded cancelled failed].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+        permissions :create? do
+          it { is_expected.not_to permit(user, trainee_upload) }
+        end
+      end
+    end
+  end
+
+  context "when the User's organisation is not a Provider" do
+    let(:user) { UserWithOrganisationContext.new(user: create(:user, :with_lead_partner_organisation), session: {}) }
+    let(:trainee_upload) { build(:bulk_update_trainee_upload, provider: user.providers.first) }
+
+    %i[uploaded pending validated in_progress succeeded failed cancelled].each do |status|
+      context "when the upload is #{status}" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+        permissions :create? do
+          it { is_expected.not_to permit(user, trainee_upload) }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/bulk_update/add_trainees/import_rows_spec.rb
+++ b/spec/services/bulk_update/add_trainees/import_rows_spec.rb
@@ -91,6 +91,7 @@ module BulkUpdate
 
             before do
               trainee_upload.import!
+
               allow(ImportRow).to receive(:call).and_return(
                 BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
                 BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),


### PR DESCRIPTION
### Context

[8086-add-a-separate-screen-to-perform-the-validation-of-the-csv-trainee-records-from-the-bulk-upload](https://trello.com/c/Mxjk90zh/8086-add-a-separate-screen-to-perform-the-validation-of-the-csv-trainee-records-from-the-bulk-upload)

Perform the importing of rows and validate the trainee records to be created in a separate action 

### Changes proposed in this pull request

* Add `BulkUpdate::AddTrainees::ImportsController#create`
* Add `BulkUpdate::Imports::TraineeUploadPolicy`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
