### PR TITLE
[8225] Update the logic for itt_aim and itt_qualification_aim to align with HESA

### DIFF
--- a/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
+++ b/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
@@ -38,6 +38,7 @@ module Api
       validates(*REQUIRED_ATTRIBUTES, presence: true)
 
       validates(:itt_aim, inclusion: { in: Hesa::CodeSets::IttAims::MAPPING.keys }, allow_blank: true)
+      validates(:itt_qualification_aim, inclusion: { in: Hesa::CodeSets::IttQualificationAims::MAPPING.keys }, allow_blank: true)
       validates(:course_age_range, inclusion: { in: Hesa::CodeSets::AgeRanges::MAPPING.keys }, allow_blank: true)
       validates(:funding_method, inclusion: { in: Hesa::CodeSets::BursaryLevels::MAPPING.keys }, allow_blank: true)
     end

--- a/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
+++ b/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
@@ -37,6 +37,7 @@ module Api
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
 
+      validates(:itt_aim, inclusion: { in: Hesa::CodeSets::IttAims::MAPPING.keys }, allow_blank: true)
       validates(:course_age_range, inclusion: { in: Hesa::CodeSets::AgeRanges::MAPPING.keys }, allow_blank: true)
       validates(:funding_method, inclusion: { in: Hesa::CodeSets::BursaryLevels::MAPPING.keys }, allow_blank: true)
     end

--- a/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
+++ b/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
@@ -24,18 +24,21 @@ module Api
 
       REQUIRED_ATTRIBUTES = %i[
         itt_aim
-        itt_qualification_aim
         course_year
         course_age_range
         fund_code
         funding_method
       ].freeze
 
+      ITT_AIM_REQUIRED_CODE = 202
+
       ATTRIBUTES.each do |attr|
         attribute attr
       end
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
+
+      validates(:itt_qualification_aim, presence: true, if: -> { itt_aim == ITT_AIM_REQUIRED_CODE || itt_aim.blank? })
 
       validates(:itt_aim, inclusion: { in: Hesa::CodeSets::IttAims::MAPPING.keys }, allow_blank: true)
       validates(:itt_qualification_aim, inclusion: { in: Hesa::CodeSets::IttQualificationAims::MAPPING.keys }, allow_blank: true)

--- a/app/services/api/v0_1/hesa_mapper/attributes.rb
+++ b/app/services/api/v0_1/hesa_mapper/attributes.rb
@@ -155,12 +155,6 @@ module Api
           params[:itt_end_date]
         end
 
-        # In hesa_trainee_detail_attributes
-        #
-        def itt_qualification_aim
-          ::Hesa::CodeSets::IttQualificationAims::MAPPING[params[:itt_qualification_aim]]
-        end
-
         # Is this been used?
         #
         def fundability

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -2927,7 +2927,7 @@ Deletes an existing degree for this trainee.
     <dt class="govuk-summary-list__key"><code>itt_qualification_aim</code></dt>
     <dd class="govuk-summary-list__value">
       <p class="govuk-body">
-        string (limited to 3 characters), required
+        string (limited to 3 characters), required if <code>itt_aim</code> is <code>202</code>
       </p>
       <p class="govuk-body">
         The qualification aim of the trainee’s course. Coded according to the <a href="https://www.hesa.ac.uk/collection/c24053/e/qlaim">HESA qualification aim field</a>.

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -2976,7 +2976,7 @@ Deletes an existing degree for this trainee.
     <dt class="govuk-summary-list__key"><code>itt_qualification_aim</code></dt>
     <dd class="govuk-summary-list__value">
       <p class="govuk-body">
-        string (limited to 3 characters), required
+        string (limited to 3 characters), required if <code>itt_aim</code> is <code>202</code>
       </p>
       <p class="govuk-body">
         The qualification aim of the trainee’s course. Coded according to the <a href="https://www.hesa.ac.uk/collection/c24053/e/qlaim">HESA qualification aim field</a>.

--- a/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
+++ b/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
@@ -218,8 +218,8 @@
     as a result of successful completion of studies.
   format: "[HESA qualification aim reference codes](https://www.hesa.ac.uk/collection/c24053/e/qlaim)"
   example: '"007" for example is the code used for a BA qualification'
-  validation: Mandatory
-  validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v0_1/hesa_trainee_detail_attributes.rb#L27
+  validation: Mandatory if itt_aim is 202
+  validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v0_1/hesa_trainee_detail_attributes.rb#L41
 - field_name: Course Subject One
   technical: course_subject_one
   hesa_alignment: SBJCA

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2076,6 +2076,8 @@ en:
               inclusion: *invalid_reference_data
             funding_method:
               inclusion: *invalid_reference_data
+            itt_aim:
+              inclusion: *invalid_reference_data
         api/v01/withdrawal_attributes:
           attributes:
             reasons:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2078,6 +2078,8 @@ en:
               inclusion: *invalid_reference_data
             itt_aim:
               inclusion: *invalid_reference_data
+            itt_qualification_aim:
+              inclusion: *invalid_reference_data
         api/v01/withdrawal_attributes:
           attributes:
             reasons:

--- a/public/openapi/v0.1.yaml
+++ b/public/openapi/v0.1.yaml
@@ -2112,7 +2112,7 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id:
-                  ukprn: '15500922'
+                  ukprn: '18449948'
                   ethnicity: '997'
                   course_qualification: QTS
                   course_title:
@@ -2146,7 +2146,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: vvJpJKhf4oHTQaRnpC2KzMa2
+                    placement_id: hnopoQddbTxZmUro9KwiJ95s
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -2162,9 +2162,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: 1kTWkRaUtecZNXMrCUHcYrAJ
+                    degree_id: RXx7vWGYtGPepdAV1Y5HtsHv
                   state: submitted_for_trn
-                  trainee_id: n4TtT9SnhACf8LYsk7qadiAf
+                  trainee_id: eas6LGKxsGhf648dUhcAA4wX
                   disability1: '58'
                   disability2: '57'
                   lead_partner_not_applicable: true
@@ -2691,9 +2691,12 @@ paths:
                         required:
                         - urn
                     itt_aim:
-                      type: integer
+                      type: string
                     itt_qualification_aim:
                       type: string
+                      description: |
+                        The Qualification aim of the object.
+                        Required if itt_aim value is 202.
                     course_year:
                       type: string
                     course_age_range:
@@ -2777,7 +2780,7 @@ paths:
                   graduation_year: '2003-06-01'
                 placements_attributes:
                 - urn: '900020'
-                itt_aim: 202
+                itt_aim: '202'
                 itt_qualification_aim: '001'
                 course_year: '2012'
                 course_age_range: '13915'
@@ -3206,7 +3209,7 @@ paths:
         required: true
         schema:
           type: string
-        example: rEZgp2HYoYHd8JMG3qzhohLP
+        example: hAc99kwsjBnJVphhLMfs91Kk
       responses:
         '200':
           description: updates the trainee
@@ -3632,7 +3635,7 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id:
-                  ukprn: '81808064'
+                  ukprn: '87041753'
                   ethnicity: '997'
                   disability1: '55'
                   course_qualification: QTS
@@ -3667,7 +3670,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: oDgwhkbKyx4EXGq7xZiNyeJD
+                    placement_id: Et3xzCsUMmPMJ812b78aWK7Y
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -3683,9 +3686,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: XAnDDfbNVXwnw99Popge5bw8
+                    degree_id: 6sUkNj4A6ErLxK8cwGCpw5DN
                   state: submitted_for_trn
-                  trainee_id: rEZgp2HYoYHd8JMG3qzhohLP
+                  trainee_id: hAc99kwsjBnJVphhLMfs91Kk
                   application_id:
                   disability2: '57'
         '401':
@@ -3764,8 +3767,8 @@ paths:
                 message: 'Validation failed: 1 error prohibited this trainee from
                   being saved'
                 errors:
-                - Hesa trainee detail attributes Funding method has invalid reference
-                  data values
+                - Hesa trainee detail attributes Itt qualification aim has invalid
+                  reference data values
       requestBody:
         content:
           application/json:
@@ -3843,7 +3846,7 @@ paths:
         required: true
         schema:
           type: string
-        example: oduaxxjfbz3u7ho4gqa71i93
+        example: ozt2318jhrz8i9oxlho0qwgh
       requestBody:
         content:
           application/json:
@@ -4153,14 +4156,14 @@ paths:
                 data:
                   commencement_status:
                   defer_date: '2024-09-15'
-                  trainee_start_date: '2024-08-07'
-                  first_names: Chad
-                  middle_names: O'Conner
-                  last_name: Jacobi
-                  email: Chad.Jacobi@example.com
+                  trainee_start_date: '2024-08-15'
+                  first_names: Stacy
+                  middle_names: Gulgowski
+                  last_name: Schmeler
+                  email: Stacy.Schmeler@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '5076145'
+                  trn: '6335476'
                   withdraw_reasons_details:
                   withdraw_reasons_dfe_details:
                   region:
@@ -4169,17 +4172,17 @@ paths:
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '1974-09-03'
+                  date_of_birth: '1962-01-05'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
-                  sex: '96'
+                  sex: '12'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-04'
+                  itt_start_date: '2024-08-15'
                   outcome_date:
-                  itt_end_date: '2025-07-23'
+                  itt_end_date: '2025-07-29'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   recommended_for_award_at:
@@ -4204,41 +4207,41 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-549
-                  ukprn: '48701811'
+                  provider_trainee_id: 24/25-555
+                  ukprn: '18380244'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-04'
+                  course_itt_start_date: '2024-08-15'
                   course_age_range:
-                  expected_end_date: '2025-07-23'
+                  expected_end_date: '2025-07-29'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code:
                   bursary_level:
-                  nationality: CZ
+                  nationality: TG
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '078'
+                  - uk_degree: '005'
                     non_uk_degree:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    subject: '100292'
-                    institution: '0403'
-                    graduation_year: 1994
-                    grade: '02'
+                    subject: '101443'
+                    institution: '0062'
+                    graduation_year: 1968
+                    grade: '01'
                     country:
                     other_grade:
-                    institution_uuid: e13e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: 116a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: b78070f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: q0s3v8f0xj2cqy7v9gh6crpo
+                    institution_uuid: 035b7f3b-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: c6aeedca-9147-4e88-886a-a90302f3d097
+                    subject_uuid: 318770f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: hgm2tndci9wu5h142w7t0tyu
                   state: deferred
-                  trainee_id: vkaoeqanzp6au8ijqfar605m
+                  trainee_id: wu9g51m7ked4nvje43t2pv6h
                   application_id:
         '404':
           description: returns status code 404
