### PR TITLE
[8155] DR testing

### DIFF
--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,5 +1,5 @@
 # The url for this app, also used by `dfe_sign_in`
-base_url: https://staging.register-trainee-teachers.service.gov.uk
+base_url: https://register-temp.test.teacherservices.cloud
 
 dttp:
   scope: https://dttp-ppad.crm4.dynamics.com/.default

--- a/terraform/aks/workspace-variables/staging.tfvars.json
+++ b/terraform/aks/workspace-variables/staging.tfvars.json
@@ -8,8 +8,7 @@
   "namespace": "bat-staging",
   "db_sslmode": "prefer",
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
-  "main_app": {
-    "main": {
+  "main": {
       "startup_command": ["/bin/sh", "-c", "STATEMENT_TIMEOUT=90s bundle exec rails db:migrate && unset STATEMENT_TIMEOUT && bundle exec rails server -b 0.0.0.0"],
       "probe_path": "/ping",
       "replicas": 2,
@@ -42,8 +41,8 @@
       "contact_group": [309326],
       "trigger_rate": 0
     }
-  },
-  "enable_gcp_wif": true,
-  "enable_prometheus_monitoring": true,
-  "send_traffic_to_maintenance_page": false
+},
+"enable_gcp_wif": true,
+"enable_prometheus_monitoring": true,
+"send_traffic_to_maintenance_page": true
 }


### PR DESCRIPTION
### Context
Disaster Recovery testing

### Changes proposed in this pull request
n/a

### Guidance to review
During Disaster Recovery testing

The first commit https://github.com/DFE-Digital/register-trainee-teachers/commit/955fc8cc68fb1601a19bfb177a9f43e157cbbb0a

Notice that it is `terraform` related so is only used for the infrastructure side.
Can be used in conjunction with the workflow apps to create a missing `database server`
Literally set the branch name in the workflow

There is _NO_ need for a PR.
---

The second commit https://github.com/DFE-Digital/register-trainee-teachers/commit/d340f6f4d80dfd416544abf4df94d5e7c046916e

This is a 3 sided coin.

1. DSI config was changed to use the `temp` url
2. The service on the `temp` url was up and running
3. The service on the `temp` url was failing to login as the redirect url was set the the `real` url

A PR is _NEEDED_ to ensure that there is a docker image created
---

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
