### PR TITLE
[xxxx] Fixed by ensuring that there is some data integrity for secondary courses vs primary courses

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
     end
 
     trait :secondary do
-      name { PUBLISH_SECONDARY_SUBJECT_SPECIALISM_MAPPING.keys.sample }
+      name { (PUBLISH_SECONDARY_SUBJECT_SPECIALISM_MAPPING.keys - [PublishSubjects::MODERN_LANGUAGES]).sample }
     end
 
     trait :with_full_time_dates do

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :subject do
-    name { (PUBLISH_SUBJECT_SPECIALISM_MAPPING.keys - PUBLISH_PRIMARY_SUBJECT_SPECIALISM_MAPPING.keys).sample }
+    name { (PUBLISH_SUBJECT_SPECIALISM_MAPPING.keys - PUBLISH_PRIMARY_SUBJECT_SPECIALISM_MAPPING.keys + [PublishSubjects::MODERN_LANGUAGES]).sample }
     code { Faker::Alphanumeric.unique.alphanumeric(number: 5).upcase }
 
     trait :music do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -291,7 +291,7 @@ FactoryBot.define do
 
     trait :with_publish_course_details do
       training_route { TRAINING_ROUTES_FOR_COURSE.keys.sample }
-      course_uuid { create(:course_with_subjects, route: training_route, accredited_body_code: provider.code).uuid }
+      course_uuid { create(:course_with_subjects, :secondary, route: training_route, accredited_body_code: provider.code).uuid }
       with_secondary_course_details
     end
 

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -154,7 +154,8 @@ private
     end
 
     if page.current_path.include?("language-specialism")
-      language_specialism_page.language_select_one.select(language_specialism_options.to_h.keys.compact_blank.sample)
+      language_specialism = language_specialism_options.to_h.keys.compact_blank.sample
+      language_specialism_page.language_select_one.select(language_specialism)
       language_specialism_page.submit_button.click
     end
   end


### PR DESCRIPTION
### Context
Flakey tests

### Changes proposed in this pull request
The factory was producing data with questionable integrity

### Guidance to review
Run this a billion times, this only reduces the collision of poor data integrity.

```bash
bundle exec rspec ./spec/features/trainee_actions/change_course_spec.rb:11
```

The issue is something along the lines of
- the trainee created was using a publish course that maybe primary but should of been a secondary
- the new publish course created for the trainee to use maybe primary but should of been a secondary
- the subject that was created was a maybe modern language

- subject cannot be a modern language as it is not a real thing
- a publish course can be a modern language only as a second
- a primary or a secondary course should use the respective subjects

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
