### PR TITLE
Add staging to maintenance page

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
         - qa
+        - staging
         - production
       mode:
         required: true

--- a/maintenance_page/manifests/maintenance/deployment_maintenance.yml.tmpl
+++ b/maintenance_page/manifests/maintenance/deployment_maintenance.yml.tmpl
@@ -20,6 +20,9 @@ spec:
       containers:
       - name: register-maintenance
         image: ghcr.io/dfe-digital/register-maintenance:#MAINTENANCE_IMAGE_TAG#
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
         ports:
         - containerPort: 8080
         resources:

--- a/maintenance_page/manifests/staging/ingress_external_to_main.yml
+++ b/maintenance_page/manifests/staging/ingress_external_to_main.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: staging.register-trainee-teachers.service.gov.uk
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: staging.register-trainee-teachers.service.gov.uk
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: register-staging
+            port:
+              number: 80

--- a/maintenance_page/manifests/staging/ingress_external_to_main2.yml
+++ b/maintenance_page/manifests/staging/ingress_external_to_main2.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: staging.register-trainee-teachers.education.gov.uk
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: staging.register-trainee-teachers.education.gov.uk
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: register-staging
+            port:
+              number: 80

--- a/maintenance_page/manifests/staging/ingress_external_to_maintenance.yml
+++ b/maintenance_page/manifests/staging/ingress_external_to_maintenance.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: staging.register-trainee-teachers.service.gov.uk
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: staging.register-trainee-teachers.service.gov.uk
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: register-maintenance
+            port:
+              number: 80

--- a/maintenance_page/manifests/staging/ingress_external_to_maintenance2.yml
+++ b/maintenance_page/manifests/staging/ingress_external_to_maintenance2.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: staging.register-trainee-teachers.education.gov.uk
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: staging.register-trainee-teachers.education.gov.uk
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: register-maintenance
+            port:
+              number: 80

--- a/maintenance_page/manifests/staging/ingress_internal_to_main.yml
+++ b/maintenance_page/manifests/staging/ingress_internal_to_main.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: register-staging.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: register-staging.test.teacherservices.cloud
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: register-staging
+            port:
+              number: 80

--- a/maintenance_page/manifests/staging/ingress_internal_to_maintenance.yml
+++ b/maintenance_page/manifests/staging/ingress_internal_to_maintenance.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: register-staging.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: register-staging.test.teacherservices.cloud
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: register-maintenance
+            port:
+              number: 80

--- a/maintenance_page/manifests/staging/ingress_maintenance.yml
+++ b/maintenance_page/manifests/staging/ingress_maintenance.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: register-maintenance.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: register-maintenance.test.teacherservices.cloud
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: register-maintenance
+            port:
+              number: 80

--- a/maintenance_page/manifests/staging/ingress_temp_to_main.yml
+++ b/maintenance_page/manifests/staging/ingress_temp_to_main.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: register-temp.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: register-temp.test.teacherservices.cloud
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: register-staging
+            port:
+              number: 80


### PR DESCRIPTION
### Context

Add staging env to the maintenance page configuration
Add some security settings to the deployment

### Changes proposed in this pull request

- Add staging as an option to the workflow
- Add staging mainfest files
- Add securityContext to deployment terraform

### Guidance to review

to be tested

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
