### PR TITLE
[8237] - stop emailing inactive users of an organisation

### DIFF
--- a/app/services/send_performance_profile_submitted_email_service.rb
+++ b/app/services/send_performance_profile_submitted_email_service.rb
@@ -9,7 +9,7 @@ class SendPerformanceProfileSubmittedEmailService
   end
 
   def call
-    provider.users.each do |user|
+    provider.users.kept.each do |user|
       PerformanceProfileSubmittedEmailMailer.generate(
         user:,
         submitted_at:,

--- a/spec/services/send_performance_profile_submitted_email_service_spec.rb
+++ b/spec/services/send_performance_profile_submitted_email_service_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe SendPerformanceProfileSubmittedEmailService do
   let(:user) { create(:user, :hei) }
+  let(:inactive_user) { create(:user, providers: [provider], discarded_at: Time.zone.now) }
   let(:provider) { user.providers.first }
   let(:submitted_at) { Time.zone.now }
 
@@ -12,6 +13,14 @@ describe SendPerformanceProfileSubmittedEmailService do
       described_class.call(provider:, submitted_at:)
     }.to have_enqueued_job.with(
       "PerformanceProfileSubmittedEmailMailer", "generate", "deliver_now", args: [user:, submitted_at:]
+    )
+  end
+
+  it "does not send an email to an inactive user" do
+    expect {
+      described_class.call(provider:, submitted_at:)
+    }.not_to have_enqueued_job.with(
+      "PerformanceProfileSubmittedEmailMailer", "generate", "deliver_now", args: [user: inactive_user, submitted_at: submitted_at]
     )
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/wYtUHNFn/8237-removing-user-from-register

### Changes proposed in this pull request

Only send out performance profile emails to active users of an organisation

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
