### PR TITLE
[8267] Document unsupported age range HESA mappings

### DIFF
--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3322,7 +3322,7 @@ Deletes an existing degree for this trainee.
         Example: <code>13918</code>
       </p>
       <p class="govuk-body">
-        Note that the following HESA values are invalid for this field:
+        The following HESA values are invalid for this field:
         <ul class='govuk-list govuk-list--bullet'>
           <li><code>99801</code> - Teacher training qualification: Further education/Higher education</li>
           <li><code>99803</code> - Teacher training qualification: Other</li>

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -3398,7 +3398,7 @@ Deletes an existing degree for this trainee.
         Example: <code>13918</code>
       </p>
       <p class="govuk-body">
-        Note that the following HESA values are invalid for this field:
+        The following HESA values are invalid for this field:
         <ul class='govuk-list govuk-list--bullet'>
           <li><code>99801</code> - Teacher training qualification: Further education/Higher education</li>
           <li><code>99803</code> - Teacher training qualification: Other</li>

--- a/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
+++ b/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
@@ -273,7 +273,7 @@
   format: |-
     "[HESA course phase reference codes](https://www.hesa.ac.uk/collection/c24053/e/ittphsc)"
 
-    Note that the following HESA values are invalid for this field:
+    The following HESA values are invalid for this field:
 
       - `99801` - Teacher training qualification: Further education/Higher education
       - `99803` - Teacher training qualification: Other


### PR DESCRIPTION
### Context

HESA values `99801` and `99803` are not considered valid by Register. So
we need to state this clearly in the API and CSV reference docs.

### Changes proposed in this pull request

![image](https://github.com/user-attachments/assets/cfb92116-0c98-41a9-a7a1-614560d698e4)

![image](https://github.com/user-attachments/assets/55e5b691-4650-4ce8-b1f6-089865908fec)

### Guidance to review

Is the wording ok?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
