### PR TITLE
[8261] Correction to API docs - `nationality` is optional

### DIFF
--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -2892,7 +2892,7 @@ Deletes an existing degree for this trainee.
     <dt class="govuk-summary-list__key"><code>nationality</code></dt>
     <dd class="govuk-summary-list__value">
       <p class="govuk-body">
-        string (limited to 2 characters), required
+        string (limited to 2 characters)
       </p>
       <p class="govuk-body">
         The nationality of the trainee. Coded according to the <a href="https://www.hesa.ac.uk/collection/c24053/e/nation">HESA nationality field</a>


### PR DESCRIPTION
### Context

The `nationality` attribute is incorrectly flagged as required in the API docs.

### Changes proposed in this pull request

Change the API docs to mark `nationality` as optional.

Before:

![image](https://github.com/user-attachments/assets/40aa8f92-a046-465a-a071-2f0d31f03c2a)


After:

![image](https://github.com/user-attachments/assets/faa363f9-c2da-4055-bda0-82648ed25a1b)


### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