@@ -4307,7 +4310,7 @@ paths:
         required: true
         schema:
           type: string
-        example: b8et6tac1mssvulw5asz784p
+        example: hivuw8z6jn9neudvwikkdt5f
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -4387,7 +4390,7 @@ paths:
         required: true
         schema:
           type: string
-        example: bpj35hrvay98pmo0b9i7f18e
+        example: j1i031cbyhn1olcl3y7leadm
       requestBody:
         content:
           application/json:
@@ -4508,7 +4511,7 @@ paths:
                   uk_degree_uuid:
                   subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                  degree_id: 43RJpft9of6e3mSbqod5qy2n
+                  degree_id: bhq3QVXYx75mdY6u73AdJV4U
         '404':
           description: does not create a new degree and returns a 404 status (not_found)
             status
@@ -4613,21 +4616,21 @@ paths:
                 - error: Conflict
                   message: This is a duplicate degree
                 data:
-                - uk_degree: '005'
+                - uk_degree: '069'
                   non_uk_degree:
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  subject: '101443'
-                  institution: '0062'
-                  graduation_year: 1968
-                  grade: '01'
+                  subject: '100729'
+                  institution: '0221'
+                  graduation_year: 2013
+                  grade: '12'
                   country:
                   other_grade:
-                  institution_uuid: 035b7f3b-7042-e811-80ff-3863bb3640b8
-                  uk_degree_uuid: c6aeedca-9147-4e88-886a-a90302f3d097
-                  subject_uuid: 318770f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                  degree_id: mnouoq8kb5qndp8wyi3zt351
+                  institution_uuid: 993e182c-1425-ec11-b6e6-000d3adf095a
+                  uk_degree_uuid: ff695652-c197-e711-80d8-005056ac45bb
+                  subject_uuid: 2d8370f0-5dce-e911-a985-000d3ab79618
+                  grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
+                  degree_id: dysb781e9jcshgwia59urdwb
         '422':
           description: does not create a new degree and returns a 422 status (unprocessable_entity)
             status
@@ -4675,13 +4678,13 @@ paths:
         required: true
         schema:
           type: string
-        example: wn887o5h4ql5e6hn27fsf63g
+        example: zdxfz6n1eisq0ktpak4ikizd
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: 6xboyds7wcjb8x9yu7buzzba
+        example: qd3fezwotcz66puc796s521h
       responses:
         '200':
           description: deletes the degree and returns a 200 status (ok)
@@ -4923,15 +4926,15 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Rudy
-                  last_name: Mitchell
-                  date_of_birth: '1986-06-07'
+                  first_names: Chanda
+                  last_name: Schmitt
+                  date_of_birth: '1990-03-30'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Rudy.Mitchell@example.com
-                  middle_names: Carroll
+                  email: Chanda.Schmitt@example.com
+                  middle_names: Aufderhar
                   training_route:
-                  sex: '12'
+                  sex: '11'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   ethnic_background:
@@ -4976,8 +4979,8 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-518
-                  ukprn: '91516277'
+                  provider_trainee_id: 24/25-524
+                  ukprn: '19640743'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
@@ -4995,7 +4998,7 @@ paths:
                   placements: []
                   degrees: []
                   state: draft
-                  trainee_id: ylomod00r6i5h04ina2cubko
+                  trainee_id: inwth2p1mlyai81xu5f2s6sb
                   application_id:
         '404':
           description: does not delete the degree and returns a 404 status (not_found)
@@ -5044,7 +5047,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 8qd8o5k7kj4uq8ahfsv4idux
+        example: 0acj8u9xsn7k9uzgdo644nr2
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5106,21 +5109,21 @@ paths:
                 - data
               example:
                 data:
-                  uk_degree: '097'
+                  uk_degree: '093'
                   non_uk_degree:
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  subject: '100091'
-                  institution: '0298'
-                  graduation_year: 2018
-                  grade: '14'
+                  subject: '100437'
+                  institution: '0254'
+                  graduation_year: 2009
+                  grade: '05'
                   country:
                   other_grade:
-                  institution_uuid: fa3e182c-1425-ec11-b6e6-000d3adf095a
-                  uk_degree_uuid: 376a5652-c197-e711-80d8-005056ac45bb
-                  subject_uuid: 7d7f70f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                  degree_id: ojrouw8a5lt3psw9dzbq3fxj
+                  institution_uuid: 403e182c-1425-ec11-b6e6-000d3adf095a
+                  uk_degree_uuid: 2f6a5652-c197-e711-80d8-005056ac45bb
+                  subject_uuid: a38170f0-5dce-e911-a985-000d3ab79618
+                  grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
+                  degree_id: x95md5u236q8qwfotcxh9sxy
         '404':
           description: returns status code 404 with a valid JSON response
           content:
@@ -5162,13 +5165,13 @@ paths:
         required: true
         schema:
           type: string
-        example: rdr65g05skoueumkp58wdjvn
+        example: fecsq2bbrfiz7q340ofyopo5
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: ts1pef276lnpn93uzsz0o7ep
+        example: 0g148s2n75r9f2t9uzdhrmfe
       requestBody:
         content:
           application/json:
@@ -5271,11 +5274,11 @@ paths:
                   grade: '02'
                   country:
                   other_grade:
-                  institution_uuid: 073f182c-1425-ec11-b6e6-000d3adf095a
+                  institution_uuid: 103e182c-1425-ec11-b6e6-000d3adf095a
                   uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 917f70f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
-                  degree_id: ay9hypux9nlcmd0kgxnyntoh
+                  grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
+                  degree_id: 3rmwhwuah5p92s3u5pe17v6f
         '404':
           description: does not update the degree and returns a 404 status (not_found)
           content:
@@ -5342,7 +5345,7 @@ paths:
         required: true
         schema:
           type: string
-        example: xvr1h0abwpvg3rvgpqgahn0p
+        example: jayyhqyhzkkjpfxlbuurawpa
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5398,7 +5401,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 2qh6si9ci90lsvoewh712c2i
+        example: cqhcgl1hyrqdbuk914cz8884
       requestBody:
         content:
           application/json:
@@ -5420,9 +5423,9 @@ paths:
               - data
             example:
               data:
-                urn: '554967'
-                name: North Olson
-                postcode: Z2C 4LJ
+                urn: '779331'
+                name: West Wisconsin College
+                postcode: WY3 8BF
       responses:
         '201':
           description: creates a new placement and returns a 201 (created) status
@@ -5460,13 +5463,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '554967'
-                  name: North Olson
-                  address: URN 554967, Z2C 4LJ
-                  postcode: Z2C 4LJ
+                  urn: '779331'
+                  name: West Wisconsin College
+                  address: URN 779331, WY3 8BF
+                  postcode: WY3 8BF
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: yDLw7XZweL16jP2F5qi2w199
+                  placement_id: WRpv5UG4fYs6P5ure1BhwTT2
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -5566,13 +5569,13 @@ paths:
         required: true
         schema:
           type: string
-        example: m4awwf2brsdqa2zsuk9vi0yy
+        example: bqczeg5l0rb9l08pp59o7mi6
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: j6zlt4zzdxfz6n1eisq0ktpa
+        example: evz0xjlerju0tlch6cpr8qd8
       responses:
         '200':
           description: removes the specified placement
@@ -5869,15 +5872,15 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Homer
-                  last_name: Krajcik
-                  date_of_birth: '1972-07-30'
+                  first_names: Austin
+                  last_name: Dach
+                  date_of_birth: '2006-05-09'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Homer.Krajcik@example.com
-                  middle_names: Wilkinson
+                  email: Austin.Dach@example.com
+                  middle_names: Haag
                   training_route:
-                  sex: '10'
+                  sex: '99'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   ethnic_background:
@@ -5912,7 +5915,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '6788489399057'
+                  hesa_id: '9719694602076'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -5922,43 +5925,43 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail: has_placement_detail
-                  provider_trainee_id: 24/25-528
-                  ukprn: '41136573'
+                  provider_trainee_id: 24/25-534
+                  ukprn: '25263394'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
                   course_itt_start_date:
-                  course_age_range: '13913'
+                  course_age_range: '13919'
                   expected_end_date:
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
-                  fund_code: '2'
-                  bursary_level: '9'
-                  previous_last_name: Nienow
-                  itt_aim: '202'
+                  fund_code: '7'
+                  bursary_level: D
+                  previous_last_name: Howell
+                  itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
                   pg_apprenticeship_start_date: '2024-09-15'
-                  funding_method: '9'
+                  funding_method: D
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
-                  itt_qualification_aim: '003'
+                  itt_qualification_aim: '021'
                   hesa_disabilities: {}
                   nationality:
                   withdraw_reasons: []
                   placements:
-                  - urn: '563149'
-                    name: Flowerlake 133 Secondary College
-                    address: URN 563149, Brooksville, D0 9BN
-                    postcode: D0 9BN
+                  - urn: '410091'
+                    name: Brookville 137 High
+                    address: URN 410091, Bernhardtown, YA4 2ZA
+                    postcode: YA4 2ZA
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: fn6cghm7jqbgn9kgkm6oyb79
+                    placement_id: 3ytzj326658xvux1qzpmg7ox
                   degrees: []
                   state: draft
-                  trainee_id: j6zlt4zzdxfz6n1eisq0ktpa
+                  trainee_id: evz0xjlerju0tlch6cpr8qd8
                   application_id:
         '404':
           description: returns status code 404 with a valid JSON response
@@ -6007,7 +6010,7 @@ paths:
         required: true
         schema:
           type: string
-        example: w17ub6mc0j1wxouuysvr6dxg
+        example: bn7cu523a4bt82b4xnou6vnq
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -6045,13 +6048,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '255926'
-                  name: Lakeacre 135 High School
-                  address: URN 255926, Hayesfort, Z5 8AB
-                  postcode: Z5 8AB
+                  urn: '544343'
+                  name: Ironston 139 High
+                  address: URN 544343, Diannashire, NV7 3JP
+                  postcode: NV7 3JP
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: 0lmpe2wureh31hwpbps6ti6p
+                  placement_id: gls1tcgc3jqzax5ylz210e2r
         '404':
           description: returns status code 404 with a valid JSON response
           content:
@@ -6093,13 +6096,13 @@ paths:
         required: true
         schema:
           type: string
-        example: tz40utz51fb7c9utwsqd07nd
+        example: bm9wanm308fotb5rtu9lff8v
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: j6qygwyg6uk5ad1svct50mny
+        example: pwhv1ep23rkdev16yhzgijt9
       requestBody:
         content:
           application/json:
