### PR TITLE
[8260] Fix missing and inaccurate information in bulk CSV reference documentation

### DIFF
--- a/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
+++ b/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
@@ -455,7 +455,7 @@
   hesa_alignment: DEGCLSS
   description: This field is used to indicate the qualification class of the student’s
     previous degree.
-  format: "[HESA codes for the qualification class of a degree](https://www.hesa.ac.uk/collection/c24053/e/degest)"
+  format: "[HESA codes for the qualification class of a degree](https://www.hesa.ac.uk/collection/c24053/e/degclss)"
   example: '"01" for example is First class honours'
   validation: Conditional - mandatory if specifying a UK degree
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v0_1/degree_attributes.rb#L38
@@ -472,7 +472,7 @@
   hesa_alignment: DEGEST
   description: This records the provider where the student’s previous qualification
     was awarded, if a UK provider.
-  format: "[HESA codes for degree establishment if a UK provider](https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/Shared%20Documents/Becoming%20a%20Teacher/TWD-REGISTER/Send%20trainee%20data%20direct%20(BAT%20without%20HESA)/Content%20design/Previous%20degree%20establishment%20%E2%80%93%20HESA%20reference%20code.docx?d=wf81961e5a671455ea6d325f87721d814&csf=1&web=1&e=1fjACa)"
+  format: "[HESA codes for degree establishment if a UK provider](https://www.hesa.ac.uk/collection/c24053/e/degest)"
   example: '"1101" for example is Hull College'
   validation: Conditional - mandatory if specifying a UK degree
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v0_1/degree_attributes.rb#L36


### PR DESCRIPTION
### Context
There are a few missing and incorrect links to HESA reference documentation in our CSV reference docs.

### Changes proposed in this pull request

- Fill in some missing links to HESA docs (making the CSV docs consistent with our API docs)
- Correct two incorrect links to HESA docs (one of which seems to be pointed at a private Sharepoint document).

### Guidance to review

It seems reasonable to just link to HESA documentation rather than replicate some of the information in our own docs. However in the future we will replace the HESA links with DfE reference data docs.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
