### PR TITLE
[xxxx] - exit RetrieveTrnJob if TRN is present

### DIFF
--- a/app/jobs/dqt/retrieve_trn_job.rb
+++ b/app/jobs/dqt/retrieve_trn_job.rb
@@ -15,6 +15,12 @@ module Dqt
       @timeout_after = timeout_after
       @trainee = trn_request.trainee
 
+      # Return early if the trainee already has a TRN and is in the trn_received state
+      if trainee.trn.present? && trainee.trn_received?
+        trn_request.received! unless trn_request.received?
+        return
+      end
+
       if @timeout_after.nil?
         self.class.perform_later(trn_request, trainee.submitted_for_trn_at + timeout)
         return

--- a/spec/jobs/dqt/retrieve_trn_job_spec.rb
+++ b/spec/jobs/dqt/retrieve_trn_job_spec.rb
@@ -48,6 +48,51 @@ module Dqt
       end
     end
 
+    context "when trainee already has a TRN and is in trn_received state" do
+      let(:existing_trn) { "12345678" }
+      let(:trainee) { create(:trainee, :trn_received, trn: existing_trn) }
+
+      context "when trn_request is not in received state" do
+        let(:trn_request) { create(:dqt_trn_request, trainee: trainee, state: :requested) }
+
+        it "updates the trn_request to received state" do
+          expect {
+            described_class.perform_now(trn_request, timeout_date)
+          }.to change { trn_request.reload.state }.from("requested").to("received")
+        end
+
+        it "doesn't call RetrieveTrn" do
+          expect(RetrieveTrn).not_to receive(:call)
+          described_class.perform_now(trn_request, timeout_date)
+        end
+
+        it "doesn't queue another job" do
+          described_class.perform_now(trn_request, timeout_date)
+          expect(RetrieveTrnJob).not_to have_been_enqueued
+        end
+      end
+
+      context "when trn_request is already in received state" do
+        let(:trn_request) { create(:dqt_trn_request, trainee: trainee, state: :received) }
+
+        it "doesn't change the trn_request state" do
+          expect {
+            described_class.perform_now(trn_request, timeout_date)
+          }.not_to change { trn_request.reload.state }
+        end
+
+        it "doesn't call RetrieveTrn" do
+          expect(RetrieveTrn).not_to receive(:call)
+          described_class.perform_now(trn_request, timeout_date)
+        end
+
+        it "doesn't queue another job" do
+          described_class.perform_now(trn_request, timeout_date)
+          expect(RetrieveTrnJob).not_to have_been_enqueued
+        end
+      end
+    end
+
     context "TRN is available" do
       let(:trn) { "123" }
 


### PR DESCRIPTION
### Context

there are lots of `RuntimeError: Invalid transition` failed `Dqt::RetrieveTrnJob` jobs

### Changes proposed in this pull request

if a trainee has their TRN, we should update the request instead of re-submitting the job

### Guidance to review

validate logic - is anything not being considered here? why isn't this already being done?