@@ -6119,8 +6122,8 @@ paths:
               - data
             example:
               data:
-                urn: '696250'
-                name: North Michigan University
+                urn: '775904'
+                name: Wunsch Academy
                 postcode: GU1 1AA
       responses:
         '200':
@@ -6161,13 +6164,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '219499'
-                  name: Larson Institute
-                  address: URN 219499, GU1 1AA
+                  urn: '738696'
+                  name: Leannon University
+                  address: URN 738696, GU1 1AA
                   postcode: GU1 1AA
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: rfiz7q340ofyopo5lsruiqa5
+                  placement_id: lzj1rlhkj38ls6ty7psj6qyg
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -6267,7 +6270,7 @@ paths:
         required: true
         schema:
           type: string
-        example: w2k2sgci1c12chb9det6y2rm
+        example: p8qb6twj4vjgia919noze9lt
       requestBody:
         content:
           application/json:
@@ -6445,7 +6448,7 @@ paths:
                           type: object
                           properties:
                             uk_degree:
-                              type: string
+                              nullable: true
                             non_uk_degree:
                               nullable: true
                             created_at:
@@ -6459,7 +6462,7 @@ paths:
                             graduation_year:
                               type: integer
                             grade:
-                              type: string
+                              nullable: true
                             country:
                               nullable: true
                             other_grade:
@@ -6576,13 +6579,13 @@ paths:
               example:
                 data:
                   recommended_for_award_at: '2024-09-15T12:34:56Z'
-                  first_names: Aiko
-                  middle_names: Hermiston
-                  last_name: Murray
-                  email: Aiko.Murray@example.com
+                  first_names: Glennis
+                  middle_names: Huels
+                  last_name: Davis
+                  email: Glennis.Davis@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '7090524'
+                  trn: '9051676'
                   withdraw_reasons_details:
                   withdraw_reasons_dfe_details:
                   region:
@@ -6590,26 +6593,26 @@ paths:
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
-                  date_of_birth: '1993-11-24'
+                  date_of_birth: '1995-10-24'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
-                  sex: '96'
+                  sex: '10'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-15'
+                  itt_start_date: '2024-08-03'
                   outcome_date: '2024-09-15'
-                  itt_end_date: '2025-07-22'
+                  itt_end_date: '2026-07-20'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
-                  trainee_start_date: '2024-08-17'
+                  trainee_start_date: '2024-08-06'
                   reinstate_date:
                   course_min_age: 11
-                  course_max_age: 16
+                  course_max_age: 18
                   awarded_at:
-                  training_initiative: '026'
+                  training_initiative: '009'
                   study_mode:
                   ebacc: false
                   course_education_phase: secondary
@@ -6628,41 +6631,41 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-571
-                  ukprn: '81985289'
+                  provider_trainee_id: 24/25-577
+                  ukprn: '52142558'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-15'
+                  course_itt_start_date: '2024-08-03'
                   course_age_range:
-                  expected_end_date: '2025-07-22'
+                  expected_end_date: '2026-07-20'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code:
                   bursary_level:
-                  nationality: IL
+                  nationality: TN
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '069'
+                  - uk_degree:
                     non_uk_degree:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    subject: '100205'
-                    institution: '0401'
-                    graduation_year: 1976
-                    grade: '02'
+                    subject: '100875'
+                    institution: '0269'
+                    graduation_year: 1988
+                    grade:
                     country:
                     other_grade:
-                    institution_uuid: 6d3e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: ff695652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 2b8070f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: lreqwaxyksuo79xsiwcu4yc7
+                    institution_uuid: f63d182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: '0584565a-1c98-4c1d-ae64-c241542c0879'
+                    subject_uuid: 1d8470f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
+                    degree_id: cmbhu7tn0hw69msuzmpscxid
                   state: recommended_for_award
-                  trainee_id: c6wht11tke8y5i4tu10hwvo8
+                  trainee_id: 7t5is4apbqubxliqrni854im
                   application_id:
         '404':
           description: returns status code 404

--- a/public/openapi/v1.0-pre.yaml
+++ b/public/openapi/v1.0-pre.yaml
@@ -2087,7 +2087,7 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id:
-                  ukprn: '25250629'
+                  ukprn: '62611066'
                   ethnicity: '997'
                   disability1: '58'
                   disability2: '57'
@@ -2123,7 +2123,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: sxYVcfAoLUYRvpvW7gcbsFxi
+                    placement_id: VYihzALZ8WUrSCAgyapSpEH1
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -2139,9 +2139,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: HjexKbDMao1CQk3VZVJ8x3ar
+                    degree_id: uGiPnyDs8yjzJfFg3kjf6yXB
                   state: submitted_for_trn
-                  trainee_id: AtrJnFBTQ9mvyCSQ2cRHhndj
+                  trainee_id: aVzZe9r13v9myh7oM5ounxLd
                   application_id:
         '409':
           description: returns status code 409 (conflict) with the potential duplicates
@@ -2635,16 +2635,30 @@ paths:
                       items:
                         type: object
                         properties:
-                          name:
-                            type: string
                           urn:
+                            nullable: true
+                            type: string
+                            description: |
+                              The URN of the object.
+                              If School 'urn' does not exist in the system, 'name' is required.
+                          name:
+                            nullable: true
+                            type: string
+                            description: |
+                              The name of the object.
+                              Required if School 'urn' does not exist in the system.
+                          postcode:
+                            nullable: true
                             type: string
                         required:
                         - urn
                     itt_aim:
-                      type: integer
+                      type: string
                     itt_qualification_aim:
                       type: string
+                      description: |
+                        The Qualification aim of the object.
+                        Required if itt_aim value is 202.
                     course_year:
                       type: string
                     course_age_range:
@@ -2722,7 +2736,7 @@ paths:
                   graduation_year: '2003-06-01'
                 placements_attributes:
                 - urn: '900020'
-                itt_aim: 202
+                itt_aim: '202'
                 itt_qualification_aim: '001'
                 course_year: '2012'
                 course_age_range: '13915'
@@ -3149,7 +3163,7 @@ paths:
         required: true
         schema:
           type: string
-        example: SnNbZM7g1K1RuNukG6zfVqxD
+        example: nrGwXDTFM6wVRUdZNuQ3b9ZQ
       responses:
         '200':
           description: updates the trainee
@@ -3569,7 +3583,7 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id:
-                  ukprn: '56753105'
+                  ukprn: '17473051'
                   ethnicity: '997'
                   disability1: '55'
                   course_qualification: QTS
@@ -3604,7 +3618,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: eZP3z4kT9r3ejBGFfiL8nzjh
+                    placement_id: GVhsv3fYpfXA9RtYgho7pbz5
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -3620,9 +3634,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: GyHTCoR1iJjwzYfFznf9fBFq
+                    degree_id: U37mtBwCeuNsEkXNRH3AAYYf
                   state: submitted_for_trn
-                  trainee_id: SnNbZM7g1K1RuNukG6zfVqxD
+                  trainee_id: nrGwXDTFM6wVRUdZNuQ3b9ZQ
                   application_id:
                   disability2: '57'
         '401':
@@ -3701,8 +3715,8 @@ paths:
                 message: 'Validation failed: 1 error prohibited this trainee from
                   being saved'
                 errors:
-                - Hesa trainee detail attributes Funding method has invalid reference
-                  data values
+                - Hesa trainee detail attributes Itt qualification aim has invalid
+                  reference data values
       requestBody:
         content:
           application/json:
@@ -3754,7 +3768,7 @@ paths:
                 nationality: FR
                 course_age_range: '13914'
                 lead_partner_urn: '900020'
-                employing_school_urn: '702474'
+                employing_school_urn: '401267'
                 ethnicity:
                 training_route:
                 disability1: '58'
@@ -3780,7 +3794,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 9oxlho0qwgh2pvi2psmi6qp9
+        example: 2qh6si9ci90lsvoewh712c2i
       requestBody:
         content:
           application/json:
@@ -4090,14 +4104,14 @@ paths:
                 data:
                   commencement_status:
                   defer_date: '2024-09-15'
-                  trainee_start_date: '2024-08-21'
-                  first_names: Stacy
-                  middle_names: Gulgowski
-                  last_name: Schmeler
-                  email: Stacy.Schmeler@example.com
+                  trainee_start_date: '2024-08-28'
+                  first_names: Orlando
+                  middle_names: Becker
+                  last_name: Mitchell
+                  email: Orlando.Mitchell@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '6335476'
+                  trn: '3359217'
                   withdraw_reasons_details:
                   withdraw_reasons_dfe_details:
                   region:
@@ -4106,17 +4120,17 @@ paths:
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '1962-01-05'
+                  date_of_birth: '1975-06-06'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
-                  sex: '96'
+                  sex: '12'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-15'
+                  itt_start_date: '2024-08-28'
                   outcome_date:
-                  itt_end_date: '2025-07-29'
+                  itt_end_date: '2025-07-20'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   recommended_for_award_at:
@@ -4141,41 +4155,41 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-551
-                  ukprn: '18380244'
+                  provider_trainee_id: 24/25-557
+                  ukprn: '80136117'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-15'
+                  course_itt_start_date: '2024-08-28'
                   course_age_range:
-                  expected_end_date: '2025-07-29'
+                  expected_end_date: '2025-07-20'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code:
                   bursary_level:
-                  nationality: CZ
+                  nationality: TG
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '078'
+                  - uk_degree: '005'
                     non_uk_degree:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    subject: '100292'
-                    institution: '0403'
-                    graduation_year: 1994
-                    grade: '02'
+                    subject: '101443'
+                    institution: '0062'
+                    graduation_year: 1968
+                    grade: '01'
                     country:
                     other_grade:
-                    institution_uuid: e13e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: 116a5652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: b78070f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: hgm2tndci9wu5h142w7t0tyu
+                    institution_uuid: 035b7f3b-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: c6aeedca-9147-4e88-886a-a90302f3d097
+                    subject_uuid: 318770f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
+                    degree_id: anajjni21na43nwxbnqampr9
                   state: deferred
-                  trainee_id: wu9g51m7ked4nvje43t2pv6h
+                  trainee_id: 6075r7vf54u0675xfb0ya9c1
                   application_id:
         '404':
           description: returns status code 404
@@ -4244,7 +4258,7 @@ paths:
         required: true
         schema:
           type: string
-        example: ahs9vdiy4srwu4pyrp3w9330
+        example: jitwfq0s3v8f0xj2cqy7v9gh
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -4324,7 +4338,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 1i031cbyhn1olcl3y7leadm1
+        example: y5cdjs8cmgdo4udv7t5is4ap
       requestBody:
         content:
           application/json:
