### PR TITLE
[8125] Change postgrad and undergrad on training routes page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1235,9 +1235,9 @@ en:
           provider_led_undergrad: *provider_led_hint
         lede: Primary and secondary training is run by higher education institutions (HEIs) or school centred initial teacher training (SCITTs) providers.
         training_course_routes:
-          postgrad_fee_funded: Postgrad (fee funded)
-          postgrad_salaried: Postgrad (salaried)
-          undergrad_fee_funded: Undergrad (fee funded)
+          postgrad_fee_funded: Postgraduate (fee funded)
+          postgrad_salaried: Postgraduate (salaried)
+          undergrad_fee_funded: Undergraduate (fee funded)
           other: Other
     start_statuses:
       edit:
@@ -1315,13 +1315,13 @@ en:
           early_years_salaried: Early years graduate employment based
           early_years_undergrad: Early years undergraduate
           iqts: International qualified teacher status (iQTS)
-          provider_led_postgrad: &provider_led_postgrad Primary and secondary (postgrad)
-          provider_led_undergrad: &provider_led_undergrad Primary and secondary (undergrad)
+          provider_led_postgrad: &provider_led_postgrad Primary and secondary (postgraduate)
+          provider_led_undergrad: &provider_led_undergrad Primary and secondary (undergraduate)
           school_direct_salaried: School direct (salaried)
           school_direct_tuition_fee: School direct (fee funded)
-          pg_teaching_apprenticeship: Teaching apprenticeship (postgrad)
+          pg_teaching_apprenticeship: Teaching apprenticeship (postgraduate)
           hpitt_postgrad: HPITT
-          opt_in_undergrad: Opt-in (undergrad)
+          opt_in_undergrad: Opt-in (undergraduate)
           itt: &itt_routes
             assessment_only: Assessment only
             early_years_assessment_only: Early years assessment only
@@ -1329,9 +1329,9 @@ en:
             early_years_salaried: Early years
             early_years_undergrad: Early years
             iqts: International qualified teacher status (iQTS)
-            provider_led_postgrad: *provider_led_postgrad
-            provider_led_undergrad: *provider_led_undergrad
-            pg_teaching_apprenticeship: Teaching apprenticeship
+            provider_led_postgrad: &provider_led Primary and secondary
+            provider_led_undergrad: *provider_led
+            pg_teaching_apprenticeship: Teacher apprenticeship
             school_direct_salaried: School direct
             school_direct_tuition_fee: School direct (fee funded)
             hpitt_postgrad: HPITT

--- a/spec/view_objects/funding/trainee_summary_view_spec.rb
+++ b/spec/view_objects/funding/trainee_summary_view_spec.rb
@@ -81,7 +81,7 @@ module Funding
       let(:bursary_array) {
         [
           {
-            route: "Primary and secondary (postgrad)",
+            route: "Primary and secondary",
             subject: "Maths",
             lead_partner: "BAT Academy",
             trainees: maths_bursary_trainees,
@@ -102,7 +102,7 @@ module Funding
       let(:scholarship_array) do
         [
           {
-            route: "Primary and secondary (postgrad)",
+            route: "Primary and secondary",
             subject: "Biology",
             lead_partner: "Regminster College",
             trainees: biology_scholarship_trainees,
@@ -110,7 +110,7 @@ module Funding
             total: "£8,000",
           },
           {
-            route: "Primary and secondary (postgrad)",
+            route: "Primary and secondary",
             subject: "Maths",
             lead_partner: "BAT Academy",
             trainees: maths_scholarship_trainees,
@@ -131,7 +131,7 @@ module Funding
       let(:tiered_bursary_array) do
         [
           {
-            route: "Primary and secondary (postgrad)",
+            route: "Primary and secondary",
             tier: "Tier 1",
             trainees: biology_tiered_bursary_trainees,
             amount_per_trainee: "£1,000",
@@ -151,7 +151,7 @@ module Funding
       let(:grant_array) do
         [
           {
-            route: "Primary and secondary (postgrad)",
+            route: "Primary and secondary",
             subject: "Maths",
             trainees: maths_grant_trainees,
             amount_per_trainee: "£3,000",

--- a/spec/view_objects/funding/trainee_summary_view_spec.rb
+++ b/spec/view_objects/funding/trainee_summary_view_spec.rb
@@ -37,6 +37,8 @@ module Funding
       end
     end
 
+    let(:route) { "Primary and secondary" }
+
     subject { TraineeSummaryView.new(trainee_summary: summary) }
 
     describe "#summary" do
@@ -81,7 +83,7 @@ module Funding
       let(:bursary_array) {
         [
           {
-            route: "Primary and secondary",
+            route: route,
             subject: "Maths",
             lead_partner: "BAT Academy",
             trainees: maths_bursary_trainees,
@@ -102,7 +104,7 @@ module Funding
       let(:scholarship_array) do
         [
           {
-            route: "Primary and secondary",
+            route: route,
             subject: "Biology",
             lead_partner: "Regminster College",
             trainees: biology_scholarship_trainees,
@@ -110,7 +112,7 @@ module Funding
             total: "£8,000",
           },
           {
-            route: "Primary and secondary",
+            route: route,
             subject: "Maths",
             lead_partner: "BAT Academy",
             trainees: maths_scholarship_trainees,
@@ -131,7 +133,7 @@ module Funding
       let(:tiered_bursary_array) do
         [
           {
-            route: "Primary and secondary",
+            route: route,
             tier: "Tier 1",
             trainees: biology_tiered_bursary_trainees,
             amount_per_trainee: "£1,000",
@@ -151,7 +153,7 @@ module Funding
       let(:grant_array) do
         [
           {
-            route: "Primary and secondary",
+            route: route,
             subject: "Maths",
             trainees: maths_grant_trainees,
             amount_per_trainee: "£3,000",


### PR DESCRIPTION
### Context

[8125-change-postgrad-and-undergrad-on-training-routes-page](https://trello.com/c/ETP72qS0/8125-change-postgrad-and-undergrad-on-training-routes-page)

Make the suggested label changes based on the new design

https://register-pr-5028.test.teacherservices.cloud/trainees

### Changes proposed in this pull request
<img width="326" alt="Screenshot 2025-02-07 at 15 47 42" src="https://github.com/user-attachments/assets/fd123ae7-43a3-449c-b8b6-f4086f0d930c" />

https://register-pr-5028.test.teacherservices.cloud/trainees/lz1s1r6fxco148ug5sgys4ot/training-routes/edit

<img width="712" alt="Screenshot 2025-02-07 at 15 48 08" src="https://github.com/user-attachments/assets/ac6fd9fd-18f8-4b53-921f-ef2329f46996" />

### Guidance to review

* This change affects how the routes are been rendered in the funding summary page as well.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
