### PR TITLE
[xxxx] - Check for discard status before retrieving TRN

### DIFF
--- a/app/jobs/dqt/retrieve_trn_job.rb
+++ b/app/jobs/dqt/retrieve_trn_job.rb
@@ -15,6 +15,11 @@ module Dqt
       @timeout_after = timeout_after
       @trainee = trn_request.trainee
 
+      if trainee.discarded?
+        trn_request.destroy
+        return
+      end
+
       # Return early if the trainee already has a TRN
       if trainee.trn.present?
         trn_request.received! unless trn_request.received?

--- a/app/jobs/trs/retrieve_trn_job.rb
+++ b/app/jobs/trs/retrieve_trn_job.rb
@@ -15,6 +15,11 @@ module Trs
       @timeout_after = timeout_after
       @trainee = trn_request.trainee
 
+      if trainee.discarded?
+        trn_request.destroy
+        return
+      end
+
       # Return early if the trainee already has a TRN
       if trainee.trn.present?
         trn_request.received! unless trn_request.received?

--- a/spec/jobs/trs/retrieve_trn_job_spec.rb
+++ b/spec/jobs/trs/retrieve_trn_job_spec.rb
@@ -20,6 +20,26 @@ module Trs
       allow(SlackNotifierService).to receive(:call)
     end
 
+    context "when trainee is discarded" do
+      let(:trainee) { create(:trainee, :submitted_for_trn, discarded_at: Time.zone.now) }
+
+      it "destroys the trn_request" do
+        expect {
+          described_class.perform_now(trn_request, timeout_date)
+        }.to change { Dqt::TrnRequest.count }.by(-1)
+      end
+
+      it "doesn't call RetrieveTrn" do
+        expect(RetrieveTrn).not_to receive(:call)
+        described_class.perform_now(trn_request, timeout_date)
+      end
+
+      it "doesn't queue another job" do
+        described_class.perform_now(trn_request, timeout_date)
+        expect(RetrieveTrnJob).not_to have_been_enqueued
+      end
+    end
+
     context "when timeout_after is nil" do
       context "during October" do
         let(:timeout_date) { trainee.submitted_for_trn_at + (configured_poll_timeout_days + 6).days }


### PR DESCRIPTION
### Context
Ok, last one, this covers TRN retrieval requests that belong to discarded trainees (the remainder of the dead trn request jobs). relates to #5135 and #5130 

### Changes proposed in this pull request

Checks discard status of a trainee before running the task