@@ -4445,7 +4459,7 @@ paths:
                   uk_degree_uuid:
                   subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                  degree_id: Ny1tXrp8nwkep72rjvynqPXh
+                  degree_id: mq3uCmagGEhYyoM5BNzQbhD3
         '404':
           description: does not create a new degree and returns a 404 status (not_found)
             status
@@ -4550,21 +4564,21 @@ paths:
                 - error: Conflict
                   message: This is a duplicate degree
                 data:
-                - uk_degree: '005'
+                - uk_degree: '069'
                   non_uk_degree:
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  subject: '101443'
-                  institution: '0062'
-                  graduation_year: 1968
-                  grade: '01'
+                  subject: '100729'
+                  institution: '0221'
+                  graduation_year: 2013
+                  grade: '12'
                   country:
                   other_grade:
-                  institution_uuid: 035b7f3b-7042-e811-80ff-3863bb3640b8
-                  uk_degree_uuid: c6aeedca-9147-4e88-886a-a90302f3d097
-                  subject_uuid: 318770f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                  degree_id: hgwia59urdwbr8zpyzcanajj
+                  institution_uuid: 993e182c-1425-ec11-b6e6-000d3adf095a
+                  uk_degree_uuid: ff695652-c197-e711-80d8-005056ac45bb
+                  subject_uuid: 2d8370f0-5dce-e911-a985-000d3ab79618
+                  grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
+                  degree_id: c79siynqqrn1916rb8206op0
         '422':
           description: does not create a new degree and returns a 422 status (unprocessable_entity)
             status
@@ -4612,13 +4626,13 @@ paths:
         required: true
         schema:
           type: string
-        example: w6b6mdgjnvtrxiuxka0ctyux
+        example: 561j26cazd6souacgi08h242
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: tkpt9qf2crvf5a4i93bsey7b
+        example: 3w16hem50pbrbojrouw8a5lt
       responses:
         '200':
           description: deletes the degree and returns a 200 status (ok)
@@ -4860,15 +4874,15 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Charise
-                  last_name: Considine
-                  date_of_birth: '1983-04-05'
+                  first_names: Felix
+                  last_name: Klein
+                  date_of_birth: '1985-10-08'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Charise.Considine@example.com
-                  middle_names: Kuphal
+                  email: Felix.Klein@example.com
+                  middle_names: Mann
                   training_route:
-                  sex: '12'
+                  sex: '11'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   ethnic_background:
@@ -4913,8 +4927,8 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-520
-                  ukprn: '59948017'
+                  provider_trainee_id: 24/25-526
+                  ukprn: '18115917'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
@@ -4932,7 +4946,7 @@ paths:
                   placements: []
                   degrees: []
                   state: draft
-                  trainee_id: nbtfeqs598luv7urq463t2w0
+                  trainee_id: c9yh138xr5hbtl1baxj453o0
                   application_id:
         '404':
           description: does not delete the degree and returns a 404 status (not_found)
@@ -4981,7 +4995,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 2n96h4gahx95md5u236q8qwf
+        example: 1wwanbt6sv67ewrrgq3276bn
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5043,21 +5057,21 @@ paths:
                 - data
               example:
                 data:
-                  uk_degree: '097'
+                  uk_degree: '093'
                   non_uk_degree:
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  subject: '100091'
-                  institution: '0298'
-                  graduation_year: 2018
-                  grade: '14'
+                  subject: '100437'
+                  institution: '0254'
+                  graduation_year: 2009
+                  grade: '05'
                   country:
                   other_grade:
-                  institution_uuid: fa3e182c-1425-ec11-b6e6-000d3adf095a
-                  uk_degree_uuid: 376a5652-c197-e711-80d8-005056ac45bb
-                  subject_uuid: 7d7f70f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                  degree_id: 69izzk1tg5wpplyqsx4jgzit
+                  institution_uuid: 403e182c-1425-ec11-b6e6-000d3adf095a
+                  uk_degree_uuid: 2f6a5652-c197-e711-80d8-005056ac45bb
+                  subject_uuid: a38170f0-5dce-e911-a985-000d3ab79618
+                  grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
+                  degree_id: cgc3jqzax5ylz210e2rnj0uu
         '404':
           description: returns status code 404 with a valid JSON response
           content:
@@ -5099,13 +5113,13 @@ paths:
         required: true
         schema:
           type: string
-        example: 71for7hgs18g0g148s2n75r9
+        example: rc69p1kkbtxu3dhii5ka805v
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: 5kb322wjvrlmsvw3l4a756zl
+        example: b9j85nza62juik8aixjuudyt
       requestBody:
         content:
           application/json:
@@ -5208,11 +5222,11 @@ paths:
                   grade: '02'
                   country:
                   other_grade:
-                  institution_uuid: 073f182c-1425-ec11-b6e6-000d3adf095a
+                  institution_uuid: 103e182c-1425-ec11-b6e6-000d3adf095a
                   uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 917f70f0-5dce-e911-a985-000d3ab79618
-                  grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
-                  degree_id: rdf4rdtjtrco9mazgito6n7a
+                  grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
+                  degree_id: jvrlmsvw3l4a756zlqi71for
         '404':
           description: does not update the degree and returns a 404 status (not_found)
           content:
@@ -5279,7 +5293,7 @@ paths:
         required: true
         schema:
           type: string
-        example: jayyhqyhzkkjpfxlbuurawpa
+        example: 4gh3om75luzx7n5py93q9om9
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5335,7 +5349,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 9kgjdiuttet7xfcgynmc7esj
+        example: 1vftik2a6w30terj4vffh1sw
       requestBody:
         content:
           application/json:
@@ -5355,9 +5369,9 @@ paths:
               - data
             example:
               data:
-                urn: '877414'
-                name: Eastern Murazik
-                postcode: SC2W 4RH
+                urn: '874640'
+                name: East Muller
+                postcode: YA8M 7NZ
       responses:
         '201':
           description: updates the progress attribute on the trainee
@@ -5397,12 +5411,12 @@ paths:
               example:
                 data:
                   urn:
-                  name: Eastern Murazik
-                  address: SC2W 4RH
-                  postcode: SC2W 4RH
+                  name: East Muller
+                  address: YA8M 7NZ
+                  postcode: YA8M 7NZ
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: xdAh9MmDZ43aJTRTaKjecrT3
+                  placement_id: 9Lh3enPiTHzeaLpFwLvZAR4q
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -5472,13 +5486,13 @@ paths:
         required: true
         schema:
           type: string
-        example: '08h242cn3p6y1uikx1php43o'
+        example: w9330x7ua1gsjxqc7vcqyojp
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: wkb4kwua1kapix41kc3w16he
+        example: 3mi00lmpe2wureh31hwpbps6
       responses:
         '200':
           description: removes the specified placement
@@ -5775,15 +5789,15 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Marcellus
-                  last_name: Fadel
-                  date_of_birth: '1967-05-16'
+                  first_names: Tamala
+                  last_name: Davis
+                  date_of_birth: '1995-04-19'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Marcellus.Fadel@example.com
-                  middle_names: Homenick
+                  email: Tamala.Davis@example.com
+                  middle_names: Klein
                   training_route:
-                  sex: '10'
+                  sex: '99'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   ethnic_background:
@@ -5818,7 +5832,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '3111991462407'
+                  hesa_id: '4021559267971'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -5828,43 +5842,43 @@ paths:
                   withdraw_reasons_dfe_details:
                   slug_sent_to_dqt_at:
                   placement_detail: has_placement_detail
-                  provider_trainee_id: 24/25-530
-                  ukprn: '88297637'
+                  provider_trainee_id: 24/25-536
+                  ukprn: '95377759'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
                   course_itt_start_date:
-                  course_age_range: '13913'
+                  course_age_range: '13919'
                   expected_end_date:
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
-                  fund_code: '2'
-                  bursary_level: '9'
-                  previous_last_name: Schuster
-                  itt_aim: '202'
+                  fund_code: '7'
+                  bursary_level: D
+                  previous_last_name: Muller
+                  itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
                   pg_apprenticeship_start_date: '2024-09-15'
-                  funding_method: '9'
+                  funding_method: D
                   ni_number: QQ 12 34 56 C
                   additional_training_initiative: '026'
-                  itt_qualification_aim: '003'
+                  itt_qualification_aim: '021'
                   hesa_disabilities: {}
                   nationality:
                   withdraw_reasons: []
                   placements:
-                  - urn: '551075'
-                    name: Mallowpond 136 High
-                    address: URN 551075, West Reggiefort, Y8D 7RP
-                    postcode: Y8D 7RP
+                  - urn: '718558'
+                    name: Brighthurst 140 High School
+                    address: URN 718558, Maobury, TS3X 6LB
+                    postcode: TS3X 6LB
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: 1jzf0lfpd97ttb68w6n6u2bd
+                    placement_id: vai7punwi9zkxrw7t4abste1
                   degrees: []
                   state: draft
-                  trainee_id: wkb4kwua1kapix41kc3w16he
+                  trainee_id: 3mi00lmpe2wureh31hwpbps6
                   application_id:
         '404':
           description: returns status code 404 with a valid JSON response
@@ -5913,7 +5927,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 1wwanbt6sv67ewrrgq3276bn
+        example: 1m7ked4nvje43t2pv6hyelw2
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5951,13 +5965,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '332632'
-                  name: Flowerlake 138 High School
-                  address: URN 332632, North Dean, Z9E 5JL
-                  postcode: Z9E 5JL
+                  urn: '895870'
+                  name: Ironston 142 High School
+                  address: URN 895870, South Ardelle, N60 5JJ
+                  postcode: N60 5JJ
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: bqpikfgvbpzo4rmew5mbm9yg
+                  placement_id: 14sbiy418kdmbc4vsjayyhqy
         '404':
           description: returns status code 404 with a valid JSON response
           content:
@@ -5999,13 +6013,13 @@ paths:
         required: true
         schema:
           type: string
-        example: 3ldicxrogl64mzy2omu8th0y
+        example: i6x1pjpbhvndowl7ppdbac98
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: nfls4mx2jhejr2mo4pkdffxt
+        example: d78kryb7ki0uevgt8gaxrud6
       requestBody:
         content:
           application/json:
@@ -6025,8 +6039,8 @@ paths:
               - data
             example:
               data:
-                urn: '529174'
-                name: The Wyoming Institute
+                urn: '287283'
+                name: South Monahan Academy
                 postcode: GU1 1AA
       responses:
         '200':
