### PR TITLE
[8195] Support playbook - Reverting award should reset `outcome_date`

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -191,7 +191,7 @@ In this scenario we must also contact DQT to fix the trainee award status and up
 ```ruby
 trainee = Trainee.find_by(slug: "limax")
 
-trainee.update(state: :trn_received, recommended_for_award_at: nil, awarded_at: nil, audit_comment: 'fill in the blanks')
+trainee.update(state: :trn_received, recommended_for_award_at: nil, awarded_at: nil, outcome_date: nil, audit_comment: 'fill in the blanks')
 
 ```
 


### PR DESCRIPTION
### Context

We found out via this Support ticket https://trello.com/c/Whh3DAu1/8195-performance-profiles-status-error that we also need to reset `Trainee#outcome_date` to `nil` when reverting an incorrect award.

### Changes proposed in this pull request

Update the code snippet in the docs to include `outcome_date`.

![image](https://github.com/user-attachments/assets/c5fb41cd-33aa-47e5-affb-ebb440ae4a04)


### Guidance to review

Anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
