### PR TITLE
Stop using azure kv for review app sentry dsn

### DIFF
--- a/.github/actions/bring-docker-image-up/action.yml
+++ b/.github/actions/bring-docker-image-up/action.yml
@@ -2,15 +2,6 @@ name: bring-docker-image-up
 description: Bring docker image up
 
 inputs:
-  azure-client-id:
-    description: Managed identity client ID
-    required: true
-  azure-subscription-id:
-    description: Azure subscription ID
-    required: true
-  azure-tenant-id:
-    description: Azure tenant ID
-    required: true
   docker-image:
     required: true
   image-tag:
@@ -24,27 +15,6 @@ runs:
       run: |
         echo "IMAGE_TAG=${{ inputs.image-tag }}" >> $GITHUB_ENV
 
-    - name: Set KV environment variables
-      shell: bash
-      run: |
-        # tag build to the review env for vars and secrets
-        tf_vars_file=terraform/aks/workspace-variables/review.tfvars.json
-        echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
-        echo "KEY_VAULT_APP_SECRET_NAME=$(jq -r '.key_vault_app_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
-
-    - uses: azure/login@v2
-      with:
-        tenant-id: ${{ inputs.azure-tenant-id }}
-        subscription-id: ${{ inputs.azure-subscription-id }}
-        client-id: ${{ inputs.azure-client-id }}
-
-    - uses: DFE-Digital/keyvault-yaml-secret@v1
-      id: get-secret
-      with:
-        keyvault: ${{ env.KEY_VAULT_NAME }}
-        secret: ${{ env.KEY_VAULT_APP_SECRET_NAME }}
-        key: SENTRY_DSN
-
     - name: Pull docker image
       shell: bash
       run: docker pull ${{ inputs.docker-image }}:${{ inputs.image-tag }}
@@ -55,4 +25,4 @@ runs:
         docker compose up --no-build -d
         docker compose exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
       env:
-        SENTRY_DSN: ${{ steps.get-secret.outputs.sentry_dsn }}
+        SENTRY_DSN: dummy

--- a/.github/actions/coverage-tests/action.yml
+++ b/.github/actions/coverage-tests/action.yml
@@ -12,15 +12,6 @@ inputs:
   use-next-academic-year:
     required: true
     type: boolean
-  azure-client-id:
-    description: Managed identity client ID
-    required: true
-  azure-subscription-id:
-    description: Azure subscription ID
-    required: true
-  azure-tenant-id:
-    description: Azure tenant ID
-    required: true
   slack-webhook:
     required: true
     type: string
@@ -37,9 +28,6 @@ runs:
     - name: Bring docker image up
       uses: ./.github/actions/bring-docker-image-up/
       with:
-        azure-client-id: ${{ inputs.azure-client-id}}
-        azure-subscription-id: ${{ inputs.azure-subscription-id}}
-        azure-tenant-id: ${{ inputs.azure-tenant-id}}
         docker-image: ${{ inputs.docker-image}}
         image-tag: ${{ inputs.image-tag }}
 

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -18,15 +18,6 @@ inputs:
   slack-webhook:
     description: Slack webhook to use
     required: true
-  azure-client-id:
-    description: Managed identity client ID
-    required: true
-  azure-subscription-id:
-    description: Azure subscription ID
-    required: true
-  azure-tenant-id:
-    description: Azure tenant ID
-    required: true
 
 runs:
   using: 'composite'
@@ -34,9 +25,6 @@ runs:
     - name: Bring docker image up
       uses: ./.github/actions/bring-docker-image-up/
       with:
-        azure-client-id: ${{ inputs.azure-client-id}}
-        azure-subscription-id: ${{ inputs.azure-subscription-id}}
-        azure-tenant-id: ${{ inputs.azure-tenant-id}}
         docker-image: ${{ inputs.docker-image }}
         image-tag: ${{ inputs.image-tag }}
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -47,8 +47,6 @@ jobs:
     name: Lint
     needs: [build]
     runs-on: ubuntu-latest
-    environment:
-      name: review
 
     strategy:
       fail-fast: false
@@ -85,9 +83,6 @@ jobs:
           docker-image: ${{ needs.build.outputs.docker-image }}
           image-tag: ${{ needs.build.outputs.image-tag }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
 
   test:
     name: Test

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -47,8 +47,6 @@ jobs:
     needs: [build]
 
     runs-on: ubuntu-latest
-    environment:
-      name: review
 
     steps:
       - name: Checkout
@@ -61,7 +59,4 @@ jobs:
           image-tag: ${{ needs.build.outputs.image-tag }}
           use-next-academic-year: false
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    environment:
-      name: review
 
     strategy:
       fail-fast: false
@@ -73,9 +71,6 @@ jobs:
       - name: Bring docker image up
         uses: ./.github/actions/bring-docker-image-up/
         with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           docker-image: ${{ inputs.docker-image}}
           image-tag: ${{ inputs.image-tag }}
 


### PR DESCRIPTION
### Context

We use azure key vault to store the review app sentry dsn but use a dummy variable
It's used in lots of testing workflows where we connect to azure and download but we don't need to do this (unless I'm missing something)

### Changes proposed in this pull request

Remove the azure login and kv secret download for the review app sentry dsn.

### Guidance to review

Check the workflows run ok.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