@@ -6067,13 +6081,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '191111'
-                  name: East Hamill
-                  address: URN 191111, GU1 1AA
+                  urn: '287364'
+                  name: Northern Alaska Institute
+                  address: URN 287364, GU1 1AA
                   postcode: GU1 1AA
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: tfkgtcirqm54b51c4gao3v8t
+                  placement_id: qc9nqg0jsttirbw1wra40j4j
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -6143,7 +6157,7 @@ paths:
         required: true
         schema:
           type: string
-        example: ay9hypux9nlcmd0kgxnyntoh
+        example: rdr65g05skoueumkp58wdjvn
       requestBody:
         content:
           application/json:
@@ -6321,7 +6335,7 @@ paths:
                           type: object
                           properties:
                             uk_degree:
-                              type: string
+                              nullable: true
                             non_uk_degree:
                               nullable: true
                             created_at:
@@ -6335,7 +6349,7 @@ paths:
                             graduation_year:
                               type: integer
                             grade:
-                              type: string
+                              nullable: true
                             country:
                               nullable: true
                             other_grade:
@@ -6452,13 +6466,13 @@ paths:
               example:
                 data:
                   recommended_for_award_at: '2024-09-15T12:34:56Z'
-                  first_names: Deon
-                  middle_names: Corwin
-                  last_name: Schmeler
-                  email: Deon.Schmeler@example.com
+                  first_names: Caleb
+                  middle_names: Trantow
+                  last_name: Connelly
+                  email: Caleb.Connelly@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '5330217'
+                  trn: '1112658'
                   withdraw_reasons_details:
                   withdraw_reasons_dfe_details:
                   region:
@@ -6466,26 +6480,26 @@ paths:
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
-                  date_of_birth: '1960-04-25'
+                  date_of_birth: '1988-04-06'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
-                  sex: '96'
+                  sex: '10'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-08'
+                  itt_start_date: '2024-08-12'
                   outcome_date: '2024-09-15'
-                  itt_end_date: '2025-07-26'
+                  itt_end_date: '2026-07-15'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
-                  trainee_start_date: '2024-08-08'
+                  trainee_start_date: '2024-08-15'
                   reinstate_date:
                   course_min_age: 11
-                  course_max_age: 16
+                  course_max_age: 18
                   awarded_at:
-                  training_initiative: '026'
+                  training_initiative: '009'
                   study_mode:
                   ebacc: false
                   course_education_phase: secondary
@@ -6504,41 +6518,41 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-573
-                  ukprn: '45001813'
+                  provider_trainee_id: 24/25-579
+                  ukprn: '56117883'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-08'
+                  course_itt_start_date: '2024-08-12'
                   course_age_range:
-                  expected_end_date: '2025-07-26'
+                  expected_end_date: '2026-07-15'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code:
                   bursary_level:
-                  nationality: IL
+                  nationality: TN
                   withdraw_reasons: []
                   placements: []
                   degrees:
-                  - uk_degree: '069'
+                  - uk_degree:
                     non_uk_degree:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    subject: '100205'
-                    institution: '0401'
-                    graduation_year: 1976
-                    grade: '02'
+                    subject: '100875'
+                    institution: '0269'
+                    graduation_year: 1988
+                    grade:
                     country:
                     other_grade:
-                    institution_uuid: 6d3e182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: ff695652-c197-e711-80d8-005056ac45bb
-                    subject_uuid: 2b8070f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: erjkuwu6rdggsfbdnbrh87ev
+                    institution_uuid: f63d182c-1425-ec11-b6e6-000d3adf095a
+                    uk_degree_uuid: '0584565a-1c98-4c1d-ae64-c241542c0879'
+                    subject_uuid: 1d8470f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
+                    degree_id: 5hgyvwjb6s47la1loaubihlg
                   state: recommended_for_award
-                  trainee_id: ji7g4xlr3y5cdjs8cmgdo4ud
+                  trainee_id: 3gisnfp8qb6twj4vjgia919n
                   application_id:
         '404':
           description: returns status code 404

--- a/spec/models/api/v0_1/degree_attributes_spec.rb
+++ b/spec/models/api/v0_1/degree_attributes_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Api::V01::DegreeAttributes do
           before { subject.uk_degree = "" }
 
           it {
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:uk_degree]).to contain_exactly("can't be blank")
           }
         end
@@ -42,7 +43,8 @@ RSpec.describe Api::V01::DegreeAttributes do
           before { subject.uk_degree = nil }
 
           it {
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:uk_degree]).to contain_exactly("can't be blank")
           }
         end
@@ -51,7 +53,8 @@ RSpec.describe Api::V01::DegreeAttributes do
           before { subject.uk_degree = "Random subject" }
 
           it {
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:uk_degree]).to contain_exactly("has invalid reference data values")
           }
         end
@@ -61,7 +64,8 @@ RSpec.describe Api::V01::DegreeAttributes do
             before { subject.uk_degree = name }
 
             it "is expected to allow #{name}" do
-              expect(subject).not_to be_valid
+              subject.validate
+
               expect(subject.errors[:uk_degree]).to be_blank
             end
           end
@@ -79,7 +83,8 @@ RSpec.describe Api::V01::DegreeAttributes do
           before { subject.non_uk_degree = "" }
 
           it {
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:non_uk_degree]).to contain_exactly("can't be blank")
           }
         end
@@ -88,7 +93,8 @@ RSpec.describe Api::V01::DegreeAttributes do
           before { subject.uk_degree = nil }
 
           it {
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:non_uk_degree]).to contain_exactly("can't be blank")
           }
         end
@@ -97,7 +103,8 @@ RSpec.describe Api::V01::DegreeAttributes do
           before { subject.non_uk_degree = "Random subject" }
 
           it {
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:non_uk_degree]).to contain_exactly("has invalid reference data values")
           }
         end
@@ -107,7 +114,8 @@ RSpec.describe Api::V01::DegreeAttributes do
             before { subject.non_uk_degree = name }
 
             it "is expected to allow #{name}" do
-              expect(subject).not_to be_valid
+              subject.validate
+
               expect(subject.errors[:non_uk_degree]).to be_blank
             end
           end
@@ -116,7 +124,7 @@ RSpec.describe Api::V01::DegreeAttributes do
     end
 
     context "with duplicate" do
-      before { subject.valid? }
+      before { subject.validate }
 
       let(:degree) { trainee.degrees.first }
 
@@ -128,7 +136,7 @@ RSpec.describe Api::V01::DegreeAttributes do
     end
 
     context "without duplicate" do
-      before { subject.valid? }
+      before { subject.validate }
 
       describe "validations" do
         it "returns no error for base duplicates" do

--- a/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
+++ b/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
           subject { described_class.new(itt_aim:) }
 
           it {
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:itt_aim]).to be_blank
           }
         end
@@ -27,7 +28,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
         subject { described_class.new(itt_aim: "300") }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:itt_aim]).to contain_exactly("has invalid reference data values")
         }
       end
@@ -59,7 +61,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
           subject { described_class.new(itt_qualification_aim:) }
 
           it {
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:itt_qualification_aim]).to be_blank
           }
         end
@@ -69,7 +72,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
         subject { described_class.new(itt_qualification_aim: "300") }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:itt_qualification_aim]).to contain_exactly("has invalid reference data values")
         }
       end
@@ -89,7 +93,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
         subject { described_class.new(funding_method: "") }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:funding_method]).to contain_exactly("can't be blank")
         }
       end
@@ -98,7 +103,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
         subject { described_class.new(funding_method: nil) }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:funding_method]).to contain_exactly("can't be blank")
         }
       end
@@ -107,7 +113,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
         subject { described_class.new(funding_method: "AD") }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:funding_method]).to contain_exactly("has invalid reference data values")
         }
       end
@@ -117,7 +124,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
           subject { described_class.new(funding_method:) }
 
           it "is expected to allow #{funding_method}" do
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:funding_method]).to be_blank
           end
         end

--- a/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
+++ b/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
 
     describe "course_age_range" do
       it { is_expected.to validate_presence_of(:course_age_range) }
+
       it {
-        is_expected.to validate_inclusion_of(:course_age_range)
+        expect(subject).to validate_inclusion_of(:course_age_range)
           .in_array(Hesa::CodeSets::AgeRanges::MAPPING.keys)
       }
     end

--- a/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
+++ b/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
       it { is_expected.to validate_presence_of(:itt_aim) }
 
       context "when included in the list of HESA itt aim codes" do
-        Hesa::CodeSets::IttAims::MAPPING.keys.each do |itt_aim|
-          subject { described_class.new(itt_aim: ) }
+        Hesa::CodeSets::IttAims::MAPPING.each_key do |itt_aim|
+          subject { described_class.new(itt_aim:) }
 
           it {
             expect(subject).not_to be_valid
@@ -55,8 +55,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
       end
 
       context "when included in the list of HESA itt qualification aim codes" do
-        ::Hesa::CodeSets::IttQualificationAims::MAPPING.keys.each do |itt_qualification_aim|
-          subject { described_class.new(itt_qualification_aim: ) }
+        Hesa::CodeSets::IttQualificationAims::MAPPING.each_key do |itt_qualification_aim|
+          subject { described_class.new(itt_qualification_aim:) }
 
           it {
             expect(subject).not_to be_valid
@@ -72,7 +72,6 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
           expect(subject).not_to be_valid
           expect(subject.errors[:itt_qualification_aim]).to contain_exactly("has invalid reference data values")
         }
-
       end
     end
 

--- a/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
+++ b/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
@@ -34,22 +34,24 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
     end
 
     describe "itt_qualification_aim" do
-      context "when empty" do
-        subject { described_class.new(itt_qualification_aim: "") }
-
-        it {
-          expect(subject).not_to be_valid
-          expect(subject.errors[:itt_qualification_aim]).to contain_exactly("can't be blank")
-        }
+      context "when itt_aim is nil" do
+        it { is_expected.to validate_presence_of(:itt_qualification_aim) }
       end
 
-      context "when nil" do
-        subject { described_class.new(itt_qualification_aim: nil) }
+      context "when itt_aim is 202" do
+        before do
+          subject.itt_aim = 202
+        end
 
-        it {
-          expect(subject).not_to be_valid
-          expect(subject.errors[:itt_qualification_aim]).to contain_exactly("can't be blank")
-        }
+        it { is_expected.to validate_presence_of(:itt_qualification_aim) }
+      end
+
+      context "when itt_aim is 201" do
+        before do
+          subject.itt_aim = 201
+        end
+
+        it { is_expected.not_to validate_presence_of(:itt_qualification_aim) }
       end
 
       context "when included in the list of HESA itt qualification aim codes" do
@@ -70,6 +72,7 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
           expect(subject).not_to be_valid
           expect(subject.errors[:itt_qualification_aim]).to contain_exactly("has invalid reference data values")
         }
