### PR TITLE
[8229] Add audits to trainee withdrawals

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -587,7 +587,7 @@ class Trainee < ApplicationRecord
   end
 
   def current_withdrawal
-    trainee_withdrawals.where(discarded_at: nil).order(:created_at)&.last
+    trainee_withdrawals.kept.last
   end
 
 private

--- a/app/models/trainee_withdrawal.rb
+++ b/app/models/trainee_withdrawal.rb
@@ -32,4 +32,6 @@ class TraineeWithdrawal < ApplicationRecord
 
   enum :trigger, { provider: "provider", trainee: "trainee" }, prefix: :triggered_by
   enum :future_interest, { yes: "yes", no: "no", unknown: "unknown" }, suffix: true
+
+  audited
 end

--- a/app/models/trainee_withdrawal.rb
+++ b/app/models/trainee_withdrawal.rb
@@ -24,6 +24,8 @@
 #  fk_rails_...  (trainee_id => trainees.id)
 #
 class TraineeWithdrawal < ApplicationRecord
+  include Discard::Model
+
   belongs_to :trainee
   has_many :trainee_withdrawal_reasons, dependent: :destroy
   has_many :withdrawal_reasons, through: :trainee_withdrawal_reasons

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -24,7 +24,7 @@ A bunch of fields will be set to `nil`, see `RouteDataManager` class. Ask suppor
 
 
 
-## Changing the witdrawal date for a withdrawn trainee
+## Changing the withdrawal date for a withdrawn trainee
 
 Sometimes support will ask a dev to change the withdrawal date for a trainee.
 

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -22,19 +22,21 @@ A bunch of fields will be set to `nil`, see `RouteDataManager` class. Ask suppor
 
 `update_training_route!` no longer kicks off an update to DQT so that will need to be done manually if needed.
 
-## Unwithdrawing a withdrawn trainee
 
-Sometimes support will ask a dev to unwithdraw a trainee which has been withdrawn in error. You can find the previous trainee state by running `trainee.audits` and comparing the numbers to the enum in `trainee.rb`.
 
-Here is an example of unwithdrawing a trainee. Note that the audit trail should be left intact.
+## Changing the witdrawal date for a withdrawn trainee
+
+Sometimes support will ask a dev to change the withdrawal date for a trainee.
 
 
 ```ruby
 trainee = Trainee.find_by(slug: "XXX")
-
-trainee.withdrawal_reasons.clear
-trainee.update_columns(state: "XXX", withdraw_reasons_details: nil, withdraw_reasons_dfe_details: nil, withdraw_date: nil)
+trainee.current_withdrawal.update!(date: Date.new(2024, 3, 3), audit_comment: "Reason for changing the date")
 ```
+
+## Unwithdrawing a withdrawn trainee
+
+Sometimes support will ask a dev to unwithdraw a trainee which has been withdrawn in error. When logged in as a system admin the trainee's withdrawal can be reverted by clicking on `Undo withdrawal` at the `Withdrawal details` section in the trainee show page `/trainees/:slug`
 
 ## Error codes on DQT trainee jobs
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -530,8 +530,7 @@ FactoryBot.define do
       withdrawn
 
       after(:create) do |trainee|
-        trainee_withdrawal = create(:trainee_withdrawal, trainee:)
-        create(:trainee_withdrawal_reason, trainee:, trainee_withdrawal:)
+        create(:trainee_withdrawal_reason, trainee: trainee, trainee_withdrawal: trainee.current_withdrawal)
       end
     end
 

--- a/spec/models/trainee_withdrawal_spec.rb
+++ b/spec/models/trainee_withdrawal_spec.rb
@@ -17,4 +17,9 @@ RSpec.describe TraineeWithdrawal do
       expect(described_class.future_interests).to eq("yes" => "yes", "no" => "no", "unknown" => "unknown")
     end
   end
+
+  describe "auditing" do
+    it { is_expected.to be_audited }
+  end
 end
+

--- a/spec/models/trainee_withdrawal_spec.rb
+++ b/spec/models/trainee_withdrawal_spec.rb
@@ -22,4 +22,3 @@ RSpec.describe TraineeWithdrawal do
     it { is_expected.to be_audited }
   end
 end
-


### PR DESCRIPTION
### Context

[8229-add-audits-to-trainee-withdrawals
](https://trello.com/c/xqPY4m4j/8229-add-audits-to-trainee-withdrawals)

Enable audits in TraineeWithdrawal

### Changes proposed in this pull request

* Refactor `Trainee#current_withdrawal`
* Add audited to `TraineeWithdrawal`
* Refactor factory
* Update support playbook 

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
