### PR TITLE
[8110] Content updates for `pending` page for new flow

### DIFF
--- a/app/components/bulk_update/trainee_uploads/show/in_progress/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/show/in_progress/view.html.erb
@@ -27,7 +27,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to "Back to bulk updates page", bulk_update_path %>
+      <%= govuk_link_to "Back to bulk updates page", bulk_update_path %>
     </p>
   </div>
 </div>

--- a/app/components/bulk_update/trainee_uploads/show/pending/view.html.erb
+++ b/app/components/bulk_update/trainee_uploads/show/pending/view.html.erb
@@ -22,7 +22,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to "Back to bulk updates page", bulk_update_path %>
+      <%= govuk_link_to "Back to bulk updates page", bulk_update_path %>
     </p>
   </div>
 </div>

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -491,16 +491,6 @@ feature "bulk add trainees" do
         when_i_click_the_review_errors_link
         then_i_see_the_review_errors_page_with_one_error
       end
-
-      context "with an upload with an uploaded status" do
-        let(:upload) { create(:bulk_update_trainee_upload, provider: current_user.organisation) }
-
-        scenario "attempt import the rows of an upload" do
-          when_a_request_is_made_to_the_imports_action(upload:)
-          and_i_visit_the_summary_page(upload:)
-          then_i_see_that_the_upload_is_processing
-        end
-      end
     end
 
     context "when the User is not authenticated", js: true do


### PR DESCRIPTION
### Context

We need to update the content of the bulk trainee upload 'pending' (validation in progress) page to better fit with the new flow.

### Changes proposed in this pull request

![image](https://github.com/user-attachments/assets/031a7c95-2c2a-4955-ba50-412922a71f9f)


### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