+
       end
     end
 

--- a/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
+++ b/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
@@ -6,10 +6,33 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
   subject { described_class.new }
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:itt_aim) }
     it { is_expected.to validate_presence_of(:itt_qualification_aim) }
     it { is_expected.to validate_presence_of(:course_year) }
     it { is_expected.to validate_presence_of(:fund_code) }
+
+    describe "itt_aim" do
+      it { is_expected.to validate_presence_of(:itt_aim) }
+
+      context "when included in the list of HESA itt aim codes" do
+        Hesa::CodeSets::IttAims::MAPPING.keys.each do |itt_aim|
+          subject { described_class.new(itt_aim: ) }
+
+          it {
+            expect(subject).not_to be_valid
+            expect(subject.errors[:itt_aim]).to be_blank
+          }
+        end
+      end
+
+      context "when not included in the list of HESA itt aim codes" do
+        subject { described_class.new(itt_aim: 300) }
+
+        it {
+          expect(subject).not_to be_valid
+          expect(subject.errors[:itt_aim]).to contain_exactly("has invalid reference data values")
+        }
+      end
+    end
 
     describe "course_age_range" do
       it { is_expected.to validate_presence_of(:course_age_range) }

--- a/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
+++ b/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
   subject { described_class.new }
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:itt_qualification_aim) }
     it { is_expected.to validate_presence_of(:course_year) }
     it { is_expected.to validate_presence_of(:fund_code) }
 
@@ -25,11 +24,51 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
       end
 
       context "when not included in the list of HESA itt aim codes" do
-        subject { described_class.new(itt_aim: 300) }
+        subject { described_class.new(itt_aim: "300") }
 
         it {
           expect(subject).not_to be_valid
           expect(subject.errors[:itt_aim]).to contain_exactly("has invalid reference data values")
+        }
+      end
+    end
+
+    describe "itt_qualification_aim" do
+      context "when empty" do
+        subject { described_class.new(itt_qualification_aim: "") }
+
+        it {
+          expect(subject).not_to be_valid
+          expect(subject.errors[:itt_qualification_aim]).to contain_exactly("can't be blank")
+        }
+      end
+
+      context "when nil" do
+        subject { described_class.new(itt_qualification_aim: nil) }
+
+        it {
+          expect(subject).not_to be_valid
+          expect(subject.errors[:itt_qualification_aim]).to contain_exactly("can't be blank")
+        }
+      end
+
+      context "when included in the list of HESA itt qualification aim codes" do
+        ::Hesa::CodeSets::IttQualificationAims::MAPPING.keys.each do |itt_qualification_aim|
+          subject { described_class.new(itt_qualification_aim: ) }
+
+          it {
+            expect(subject).not_to be_valid
+            expect(subject.errors[:itt_qualification_aim]).to be_blank
+          }
+        end
+      end
+
+      context "when not included in the list of HESA itt qualification aim codes" do
+        subject { described_class.new(itt_qualification_aim: "300") }
+
+        it {
+          expect(subject).not_to be_valid
+          expect(subject.errors[:itt_qualification_aim]).to contain_exactly("has invalid reference data values")
         }
       end
     end

--- a/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
+++ b/spec/models/api/v0_1/hesa_trainee_detail_attributes_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe Api::V01::HesaTraineeDetailAttributes do
 
     describe "course_age_range" do
       it { is_expected.to validate_presence_of(:course_age_range) }
-
       it {
-        expect(subject).to validate_inclusion_of(:course_age_range)
+        is_expected.to validate_inclusion_of(:course_age_range)
           .in_array(Hesa::CodeSets::AgeRanges::MAPPING.keys)
       }
     end

--- a/spec/models/api/v0_1/trainee_attributes_spec.rb
+++ b/spec/models/api/v0_1/trainee_attributes_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(sex: "") }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:sex]).to contain_exactly("can't be blank")
         }
       end
@@ -40,7 +41,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(sex: nil) }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:sex]).to contain_exactly("can't be blank")
         }
       end
@@ -49,7 +51,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(sex: 100) }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:sex]).to contain_exactly("has invalid reference data values")
         }
       end
@@ -59,7 +62,8 @@ RSpec.describe Api::V01::TraineeAttributes do
           subject { described_class.new(sex:) }
 
           it "is expected to allow #{sex}" do
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:sex]).to be_blank
           end
         end
@@ -71,7 +75,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(course_subject_one: "") }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:course_subject_one]).to contain_exactly("can't be blank")
         }
       end
@@ -80,7 +85,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(course_subject_one: nil) }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:course_subject_one]).to contain_exactly("can't be blank")
         }
       end
@@ -89,7 +95,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(course_subject_one: "random subject") }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:course_subject_one]).to contain_exactly("has invalid reference data values")
         }
       end
@@ -98,8 +105,11 @@ RSpec.describe Api::V01::TraineeAttributes do
         Hesa::CodeSets::CourseSubjects::MAPPING.each_value do |course_subject|
           subject { described_class.new(course_subject_one: course_subject) }
 
+          before do
+            subject.validate
+          end
+
           it "is expected to allow #{course_subject}" do
-            expect(subject).not_to be_valid
             expect(subject.errors[:course_subject_one]).to be_blank
           end
         end
@@ -119,7 +129,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(study_mode: "") }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:study_mode]).to contain_exactly("can't be blank")
         }
       end
@@ -128,7 +139,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(study_mode: nil) }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:study_mode]).to contain_exactly("can't be blank")
         }
       end
@@ -137,7 +149,8 @@ RSpec.describe Api::V01::TraineeAttributes do
         subject { described_class.new(study_mode: 2) }
 
         it {
-          expect(subject).not_to be_valid
+          subject.validate
+
           expect(subject.errors[:study_mode]).to contain_exactly("has invalid reference data values")
         }
       end
@@ -147,7 +160,8 @@ RSpec.describe Api::V01::TraineeAttributes do
           subject { described_class.new(study_mode:) }
 
           it "is expected to allow #{study_mode}" do
-            expect(subject).not_to be_valid
+            subject.validate
+
             expect(subject.errors[:study_mode]).to be_blank
           end
         end

--- a/spec/requests/api/v0_1/duplicate_trainees_spec.rb
+++ b/spec/requests/api/v0_1/duplicate_trainees_spec.rb
@@ -26,7 +26,7 @@ describe "Trainees API" do
           course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[CourseSubjects::BIOLOGY],
           study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
           nationality: "GB",
-          itt_aim: 202,
+          itt_aim: "202",
           itt_qualification_aim: "001",
           course_year: "2012",
           course_age_range: "13915",

--- a/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
@@ -888,6 +888,20 @@ describe "`POST /api/v0.1/trainees` endpoint" do
         )
       end
     end
+
+    context "when itt_qualification_aim has invalid reference data values" do
+      let(:itt_qualification_aim) { "321" }
+      let(:params) do
+        { data: data.merge({ itt_qualification_aim: }) }
+      end
+
+      it "return status code 422 with a meaningful error message" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          "Hesa trainee detail attributes Itt qualification aim has invalid reference data values"
+        )
+      end
+    end
   end
 
   context "when a placement has invalid reference data values" do

--- a/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
@@ -884,7 +884,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to contain_exactly(
-          "Hesa trainee detail attributes Itt aim has invalid reference data values"
+          "Hesa trainee detail attributes Itt aim has invalid reference data values",
         )
       end
     end
@@ -898,7 +898,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to contain_exactly(
-          "Hesa trainee detail attributes Itt qualification aim has invalid reference data values"
+          "Hesa trainee detail attributes Itt qualification aim has invalid reference data values",
         )
       end
     end

--- a/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
@@ -57,7 +57,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
           urn: "900020",
         },
       ],
-      itt_aim: 202,
+      itt_aim: "202",
       itt_qualification_aim: "001",
       course_year: "2012",
       course_age_range: course_age_range,
@@ -872,6 +872,20 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to contain_exactly("Hesa trainee detail attributes Funding method has invalid reference data values")
+      end
+    end
+
+    context "when itt_aim has invalid reference data values" do
+      let(:itt_aim) { "321" }
+      let(:params) do
+        { data: data.merge({ itt_aim: }) }
+      end
+
+      it "return status code 422 with a meaningful error message" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          "Hesa trainee detail attributes Itt aim has invalid reference data values"
+        )
       end
     end
   end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -1159,7 +1159,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         it "return status code 422 with a meaningful error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body["errors"]).to contain_exactly(
-            "Hesa trainee detail attributes Itt aim has invalid reference data values"
+            "Hesa trainee detail attributes Itt aim has invalid reference data values",
           )
         end
       end
@@ -1181,7 +1181,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         it "return status code 422 with a meaningful error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body["errors"]).to contain_exactly(
-            "Hesa trainee detail attributes Itt qualification aim has invalid reference data values"
+            "Hesa trainee detail attributes Itt qualification aim has invalid reference data values",
           )
         end
       end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -1163,6 +1163,28 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           )
         end
       end
+
+      context "when itt_qualification_aim has invalid reference data values" do
+        let(:itt_qualification_aim) { "321" }
+        let(:params) do
+          { data: { itt_qualification_aim: } }
+        end
+
+        before do
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        it "return status code 422 with a meaningful error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body["errors"]).to contain_exactly(
+            "Hesa trainee detail attributes Itt qualification aim has invalid reference data values"
+          )
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -1141,6 +1141,28 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           expect(response.parsed_body["errors"]).to contain_exactly("Hesa trainee detail attributes Funding method has invalid reference data values")
         end
       end
+
+      context "when itt_aim has invalid reference data values" do
+        let(:itt_aim) { "321" }
+        let(:params) do
+          { data: { itt_aim: } }
+        end
+
+        before do
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        it "return status code 422 with a meaningful error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body["errors"]).to contain_exactly(
+            "Hesa trainee detail attributes Itt aim has invalid reference data values"
+          )
+        end
+      end
     end
   end
 
@@ -1182,7 +1204,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
               urn: "900020",
             },
           ],
-          itt_aim: 202,
+          itt_aim: "202",
           itt_qualification_aim: "001",
           course_year: "2012",
           course_age_range: "13915",

--- a/spec/requests/api/v1_0_pre/duplicate_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/duplicate_trainees_spec.rb
@@ -26,7 +26,7 @@ describe "Trainees API" do
           course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[CourseSubjects::BIOLOGY],
           study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
           nationality: "GB",
