### PR TITLE
[8162] Enable lead partners for early_years_undergrad

### DIFF
--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -91,7 +91,15 @@ PLACEMENTS_ROUTES = TRAINING_ROUTES.select { |training_route|
   TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :early_years_assessment_only).exclude?(training_route)
 }.freeze
 
-LEAD_PARTNER_ROUTES = %i[school_direct_salaried school_direct_tuition_fee pg_teaching_apprenticeship provider_led_postgrad provider_led_undergrad early_years_salaried iqts].freeze
+LEAD_PARTNER_ROUTES = %i[
+  school_direct_salaried
+  school_direct_tuition_fee
+  pg_teaching_apprenticeship
+  provider_led_postgrad provider_led_undergrad
+  early_years_salaried
+  early_years_undergrad
+  iqts
+].freeze
 EMPLOYING_SCHOOL_ROUTES = %i[school_direct_salaried pg_teaching_apprenticeship early_years_salaried].freeze
 
 TRAINING_ROUTE_FEATURE_FLAGS = TRAINING_ROUTE_ENUMS.keys.reject { |training_route|

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -95,7 +95,8 @@ LEAD_PARTNER_ROUTES = %i[
   school_direct_salaried
   school_direct_tuition_fee
   pg_teaching_apprenticeship
-  provider_led_postgrad provider_led_undergrad
+  provider_led_postgrad
+  provider_led_undergrad
   early_years_salaried
   early_years_undergrad
   iqts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -678,7 +678,7 @@ en:
             provider_led_postgrad: *lead_partner_and_employing_school
             provider_led_undergrad: *lead_partner_and_employing_school
             early_years_salaried: *lead_partner_and_employing_school
-            early_years_undergrad: *lead_partner_and_employing_school
+            early_years_undergrad: *lead_partner
     personas:
       view:
         provider_user: "Belongs to <strong>%{provider_name}</strong> and is responsible for managing trainees."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -678,6 +678,7 @@ en:
             provider_led_postgrad: *lead_partner_and_employing_school
             provider_led_undergrad: *lead_partner_and_employing_school
             early_years_salaried: *lead_partner_and_employing_school
+            early_years_undergrad: *lead_partner_and_employing_school
     personas:
       view:
         provider_user: "Belongs to <strong>%{provider_name}</strong> and is responsible for managing trainees."

--- a/spec/features/end_to_end/early_years_undergrad_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_undergrad_journey_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Early years undergrad end-to-end journey" do
+  background { given_i_am_authenticated }
+
+  include_context "perform enqueued jobs"
+
+  fscenario "submit for TRN", "feature_routes.early_years_undergrad": true do
+    given_i_have_created_an_early_years_undergrad_trainee
+    and_the_personal_details_is_complete
+    and_the_contact_details_is_complete
+    and_the_diversity_information_is_complete
+    and_the_course_details_is_complete(early_years_undergrad: true)
+    and_the_placements_details_is_complete
+    and_the_trainee_id_is_complete
+    and_the_funding_details_is_complete
+    and_the_lead_partner_section_is_complete
+    and_the_draft_record_has_been_reviewed
+    and_all_sections_are_complete
+    when_i_submit_for_trn
+    then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/features/end_to_end/early_years_undergrad_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_undergrad_journey_spec.rb
@@ -7,7 +7,7 @@ feature "Early years undergrad end-to-end journey" do
 
   include_context "perform enqueued jobs"
 
-  fscenario "submit for TRN", "feature_routes.early_years_undergrad": true do
+  scenario "submit for TRN", "feature_routes.early_years_undergrad": true do
     given_i_have_created_an_early_years_undergrad_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -13,12 +13,17 @@ module Features
       and_the_course_details_is_marked_completed
     end
 
-    def and_the_course_details_is_complete(assessment_only: false)
+    def and_the_course_details_is_complete(
+      assessment_only: false, early_years_undergrad: false
+    )
+
       given_subject_specialisms_are_available_for_selection
       and_the_course_education_phase_is_completed
       course_details_page.load(id: trainee_from_url.slug)
-      course_details_page.subject.select(subject_specialism_name)
-      course_details_page.main_age_range_11_to_16.choose
+      unless early_years_undergrad
+        course_details_page.subject.select(subject_specialism_name)
+        course_details_page.main_age_range_11_to_16.choose
+      end
       and_the_course_study_mode_field_is_completed unless assessment_only
       and_the_course_date_fields_are_completed
       and_the_course_details_are_submitted

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -16,7 +16,6 @@ module Features
     def and_the_course_details_is_complete(
       assessment_only: false, early_years_undergrad: false
     )
-
       given_subject_specialisms_are_available_for_selection
       and_the_course_education_phase_is_completed
       course_details_page.load(id: trainee_from_url.slug)

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -38,6 +38,10 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:early_years_salaried])
     end
 
+    def given_i_have_created_an_early_years_undergrad_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:early_years_undergrad])
+    end
+
     def given_i_have_created_a_pg_teaching_apprenticeship_trainee
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship])
     end


### PR DESCRIPTION
### Context

[8162-enable-setting-lead-partners-for-early-years-ug-trainees](https://trello.com/c/Jg881UFJ/8162-enable-setting-lead-partners-for-early-years-ug-trainees)

### Changes proposed in this pull request

* Allow setting a lead partner for `early_years_undergrad` trainees

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
