### PR TITLE
Fix permissions on next-academic-year-tests gh wf

### DIFF
--- a/.github/workflows/next-academic-year-tests.yml
+++ b/.github/workflows/next-academic-year-tests.yml
@@ -11,6 +11,7 @@ permissions:
   deployments: write
   packages: write
   id-token: write
+  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
### Context

next-academic-year-tests github workflow is missing pull-request write permission

see https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/13537623474

### Changes proposed in this pull request

Add permission to workflow

### Guidance to review

see https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/13539894039

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