-          itt_aim: 202,
+          itt_aim: "202",
           itt_qualification_aim: "001",
           course_year: "2012",
           course_age_range: "13915",

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -879,7 +879,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to contain_exactly(
-          "Hesa trainee detail attributes Itt aim has invalid reference data values"
+          "Hesa trainee detail attributes Itt aim has invalid reference data values",
         )
       end
     end
@@ -893,7 +893,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to contain_exactly(
-          "Hesa trainee detail attributes Itt qualification aim has invalid reference data values"
+          "Hesa trainee detail attributes Itt qualification aim has invalid reference data values",
         )
       end
     end

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -52,7 +52,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
           urn: "900020",
         },
       ],
-      itt_aim: 202,
+      itt_aim: "202",
       itt_qualification_aim: "001",
       course_year: "2012",
       course_age_range: course_age_range,
@@ -867,6 +867,20 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to contain_exactly("Hesa trainee detail attributes Funding method has invalid reference data values")
+      end
+    end
+
+    context "when itt_aim has invalid reference data values" do
+      let(:itt_aim) { "321" }
+      let(:params) do
+        { data: data.merge({ itt_aim: }) }
+      end
+
+      it "return status code 422 with a meaningful error message" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          "Hesa trainee detail attributes Itt aim has invalid reference data values"
+        )
       end
     end
   end

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -883,6 +883,20 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
         )
       end
     end
+
+    context "when itt_qualification_aim has invalid reference data values" do
+      let(:itt_qualification_aim) { "321" }
+      let(:params) do
+        { data: data.merge({ itt_qualification_aim: }) }
+      end
+
+      it "return status code 422 with a meaningful error message" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          "Hesa trainee detail attributes Itt qualification aim has invalid reference data values"
+        )
+      end
+    end
   end
 
   context "when a placement has invalid reference data values" do

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -1172,6 +1172,28 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
           expect(response.parsed_body["errors"]).to contain_exactly("Hesa trainee detail attributes Funding method has invalid reference data values")
         end
       end
+
+      context "when itt_aim has invalid reference data values" do
+        let(:itt_aim) { "321" }
+        let(:params) do
+          { data: { itt_aim: } }
+        end
+
+        before do
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        it "return status code 422 with a meaningful error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body["errors"]).to contain_exactly(
+            "Hesa trainee detail attributes Itt aim has invalid reference data values"
+          )
+        end
+      end
     end
   end
 
@@ -1213,7 +1235,7 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
               urn: "900020",
             },
           ],
-          itt_aim: 202,
+          itt_aim: "202",
           itt_qualification_aim: "001",
           course_year: "2012",
           course_age_range: "13915",

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -1190,7 +1190,7 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
         it "return status code 422 with a meaningful error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body["errors"]).to contain_exactly(
-            "Hesa trainee detail attributes Itt aim has invalid reference data values"
+            "Hesa trainee detail attributes Itt aim has invalid reference data values",
           )
         end
       end
@@ -1212,133 +1212,134 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
         it "return status code 422 with a meaningful error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body["errors"]).to contain_exactly(
-            "Hesa trainee detail attributes Itt qualification aim has invalid reference data values"
+            "Hesa trainee detail attributes Itt qualification aim has invalid reference data values",
           )
         end
-    end
-  end
-
-  context "Updating a newly created trainee" do
-    let(:token) { "trainee_token" }
-    let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }
-    let!(:nationality) { create(:nationality, :british) }
-
-    let(:headers) { { Authorization: token, **json_headers } }
-
-    let(:start_academic_cycle) { create(:academic_cycle, :current) }
-    let(:end_academic_cycle) { create(:academic_cycle, next_cycle: true) }
-
-    let(:params_for_create) do
-      {
-        data: {
-          first_names: "John",
-          last_name: "Doe",
-          date_of_birth: "1990-01-01",
-          sex: Hesa::CodeSets::Sexes::MAPPING.invert[Trainee.sexes[:male]],
-          email: "john.doe@example.com",
-          nationality: "GB",
-          training_route: Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]],
-          itt_start_date: start_academic_cycle.start_date,
-          itt_end_date: end_academic_cycle.end_date,
-          course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[course_subject],
-          study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
-          degrees_attributes: [
-            {
-              grade: "02",
-              subject: "100425",
-              institution: "0116",
-              uk_degree: "083",
-              graduation_year: "2003-06-01",
-            },
-          ],
-          placements_attributes: [
-            {
-              urn: "900020",
-            },
-          ],
-          itt_aim: "202",
-          itt_qualification_aim: "001",
-          course_year: "2012",
-          course_age_range: "13915",
-          fund_code: "7",
-          funding_method: "4",
-          hesa_id: "0310261553101",
-        },
-      }
+      end
     end
 
-    let(:course_allocation_subject) do
-      subject_specialism = create(:subject_specialism, name: course_subject)
+    context "Updating a newly created trainee" do
+      let(:token) { "trainee_token" }
+      let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }
+      let!(:nationality) { create(:nationality, :british) }
 
-      subject_specialism.allocation_subject
-    end
+      let(:headers) { { Authorization: token, **json_headers } }
 
-    [CourseSubjects::PHYSICS, CourseSubjects::BIOLOGY].each do |cs|
-      context "when creating a new trainee with #{cs} course with valid params" do
-        if cs == CourseSubjects::PHYSICS
-          let!(:funding_method) {
-            funding_method = create(:funding_method, :bursary, amount: 9000, training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad])
-            create(:funding_method_subject, funding_method: funding_method, allocation_subject: course_allocation_subject)
-          }
-        end
+      let(:start_academic_cycle) { create(:academic_cycle, :current) }
+      let(:end_academic_cycle) { create(:academic_cycle, next_cycle: true) }
 
-        let(:course_subject) { cs }
-        let(:slug) { response.parsed_body[:data][:trainee_id] }
-        let(:trainee) { Trainee.last.reload }
-
-        before do
-          allow(Api::V10Pre::HesaMapper::Attributes).to receive(:call).and_call_original
-          allow(Trainees::MapFundingFromDttpEntityId).to receive(:call).and_call_original
-
-          post "/api/v1.0-pre/trainees", params: params_for_create.to_json, headers: headers
-        end
-
-        it "creates a trainee" do
-          expect(response).to have_http_status(:created)
-          expect(Trainee.count).to eq(1)
-
-          expect(trainee.state).to eq("submitted_for_trn")
-          expect(trainee.slug).to eq(slug)
-        end
-
-        context "when updating a newly created trainee with valid params" do
-          let(:params_for_update) do
-            {
-              data:
+      let(:params_for_create) do
+        {
+          data: {
+            first_names: "John",
+            last_name: "Doe",
+            date_of_birth: "1990-01-01",
+            sex: Hesa::CodeSets::Sexes::MAPPING.invert[Trainee.sexes[:male]],
+            email: "john.doe@example.com",
+            nationality: "GB",
+            training_route: Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]],
+            itt_start_date: start_academic_cycle.start_date,
+            itt_end_date: end_academic_cycle.end_date,
+            course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[course_subject],
+            study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
+            degrees_attributes: [
               {
-                first_names: "Alice",
-                study_mode: "63",
+                grade: "02",
+                subject: "100425",
+                institution: "0116",
+                uk_degree: "083",
+                graduation_year: "2003-06-01",
               },
+            ],
+            placements_attributes: [
+              {
+                urn: "900020",
+              },
+            ],
+            itt_aim: "202",
+            itt_qualification_aim: "001",
+            course_year: "2012",
+            course_age_range: "13915",
+            fund_code: "7",
+            funding_method: "4",
+            hesa_id: "0310261553101",
+          },
+        }
+      end
+
+      let(:course_allocation_subject) do
+        subject_specialism = create(:subject_specialism, name: course_subject)
+
+        subject_specialism.allocation_subject
+      end
+
+      [CourseSubjects::PHYSICS, CourseSubjects::BIOLOGY].each do |cs|
+        context "when creating a new trainee with #{cs} course with valid params" do
+          if cs == CourseSubjects::PHYSICS
+            let!(:funding_method) {
+              funding_method = create(:funding_method, :bursary, amount: 9000, training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad])
+              create(:funding_method_subject, funding_method: funding_method, allocation_subject: course_allocation_subject)
             }
           end
 
-          it "updates the trainee" do
-            put(
-              "/api/v1.0-pre/trainees/#{slug}",
-              params: params_for_update.to_json,
-              headers: headers,
-            )
+          let(:course_subject) { cs }
+          let(:slug) { response.parsed_body[:data][:trainee_id] }
+          let(:trainee) { Trainee.last.reload }
 
-            expect(response).to have_http_status(:ok)
-            expect(trainee.first_names).to eq("Alice")
+          before do
+            allow(Api::V10Pre::HesaMapper::Attributes).to receive(:call).and_call_original
+            allow(Trainees::MapFundingFromDttpEntityId).to receive(:call).and_call_original
 
-            expect(response.parsed_body[:data][:trainee_id]).to eq(slug)
-            expect(response.parsed_body[:data][:study_mode]).to eq("63")
+            post "/api/v1.0-pre/trainees", params: params_for_create.to_json, headers: headers
           end
-        end
 
-        context "when request body is not valid JSON" do
-          let(:params_for_update) { "{ \"data\": { \"first_names\": \"Alice\", \"last_name\": \"Roberts\", } }" }
+          it "creates a trainee" do
+            expect(response).to have_http_status(:created)
+            expect(Trainee.count).to eq(1)
 
-          it "does not update the trainee and returns a meaningful error", openapi: false do
-            put(
-              "/api/v1.0-pre/trainees/#{slug}",
-              headers: headers,
-              params: params_for_update,
-            )
-            expect(response).to have_http_status(:bad_request)
-            expect(trainee.reload.first_names).to eq("John")
-            expect(response.parsed_body).to have_key(:errors)
+            expect(trainee.state).to eq("submitted_for_trn")
+            expect(trainee.slug).to eq(slug)
+          end
+
+          context "when updating a newly created trainee with valid params" do
+            let(:params_for_update) do
+              {
+                data:
+                {
+                  first_names: "Alice",
+                  study_mode: "63",
+                },
+              }
+            end
+
+            it "updates the trainee" do
+              put(
+                "/api/v1.0-pre/trainees/#{slug}",
+                params: params_for_update.to_json,
+                headers: headers,
+              )
+
+              expect(response).to have_http_status(:ok)
+              expect(trainee.first_names).to eq("Alice")
+
+              expect(response.parsed_body[:data][:trainee_id]).to eq(slug)
+              expect(response.parsed_body[:data][:study_mode]).to eq("63")
+            end
+          end
+
+          context "when request body is not valid JSON" do
+            let(:params_for_update) { "{ \"data\": { \"first_names\": \"Alice\", \"last_name\": \"Roberts\", } }" }
+
+            it "does not update the trainee and returns a meaningful error", openapi: false do
+              put(
+                "/api/v1.0-pre/trainees/#{slug}",
+                headers: headers,
+                params: params_for_update,
+              )
+              expect(response).to have_http_status(:bad_request)
+              expect(trainee.reload.first_names).to eq("John")
+              expect(response.parsed_body).to have_key(:errors)
+            end
           end
         end
       end

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -1217,129 +1217,129 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
         end
       end
     end
