### PR TITLE
[8142] Fix for handling of handling missing lines in bulk CSV upload

### DIFF
--- a/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
+++ b/app/forms/bulk_update/bulk_add_trainees_upload_form.rb
@@ -56,7 +56,7 @@ module BulkUpdate
     end
 
     def number_of_trainees
-      @number_of_trainees ||= csv.count
+      @number_of_trainees ||= csv.entries.reject { |entry| entry.to_h.values.all?(&:blank?) }.count
     end
 
     def build_upload

--- a/spec/forms/bulk_update/bulk_add_trainees_upload_form_spec.rb
+++ b/spec/forms/bulk_update/bulk_add_trainees_upload_form_spec.rb
@@ -86,5 +86,23 @@ module BulkUpdate
         expect(upload.number_of_trainees).to be(2)
       end
     end
+
+    context "when passed a valid file with blank lines" do
+      let(:valid_columns) { BulkUpdate::AddTrainees::ImportRows::ALL_HEADERS.keys.join(",") }
+      let(:test_file_contents) { "#{valid_columns}\n\n0123456789,Bob,Roberts\n\n9876543210,Alice,Roberts\n" }
+
+      it "returns no validation errors and creates a BulkUpdate::TraineeUpload record" do
+        expect { form.save }.to change {
+          BulkUpdate::TraineeUpload.count
+        }.by(1).and not_change { BulkUpdate::TraineeUploadRow.count }
+
+        upload = BulkUpdate::TraineeUpload.last
+
+        expect(upload).to be_uploaded
+        expect(upload.provider).to eq(provider)
+        expect(upload.file.download).to eq(test_file_contents)
+        expect(upload.number_of_trainees).to be(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

This PR is a follow up to https://github.com/DFE-Digital/register-trainee-teachers/pull/5038

In product review we found that the number of lines reported on the `uploaded` page includes blank entries. It should only count non-blank lines.

### Changes proposed in this pull request
The logic in `BulkUpdate::BulkAddTraineesUploadForm` needs to handle blank lines in the CSV so that we save the correct count of (non-blank) trainee records in the CSV rather than a simple number of rows.

### Guidance to review
Is there anything else missing here?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
