### PR TITLE
Create separate storage account for sanitised bkp

### DIFF
--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -7,4 +7,6 @@ module "azure" {
   tempdata_storage_account_name    = local.azure_tempdata_storage_account_name
   storage_account_replication_type = var.azure_storage_account_replication_type
   deploy_temp_data_storage_account = var.deploy_temp_data_storage_account
+  sanitised_storage_account_name   = local.azure_sanitised_storage_account_name
+  enable_sanitised_storage         = var.enable_sanitised_storage
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -89,6 +89,7 @@ variable "azure_resource_group_name" { default = null }
 variable "azure_tempdata_storage_account_name" { default = null }
 variable "azure_storage_account_replication_type" { default = "LRS" }
 variable "deploy_temp_data_storage_account" { default = true }
+variable "enable_sanitised_storage" { default = false }
 
 locals {
   app_name_suffix   = var.app_name == null ? var.app_environment : var.app_name
@@ -124,4 +125,5 @@ locals {
   )
   default_azure_tempdata_storage_account_name = replace("${var.azure_resource_prefix}${var.service_short}${local.app_name_suffix}tmp", "-", "")
   azure_tempdata_storage_account_name         = var.azure_tempdata_storage_account_name != null ? var.azure_tempdata_storage_account_name : local.default_azure_tempdata_storage_account_name
+  azure_sanitised_storage_account_name        = "${var.azure_resource_prefix}${var.service_short}dbbkpsan${var.config_short}sa"
 }

--- a/terraform/aks/workspace-variables/production.tfvars.json
+++ b/terraform/aks/workspace-variables/production.tfvars.json
@@ -57,5 +57,6 @@
     }
   },
   "enable_gcp_wif": true,
-  "enable_prometheus_monitoring": true
+  "enable_prometheus_monitoring": true,
+  "enable_sanitised_storage": true
 }

--- a/terraform/modules/azure/storage.tf
+++ b/terraform/modules/azure/storage.tf
@@ -30,3 +30,56 @@ resource "azurerm_storage_container" "tempdata" {
   storage_account_name  = resource.azurerm_storage_account.tempdata[0].name
   container_access_type = "private"
 }
+
+resource "azurerm_storage_account" "sanitised_uploads" {
+  count = var.enable_sanitised_storage ? 1 : 0
+
+  name                              = var.sanitised_storage_account_name
+  resource_group_name               = var.resource_group_name
+  location                          = "UK South"
+  account_replication_type          = "LRS"
+  account_tier                      = "Standard"
+  account_kind                      = "StorageV2"
+  min_tls_version                   = "TLS1_2"
+  infrastructure_encryption_enabled = true
+  allow_nested_items_to_be_public   = false
+  cross_tenant_replication_enabled  = false
+
+  blob_properties {
+
+    container_delete_retention_policy {
+      days = 7
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_storage_container" "sanitised_uploads" {
+  count                 = var.enable_sanitised_storage ? 1 : 0
+
+  name                  = "database-backup"
+  storage_account_name  = azurerm_storage_account.sanitised_uploads[0].name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_management_policy" "sanitised_backup" {
+  count = var.enable_sanitised_storage ? 1 : 0
+
+  storage_account_id = azurerm_storage_account.sanitised_uploads[0].id
+
+  rule {
+    name    = "DeleteAfter7Days"
+    enabled = true
+    filters {
+      blob_types = ["blockBlob"]
+    }
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 7
+      }
+    }
+  }
+}

--- a/terraform/modules/azure/variables.tf
+++ b/terraform/modules/azure/variables.tf
@@ -11,3 +11,7 @@ variable "storage_account_replication_type" {
 }
 
 variable "deploy_temp_data_storage_account" { default = true }
+
+variable "sanitised_storage_account_name" { default = null }
+
+variable "enable_sanitised_storage" { default = false }


### PR DESCRIPTION
### Context

Create a separate storage account that will hold the sanitised database backup.
Provides better security, especially with upcoming move to oidc for github workflows.

### Changes proposed in this pull request

Add terraform config for new storage account

### Guidance to review

make production deploy-plan (should show 3 new resources for sanitised stg account)
make qa deploy-plan (no extra resources)

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
