### PR TITLE
Use sanitised storage account in db workflows

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -157,7 +157,7 @@ jobs:
       run: |
         az storage blob upload --container-name database-backup \
         --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
-        --connection-string '${{ env.STORAGE_CONN_STR }}'
+        --connection-string '${{ secrets.AZURE_STORAGE_CONNECTION_STRING_SANITISED }}'
         rm ${SANITISED_FILE_NAME}.sql.gz
 
     - name: Check for Failure
@@ -181,26 +181,11 @@ jobs:
     - name: Set env variable
       run: echo "SANITISED_FILE_NAME=register_sanitised_$(date +"%F")" >> $GITHUB_ENV
 
-    - name: Set KV environment variables
-      run: |
-        tf_vars_file=terraform/aks/workspace-variables/production.tfvars.json
-        echo "key_vault_name=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
-
-    - uses: azure/login@v2
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
-
-    - name: Set Connection String
-      run: |
-        STORAGE_CONN_STR="$(az keyvault secret show --name REGISTER-BACKUP-STORAGE-CONNECTION-STRING-AKS --vault-name ${{ env.key_vault_name }} | jq -r .value)"
-        echo "::add-mask::$STORAGE_CONN_STR"
-        echo "STORAGE_CONN_STR=$STORAGE_CONN_STR" >> $GITHUB_ENV
-
     - name: Download Backup
       run: |
         az storage blob download --container-name database-backup \
         --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz \
-        --connection-string '${{ env.STORAGE_CONN_STR }}'
+        --connection-string '${{ secrets.AZURE_STORAGE_CONNECTION_STRING_SANITISED }}'
         az logout
 
     - uses: azure/login@v2

--- a/.github/workflows/reset-sandbox-database.yml
+++ b/.github/workflows/reset-sandbox-database.yml
@@ -19,29 +19,14 @@ jobs:
     - uses: actions/checkout@v4
       name: Checkout
 
-    - name: Set KV environment variables
-      run: |
-        tf_vars_file=terraform/aks/workspace-variables/production.tfvars.json
-        echo "key_vault_name=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
-
     - name: Set env variable
       run: echo "SANITISED_FILE_NAME=register_sanitised_$(date +"%F")" >> $GITHUB_ENV
-
-    - uses: azure/login@v2
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
-
-    - name: Set Connection String
-      run: |
-        STORAGE_CONN_STR="$(az keyvault secret show --name REGISTER-BACKUP-STORAGE-CONNECTION-STRING-AKS --vault-name ${{ env.key_vault_name }} | jq -r .value)"
-        echo "::add-mask::$STORAGE_CONN_STR"
-        echo "STORAGE_CONN_STR=$STORAGE_CONN_STR" >> $GITHUB_ENV
 
     - name: Download Backup
       run: |
         az storage blob download --container-name database-backup \
         --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz \
-        --connection-string '${{ env.STORAGE_CONN_STR }}'
+        --connection-string '${{ secrets.AZURE_STORAGE_CONNECTION_STRING_SANITISED }}'
         az logout
 
     - uses: azure/login@v2

--- a/docs/setup-development.md
+++ b/docs/setup-development.md
@@ -121,7 +121,7 @@ DEVELOPER_PERSONA = { first_name: "first", last_name: "last", email: "first.last
 If you want to seed the database with a sanitised production dump, follow the steps below:
 
 - Download the sanitised production dump from the Azure Storage Account.
-- In the Azure portal, go to 'Storage Accounts' -> 's189p01rttdbbkppdsa' -> 'Containers' -> 'database-backup'
+- In the Azure portal, go to 'Storage Accounts' -> 's189p01rttdbbkpsanpdsa' -> 'Containers' -> 'database-backup'
 - Download the latest sanitised backup.
 - Unzip the file and you should see a file called `backup_sanitised.sql`.
 


### PR DESCRIPTION
### Context

DB workflows will use a separate storage account to hold sanitised backups.

### Changes proposed in this pull request

Update workflows to use the new storage account for sanitised backups

### Guidance to review

test run (without restore) https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/13495166375

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
