### PR TITLE
[8054] Amended the degree policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 config/initializers/developer_persona.rb
+config/initializers/sanitised_data_users_persona.rb
 
 # Localhost ssl related
 config/localhost/https/localhost.key

--- a/app/models/persona.rb
+++ b/app/models/persona.rb
@@ -27,7 +27,20 @@
 #  index_users_on_discarded_at     (discarded_at)
 #
 class Persona < User
-  def self.sanitised_user_ids = %w[600 874 296 732 846 605 1302 567 56 1199]
+  def self.notable_user_ids
+    popular_providers = Provider.kept
+      .joins(:trainees)
+      .group(:id)
+      .order("COUNT(trainees.id) DESC")
+      .limit(10)
 
-  default_scope { where(email: PERSONA_EMAILS).or(where(id: sanitised_user_ids)) }
+    user_ids = popular_providers
+      .flat_map { |provider| provider.users.kept.sample.id }
+
+    user_ids += PERSONA_IDS
+
+    user_ids
+  end
+
+  default_scope { where(email: PERSONA_EMAILS).or(where(id: notable_user_ids)) }
 end

--- a/app/policies/degrees/trainee_policy.rb
+++ b/app/policies/degrees/trainee_policy.rb
@@ -2,10 +2,10 @@
 
 class Degrees::TraineePolicy < TraineePolicy
   def new?
-    (user.system_admin? || user.accredited_provider?) && !user_is_read_only?
+    (user.system_admin? || user_in_provider_context?) && !user_is_read_only?
   end
 
   def create?
-    (user.system_admin? || (user_in_provider_context? && user.accredited_provider?)) && !user_is_read_only?
+    (user.system_admin? || user_in_provider_context?) && !user_is_read_only?
   end
 end

--- a/config/initializers/personas.rb
+++ b/config/initializers/personas.rb
@@ -13,3 +13,4 @@ PERSONAS = [
 ].push((DEVELOPER_PERSONA if defined?(DEVELOPER_PERSONA))).compact.freeze
 
 PERSONA_EMAILS = PERSONAS.map { |persona| persona[:email] }
+PERSONA_IDS = defined?(SANITISED_DATA_USERS_IDS_PERSONA) ? SANITISED_DATA_USERS_IDS_PERSONA : []

--- a/docs/setup-development.md
+++ b/docs/setup-development.md
@@ -130,6 +130,17 @@ Then run the following command to populate the database:
 ```bash
 psql register_trainee_teacher_data_development < ~/Downloads/backup_sanitised.sql
 ```
+#### Using a sanitised data users as persona (optional)
+
+This will allow you to use an existing user - useful for support dev, user and provider testing and debugging
+
+create the file `config/initializers/sanitised_data_users_persona.rb`
+
+```ruby
+SANITISED_DATA_USERS_IDS_PERSONA = [
+  # add the user id
+]
+```
 
 ## Schools data
 [Get Information about Schools](https://get-information-schools.service.gov.uk) holds the most complete information for schools.

--- a/spec/models/persona_spec.rb
+++ b/spec/models/persona_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Persona do
+  describe ".notable_user_ids" do
+    let(:persona_user) { create(:user) }
+    let(:not_notable_user) { create(:user) }
+    let(:notable_users) { create_list(:user, 10) }
+
+    let(:notable_user_ids) { notable_users.pluck(:id) }
+    let(:popular_providers) { notable_users.flat_map(&:providers) }
+
+    before do
+      persona_user
+      popular_providers.each do |provider|
+        create_list(:trainee, 5, provider:)
+      end
+      create_list(:trainee, 4, provider: not_notable_user.providers.first)
+    end
+
+    subject { described_class.notable_user_ids }
+
+    it "returns notable user ids" do
+      expect(subject).to match_array(notable_user_ids)
+    end
+
+    context "with PERSONA_IDS" do
+      it "returns the persona user ids & notable user ids" do
+        stub_const("PERSONA_IDS", [persona_user.id])
+        expect(subject).to match_array([persona_user.id] + notable_user_ids)
+      end
+    end
+  end
+
+  describe ".default_scope" do
+    let(:persona_user) { create(:user) }
+    let(:notable_users) { create_list(:user, 10) }
+
+    let(:notable_user_ids) { notable_users.pluck(:id) }
+    let(:popular_providers) { notable_users.flat_map(&:providers) }
+
+    before do
+      persona_user
+      popular_providers.each do |provider|
+        create_list(:trainee, 5, provider:)
+      end
+    end
+
+    subject { described_class.pluck(:id) }
+
+    it "returns notable user ids" do
+      expect(subject).to match_array(notable_user_ids)
+    end
+
+    context "with PERSONA_EMAILS" do
+      it "returns persona user ids & notable user ids" do
+        stub_const("PERSONA_EMAILS", [persona_user.email])
+        expect(subject).to match_array([persona_user.id] + notable_user_ids)
+      end
+    end
+
+    context "with PERSONA_IDS" do
+      it "returns the persona user ids & notable user ids" do
+        stub_const("PERSONA_IDS", [persona_user.id])
+        expect(subject).to match_array([persona_user.id] + notable_user_ids)
+      end
+    end
+  end
+end

--- a/spec/policies/degrees/trainee_policy_spec.rb
+++ b/spec/policies/degrees/trainee_policy_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Degrees::TraineePolicy, type: :policy do
   permissions :new?, :create? do
     it { is_expected.to permit(provider_user, provider_trainee) }
     it { is_expected.to permit(system_admin_user, provider_trainee) }
+    it { is_expected.to permit(unaccredited_provider_user, unaccredited_provider_trainee) }
 
     it { is_expected.not_to permit(lead_partner_user, lead_partner_trainee) }
     it { is_expected.not_to permit(read_only_provider_user, provider_trainee) }
-    it { is_expected.not_to permit(unaccredited_provider_user, unaccredited_provider_trainee) }
   end
 end


### PR DESCRIPTION
### Context
Degree policies

### Changes proposed in this pull request
Relax the degree policies

### Guidance to review
As long as the trainee is created, then the provider of which the trainee belongs to can create and amend the trainee's degree.

1. Take a copy of the `Sanitised Data`
2. Setup `config/initializers/sanitised_data_users_persona.rb`
```ruby
SANITISED_DATA_USERS_IDS_PERSONA = [1813]
```
3. Log in as user
4. CRUD those degrees for traine with slug `zuYybg6JnTNP7DS1sGHLS1c5`

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