+  end
 
-    context "Updating a newly created trainee" do
-      let(:token) { "trainee_token" }
-      let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }
-      let!(:nationality) { create(:nationality, :british) }
+  context "Updating a newly created trainee" do
+    let(:token) { "trainee_token" }
+    let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }
+    let!(:nationality) { create(:nationality, :british) }
 
-      let(:headers) { { Authorization: token, **json_headers } }
+    let(:headers) { { Authorization: token, **json_headers } }
 
-      let(:start_academic_cycle) { create(:academic_cycle, :current) }
-      let(:end_academic_cycle) { create(:academic_cycle, next_cycle: true) }
+    let(:start_academic_cycle) { create(:academic_cycle, :current) }
+    let(:end_academic_cycle) { create(:academic_cycle, next_cycle: true) }
 
-      let(:params_for_create) do
-        {
-          data: {
-            first_names: "John",
-            last_name: "Doe",
-            date_of_birth: "1990-01-01",
-            sex: Hesa::CodeSets::Sexes::MAPPING.invert[Trainee.sexes[:male]],
-            email: "john.doe@example.com",
-            nationality: "GB",
-            training_route: Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]],
-            itt_start_date: start_academic_cycle.start_date,
-            itt_end_date: end_academic_cycle.end_date,
-            course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[course_subject],
-            study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
-            degrees_attributes: [
+    let(:params_for_create) do
+      {
+        data: {
+          first_names: "John",
+          last_name: "Doe",
+          date_of_birth: "1990-01-01",
+          sex: Hesa::CodeSets::Sexes::MAPPING.invert[Trainee.sexes[:male]],
+          email: "john.doe@example.com",
+          nationality: "GB",
+          training_route: Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]],
+          itt_start_date: start_academic_cycle.start_date,
+          itt_end_date: end_academic_cycle.end_date,
+          course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[course_subject],
+          study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
+          degrees_attributes: [
+            {
+              grade: "02",
+              subject: "100425",
+              institution: "0116",
+              uk_degree: "083",
+              graduation_year: "2003-06-01",
+            },
+          ],
+          placements_attributes: [
+            {
+              urn: "900020",
+            },
+          ],
+          itt_aim: "202",
+          itt_qualification_aim: "001",
+          course_year: "2012",
+          course_age_range: "13915",
+          fund_code: "7",
+          funding_method: "4",
+          hesa_id: "0310261553101",
+        },
+      }
+    end
+
+    let(:course_allocation_subject) do
+      subject_specialism = create(:subject_specialism, name: course_subject)
+
+      subject_specialism.allocation_subject
+    end
+
+    [CourseSubjects::PHYSICS, CourseSubjects::BIOLOGY].each do |cs|
+      context "when creating a new trainee with #{cs} course with valid params" do
+        if cs == CourseSubjects::PHYSICS
+          let!(:funding_method) {
+            funding_method = create(:funding_method, :bursary, amount: 9000, training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad])
+            create(:funding_method_subject, funding_method: funding_method, allocation_subject: course_allocation_subject)
+          }
+        end
+
+        let(:course_subject) { cs }
+        let(:slug) { response.parsed_body[:data][:trainee_id] }
+        let(:trainee) { Trainee.last.reload }
+
+        before do
+          allow(Api::V10Pre::HesaMapper::Attributes).to receive(:call).and_call_original
+          allow(Trainees::MapFundingFromDttpEntityId).to receive(:call).and_call_original
+
+          post "/api/v1.0-pre/trainees", params: params_for_create.to_json, headers: headers
+        end
+
+        it "creates a trainee" do
+          expect(response).to have_http_status(:created)
+          expect(Trainee.count).to eq(1)
+
+          expect(trainee.state).to eq("submitted_for_trn")
+          expect(trainee.slug).to eq(slug)
+        end
+
+        context "when updating a newly created trainee with valid params" do
+          let(:params_for_update) do
+            {
+              data:
               {
-                grade: "02",
-                subject: "100425",
-                institution: "0116",
-                uk_degree: "083",
-                graduation_year: "2003-06-01",
+                first_names: "Alice",
+                study_mode: "63",
               },
-            ],
-            placements_attributes: [
-              {
-                urn: "900020",
-              },
-            ],
-            itt_aim: "202",
-            itt_qualification_aim: "001",
-            course_year: "2012",
-            course_age_range: "13915",
-            fund_code: "7",
-            funding_method: "4",
-            hesa_id: "0310261553101",
-          },
-        }
-      end
-
-      let(:course_allocation_subject) do
-        subject_specialism = create(:subject_specialism, name: course_subject)
-
-        subject_specialism.allocation_subject
-      end
-
-      [CourseSubjects::PHYSICS, CourseSubjects::BIOLOGY].each do |cs|
-        context "when creating a new trainee with #{cs} course with valid params" do
-          if cs == CourseSubjects::PHYSICS
-            let!(:funding_method) {
-              funding_method = create(:funding_method, :bursary, amount: 9000, training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad])
-              create(:funding_method_subject, funding_method: funding_method, allocation_subject: course_allocation_subject)
             }
           end
 
-          let(:course_subject) { cs }
-          let(:slug) { response.parsed_body[:data][:trainee_id] }
-          let(:trainee) { Trainee.last.reload }
+          it "updates the trainee" do
+            put(
+              "/api/v1.0-pre/trainees/#{slug}",
+              params: params_for_update.to_json,
+              headers: headers,
+            )
 
-          before do
-            allow(Api::V10Pre::HesaMapper::Attributes).to receive(:call).and_call_original
-            allow(Trainees::MapFundingFromDttpEntityId).to receive(:call).and_call_original
+            expect(response).to have_http_status(:ok)
+            expect(trainee.first_names).to eq("Alice")
 
-            post "/api/v1.0-pre/trainees", params: params_for_create.to_json, headers: headers
+            expect(response.parsed_body[:data][:trainee_id]).to eq(slug)
+            expect(response.parsed_body[:data][:study_mode]).to eq("63")
           end
+        end
 
-          it "creates a trainee" do
-            expect(response).to have_http_status(:created)
-            expect(Trainee.count).to eq(1)
+        context "when request body is not valid JSON" do
+          let(:params_for_update) { "{ \"data\": { \"first_names\": \"Alice\", \"last_name\": \"Roberts\", } }" }
 
-            expect(trainee.state).to eq("submitted_for_trn")
-            expect(trainee.slug).to eq(slug)
-          end
-
-          context "when updating a newly created trainee with valid params" do
-            let(:params_for_update) do
-              {
-                data:
-                {
-                  first_names: "Alice",
-                  study_mode: "63",
-                },
-              }
-            end
-
-            it "updates the trainee" do
-              put(
-                "/api/v1.0-pre/trainees/#{slug}",
-                params: params_for_update.to_json,
-                headers: headers,
-              )
-
-              expect(response).to have_http_status(:ok)
-              expect(trainee.first_names).to eq("Alice")
-
-              expect(response.parsed_body[:data][:trainee_id]).to eq(slug)
-              expect(response.parsed_body[:data][:study_mode]).to eq("63")
-            end
-          end
-
-          context "when request body is not valid JSON" do
-            let(:params_for_update) { "{ \"data\": { \"first_names\": \"Alice\", \"last_name\": \"Roberts\", } }" }
-
-            it "does not update the trainee and returns a meaningful error", openapi: false do
-              put(
-                "/api/v1.0-pre/trainees/#{slug}",
-                headers: headers,
-                params: params_for_update,
-              )
-              expect(response).to have_http_status(:bad_request)
-              expect(trainee.reload.first_names).to eq("John")
-              expect(response.parsed_body).to have_key(:errors)
-            end
+          it "does not update the trainee and returns a meaningful error", openapi: false do
+            put(
+              "/api/v1.0-pre/trainees/#{slug}",
+              headers: headers,
+              params: params_for_update,
+            )
+            expect(response).to have_http_status(:bad_request)
+            expect(trainee.reload.first_names).to eq("John")
+            expect(response.parsed_body).to have_key(:errors)
           end
         end
       end

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -1194,6 +1194,27 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
           )
         end
       end
+
+      context "when itt_qualification_aim has invalid reference data values" do
+        let(:itt_qualification_aim) { "321" }
+        let(:params) do
+          { data: { itt_qualification_aim: } }
+        end
+
+        before do
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        it "return status code 422 with a meaningful error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body["errors"]).to contain_exactly(
+            "Hesa trainee detail attributes Itt qualification aim has invalid reference data values"
+          )
+        end
     end
   end
 

--- a/spec/requests/api/v1_0_pre/trainees/put_degrees_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/put_degrees_spec.rb
@@ -306,7 +306,6 @@ describe "`PUT /trainees/:trainee_slug/degrees/:slug` endpoint" do
       end
     end
 
-
     context "with an invalid request structure" do
       it "does not update the degree and returns a 422 status (unprocessable_entity)" do
         put(

--- a/spec/requests/api/v1_0_pre/trainees/put_degrees_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/put_degrees_spec.rb
@@ -306,6 +306,7 @@ describe "`PUT /trainees/:trainee_slug/degrees/:slug` endpoint" do
       end
     end
 
+
     context "with an invalid request structure" do
       it "does not update the degree and returns a 422 status (unprocessable_entity)" do
         put(


### PR DESCRIPTION
### Context

[8225-update-the-logic-for-ittaim-and-ittqualificationaim-to-align-with-hesa
](https://trello.com/c/LUjx8wrx/8225-update-the-logic-for-ittaim-and-ittqualificationaim-to-align-with-hesa)

Change validation for `itt_qualification_aim` presence to rely on `itt_aim` value

### Changes proposed in this pull request

* Add inclusion validation for `itt_aim`
* Add inclusion validation for `itt_qualification_aim`
* Refactor `itt_qualification_aim` presence validation
* Remove `itt_qualification_aim` from `Api::V01::HesaMapper::Attributes`
* Update docs

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
