### PR TITLE
[xxxx] Removed QA holdup

### DIFF
--- a/.github/actions/deploy-before-production/action.yml
+++ b/.github/actions/deploy-before-production/action.yml
@@ -1,0 +1,40 @@
+name: Deploy Before Production
+description: Deploy application to other environments before production
+inputs:
+  environment: { description: 'Environment to deploy to', required: true }
+  skip-environments: { description: 'List of environments to skip', required: false, default: '[]' }
+  skip-environments-message: { description: 'Message to send when skipping environments', required: false, default: 'Deployment was skipped' }
+  azure-credentials: { description: 'Azure credentials', required: true }
+  slack-webhook: { description: 'Slack webhook URL', required: true }
+  smoke-test-username: { description: 'Smoke test username', required: true }
+  smoke-test-password: { description: 'Smoke test password', required: true }
+  basic-auth-username: { description: 'Basic auth username', required: true }
+  basic-auth-password: { description: 'Basic auth password', required: true }
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Deploy app to ${{ inputs.environment }}
+      id: deploy_app_before_production
+      if: ${{ !contains(inputs.skip-environments, inputs.environment) }}
+      uses: ./.github/actions/deploy/
+      with:
+        azure-credentials: ${{ inputs.azure-credentials }}
+        environment: ${{ inputs.environment }}
+        sha: ${{ github.sha }}
+        slack-webhook: ${{ inputs.slack-webhook }}
+        smoke-test-username: ${{ inputs.smoke-test-username }}
+        smoke-test-password: ${{ inputs.smoke-test-password }}
+        basic-auth-username: ${{ inputs.basic-auth-username }}
+        basic-auth-password: ${{ inputs.basic-auth-password }}
+
+    - name: Notify Slack channel on deployment skip
+      uses: ./.github/actions/send-slack-notification/
+      if: ${{ contains(inputs.skip-environments, inputs.environment) }}
+      with:
+        slack-title: 'Deployment skipped on ${{ inputs.environment }}'
+        slack-message: ':skip: ${{ inputs.skip-environments-message }}'
+        slack-webhook: ${{ inputs.slack-webhook }}
+        slack-color: '#FF9900'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -164,10 +164,7 @@ jobs:
 
   deploy-before-production:
     name: Parallel deployment before production
-    environment:
-      name: ${{ matrix.environment }}
-      url: ${{ steps.deploy_app_before_production.outputs.deploy-url }}
-    if: ${{ success() && github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: [test, next_academic_year_test]
     runs-on: ubuntu-latest
     strategy:
@@ -175,16 +172,15 @@ jobs:
       matrix:
         environment: [qa, staging]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Deploy app to ${{ matrix.environment }}
-      id: deploy_app_before_production
-      uses: ./.github/actions/deploy/
+    - name: Deploy before production
+      uses: ./.github/actions/deploy-before-production
       with:
-        azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
         environment: ${{ matrix.environment }}
-        sha: ${{ github.sha }}
+        # NOTE: Uncomment the below and make it required changes
+        #       Can use `@twd-register-devs` and such to inform,
+        # skip-environments: [qa]
+        # skip-environments-message: 'PUT SOMETHING MEANINGFUL'
+        azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
         smoke-test-username: ${{ secrets.SMOKE_TEST_USERNAME }}
         smoke-test-password: ${{ secrets.SMOKE_TEST_PASSWORD }}


### PR DESCRIPTION
### Context
`QA` was getting used for other reasons and was not used as part of the CI/CD pipeline as per norm.
Attempts was made to deploy to `QA` as part of the normal CI/CD pipeline anyways.
It failed consecutively for a week.
Hence nothing was deployed to `Production` for the week.

### Changes proposed in this pull request
Pay QA holdup ransom, by allowing it to be skipped.

### Guidance to review
 
If we know we will be commandeering an environment like `QA` or `Staging` and send us a slack to remind us all.

This will retain our common async nature of working.
Remove the need to look and confirm something is out sync and my goldfish memory.

> I merged something it is not going to be on QA as it is in use and I know why
![image](https://github.com/user-attachments/assets/cef61992-cc98-4dc7-ad22-c29c816186dc)


vs
> I merged something and failed QA now i need to work it out
![image](https://github.com/user-attachments/assets/c363ea9f-76e8-4198-8a05-e03794b57208)


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
