### PR TITLE
[8272] Create new self-serve token management index page - part 2

### DIFF
--- a/app/components/authentication_tokens/details/view.rb
+++ b/app/components/authentication_tokens/details/view.rb
@@ -46,7 +46,7 @@ module AuthenticationTokens
         if expires_at.present?
           row += [
             {
-              key: { text: expired? ? "Expired" : "Expires at" }, value: { text: expires_at.to_fs(:govuk) }
+              key: { text: expired? ? "Expired" : "Expires on" }, value: { text: expires_at.to_fs(:govuk) }
             },
           ]
         end

--- a/app/components/authentication_tokens/details/view.rb
+++ b/app/components/authentication_tokens/details/view.rb
@@ -13,6 +13,9 @@ module AuthenticationTokens
                :expires_at,
                :last_used_at,
                :revoked_by,
+               :revoked_at,
+               :revoked?,
+               :expired?,
                to: :token
 
       def initialize(token)
@@ -20,7 +23,7 @@ module AuthenticationTokens
       end
 
       def rows
-        [
+        row = [
           {
             key: { text: "Status" }, value: { text: status.capitalize }
           },
@@ -30,19 +33,25 @@ module AuthenticationTokens
           {
             key: { text: "Last used" }, value: { text: last_used_at&.to_date&.to_fs(:govuk) }
           },
-          {
-            key: { text: "Revoked by" }, value: { text: revoked_by&.name }
-          },
-          {
-            key: { text: "Expired" }, value: { text: expired_at&.to_date&.to_fs(:govuk) }
-          },
         ]
-      end
 
-    private
+        if revoked?
+          row += [
+            {
+              key: { text: "Revoked by" }, value: { text: "#{revoked_by.name} on #{revoked_at.to_date.to_fs(:govuk)}" }
+            },
+          ]
+        end
 
-      def expired_at
-        expires_at if expires_at.present? && (expires_at < Time.zone.today)
+        if expires_at.present?
+          row += [
+            {
+              key: { text: expired? ? "Expired" : "Expires at" }, value: { text: expires_at.to_fs(:govuk) }
+            },
+          ]
+        end
+
+        row
       end
     end
   end

--- a/app/controllers/authentication_tokens_controller.rb
+++ b/app/controllers/authentication_tokens_controller.rb
@@ -4,13 +4,14 @@ class AuthenticationTokensController < ApplicationController
   before_action { require_feature_flag(:token_management) }
 
   def index
-    @tokens = authorize(tokens).by_status_and_last_used_at
+    authorize(tokens)
   end
 
 private
 
   def tokens
-    policy_scope(AuthenticationToken)
+    @tokens ||= policy_scope(AuthenticationToken)
       .includes(:provider, :created_by, :revoked_by)
+      .by_status_and_last_used_at
   end
 end

--- a/app/controllers/authentication_tokens_controller.rb
+++ b/app/controllers/authentication_tokens_controller.rb
@@ -4,13 +4,13 @@ class AuthenticationTokensController < ApplicationController
   before_action { require_feature_flag(:token_management) }
 
   def index
-    authorize(tokens)
+    @tokens = authorize(tokens).by_status_and_last_used_at
   end
 
 private
 
   def tokens
-    @tokens ||= policy_scope(AuthenticationToken)
+    policy_scope(AuthenticationToken)
       .includes(:provider, :created_by, :revoked_by)
   end
 end

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -58,6 +58,8 @@ class AuthenticationToken < ApplicationRecord
   validates :hashed_token, presence: true, uniqueness: true
   validates :name, presence: true, length: { maximum: 200 }
 
+  scope :by_status_and_last_used_at, -> { order(:status, last_used_at: :desc) }
+
   def self.create_with_random_token(attributes = {})
     token = "#{Rails.env}_" + SecureRandom.hex(10)
     hashed_token = hash_token(token)

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -11,6 +11,7 @@
 #  last_used_at  :datetime
 #  name          :string           not null
 #  revoked_at    :datetime
+#  status        :string           default("active")
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  created_by_id :bigint
@@ -19,10 +20,12 @@
 #
 # Indexes
 #
-#  index_authentication_tokens_on_created_by_id  (created_by_id)
-#  index_authentication_tokens_on_hashed_token   (hashed_token) UNIQUE
-#  index_authentication_tokens_on_provider_id    (provider_id)
-#  index_authentication_tokens_on_revoked_by_id  (revoked_by_id)
+#  index_authentication_tokens_on_created_by_id            (created_by_id)
+#  index_authentication_tokens_on_hashed_token             (hashed_token) UNIQUE
+#  index_authentication_tokens_on_provider_id              (provider_id)
+#  index_authentication_tokens_on_revoked_by_id            (revoked_by_id)
+#  index_authentication_tokens_on_status                   (status)
+#  index_authentication_tokens_on_status_and_last_used_at  (status,last_used_at)
 #
 # Foreign Keys
 #

--- a/app/policies/authentication_token_policy.rb
+++ b/app/policies/authentication_token_policy.rb
@@ -11,13 +11,9 @@ class AuthenticationTokenPolicy
     end
 
     def resolve
-      return scope.none unless user.organisation?
+      return scope.none unless user.provider?
 
-      if user.lead_partner?
-        scope.where(provider_id: user.organisation.provider_id)
-      else
-        scope.where(provider_id: user.organisation.id)
-      end
+      scope.where(provider_id: user.organisation.id)
     end
   end
 
@@ -28,6 +24,6 @@ class AuthenticationTokenPolicy
   end
 
   def index?
-    user.organisation?
+    user.provider?
   end
 end

--- a/app/views/organisation_settings/show.html.erb
+++ b/app/views/organisation_settings/show.html.erb
@@ -24,7 +24,7 @@
       end
     end %>
 
-    <% if FeatureService.enabled?(:token_management) %>
+    <% if FeatureService.enabled?(:token_management) && policy(AuthenticationToken).index? %>
       <h2 class="govuk-heading-m">API Tokens</h2>
 
       <p class="govuk-body">

--- a/app/views/organisation_settings/show.html.erb
+++ b/app/views/organisation_settings/show.html.erb
@@ -25,16 +25,18 @@
     end %>
 
     <% if FeatureService.enabled?(:token_management) && policy(AuthenticationToken).index? %>
-      <h2 class="govuk-heading-m">API Tokens</h2>
+      <h2 class="govuk-heading-m">Register API Tokens</h2>
 
       <p class="govuk-body">
-        If you want to use the Register API to send your trainee data from your Students Record System directly to the Register service, you will need an API token.
+        You need an API token if you want to use the Register API to send your trainee data from your students record system directly to the Register service.
       </p>
 
-      <h3 class="govuk-heading-s">What is an API token?</h3>
+      <p class="govuk-body">
+        The API token is unique to your organisation and is a code that authenticates the transfer of your trainee data from your student record system directly into the Register service.
+      </p>
 
       <p class="govuk-body">
-        The API token is unique to your organisation and is a code that authenticates the transfer of your trainee data from your Student Record System directly into the Register service via the Register API (piece of software).
+        Your token is needed by the developers who are managing your Register API integration.
       </p>
 
       <p class="govuk-body">

--- a/db/migrate/20250314141354_add_attributes_to_authetication_tokens.rb
+++ b/db/migrate/20250314141354_add_attributes_to_authetication_tokens.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class AddAttributesToAutheticationTokens < ActiveRecord::Migration[7.2]
-  class AuthenticationToken < ApplicationRecord; end
+  class AuthenticationToken < ApplicationRecord
+    belongs_to :provider
+    belongs_to :created_by, class_name: "User", optional: true
+    belongs_to :revoked_by, class_name: "User", optional: true
+  end
 
   def change
     safety_assured do
@@ -11,15 +15,19 @@ class AddAttributesToAutheticationTokens < ActiveRecord::Migration[7.2]
       add_reference :authentication_tokens, :created_by, foreign_key: { to_table: :users }
       add_reference :authentication_tokens, :revoked_by, foreign_key: { to_table: :users }
 
-      # Ensure existing tokens have a created_by user and name going forward
+      reversible do |dir|
+        dir.up do
+          # Ensure existing tokens have a created_by user and name going forward
 
-      AuthenticationToken.find_each do |authentication_token|
-        provider = authentication_token.provider
+          AuthenticationToken.find_each do |authentication_token|
+            provider = authentication_token.provider
 
-        authentication_token.update!(created_by: provider.users.kept.first, name: "Test token")
+            authentication_token.update!(created_by: provider.users.kept.first, name: "Test token")
+          end
+
+          change_column_null :authentication_tokens, :name, false
+        end
       end
-
-      change_column_null :authentication_tokens, :name, false
     end
   end
 end

--- a/db/migrate/20250314141354_add_attributes_to_authetication_tokens.rb
+++ b/db/migrate/20250314141354_add_attributes_to_authetication_tokens.rb
@@ -3,7 +3,7 @@
 class AddAttributesToAutheticationTokens < ActiveRecord::Migration[7.2]
   class AuthenticationToken < ApplicationRecord
     belongs_to :provider
-    belongs_to :created_by, class_name: "User", optional: true
+    belongs_to :created_by, class_name: "User"
     belongs_to :revoked_by, class_name: "User", optional: true
   end
 

--- a/db/migrate/20250321143706_add_status_last_used_at_index_to_authentication_tokens.rb
+++ b/db/migrate/20250321143706_add_status_last_used_at_index_to_authentication_tokens.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddStatusLastUsedAtIndexToAuthenticationTokens < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :authentication_tokens, %i[status last_used_at], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_18_153401) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_21_143706) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -141,6 +141,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_18_153401) do
     t.index ["hashed_token"], name: "index_authentication_tokens_on_hashed_token", unique: true
     t.index ["provider_id"], name: "index_authentication_tokens_on_provider_id"
     t.index ["revoked_by_id"], name: "index_authentication_tokens_on_revoked_by_id"
+    t.index ["status", "last_used_at"], name: "index_authentication_tokens_on_status_and_last_used_at"
     t.index ["status"], name: "index_authentication_tokens_on_status"
   end
 
@@ -686,10 +687,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_18_153401) do
     t.string "surname16"
     t.string "ttcid"
     t.string "hesa_committed_at"
-    t.string "previous_hesa_id"
     t.string "application_choice_id"
     t.string "itt_start_date"
     t.string "trainee_start_date"
+    t.string "previous_hesa_id"
     t.string "provider_trainee_id"
     t.string "lead_partner_urn"
     t.index ["hesa_id", "rec_id"], name: "index_hesa_students_on_hesa_id_and_rec_id", unique: true

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -111,9 +111,10 @@ namespace :example_data do
       FactoryBot.create(:payment_schedule, :for_full_year, payable: provider)
       FactoryBot.create(:trainee_summary, :with_bursary_and_scholarship_and_multiple_amounts, payable: provider)
 
-      FactoryBot.create(:authentication_token, provider:)
-      FactoryBot.create(:authentication_token, :expired, provider:)
       FactoryBot.create(:authentication_token, :revoked, provider: provider, revoked_by: persona)
+      FactoryBot.create(:authentication_token, provider: provider, last_used_at: 1.day.ago)
+      FactoryBot.create(:authentication_token, :will_expire, provider:)
+      FactoryBot.create(:authentication_token, :expired, provider:)
 
       if persona_attributes[:lead_partner]
         lead_partner = lead_partners.sample

--- a/spec/factories/authentication_tokens.rb
+++ b/spec/factories/authentication_tokens.rb
@@ -7,8 +7,11 @@ FactoryBot.define do
     provider
     created_by { provider.users.first }
     name { "test token" }
-    expires_at { Faker::Date.forward(days: 30) }
     last_used_at { Time.current }
+
+    trait :will_expire do
+      expires_at { 1.month.from_now }
+    end
 
     trait :expired do
       status { :expired }
@@ -20,6 +23,7 @@ FactoryBot.define do
       status { :revoked }
 
       revoked_at { Time.current }
+      revoked_by { created_by }
     end
   end
 end

--- a/spec/features/organisation_settings_spec.rb
+++ b/spec/features/organisation_settings_spec.rb
@@ -28,6 +28,7 @@ feature "Organisation details" do
       then_i_see_the_organisation_details
       and_i_see_the_organisation_team_members
       and_i_see_the_contact_support_email
+      and_i_dont_see_api_tokens_details
 
       when_i_click_on_back_link
       then_i_see_the_root_page
@@ -85,13 +86,9 @@ feature "Organisation details" do
     let(:provider) { create(:provider) }
 
     scenario "a user attempts to view the organisation settings page" do
-      expect(page).not_to have_link("Organisation settings")
-
-      organisation_settings_page.load
-
-      expect(page).to have_content(
-        "You do not have permission to perform this action",
-      )
+      given_the_organisation_settings_link_is_not_visible
+      when_i_attempt_to_visit_the_organisation_settings_page
+      then_i_see_the_unauthorized_message
     end
 
     scenario "a user attempts to view the token management page", feature_token_management: true do
@@ -102,8 +99,16 @@ feature "Organisation details" do
 
 private
 
+  def given_the_organisation_settings_link_is_not_visible
+    expect(page).not_to have_link("Organisation settings")
+  end
+
   def given_i_have_clicked_on_the_organisation_name_link
     click_on organisation.name
+  end
+
+  def when_i_attempt_to_visit_the_organisation_settings_page
+    organisation_settings_page.load
   end
 
   def when_i_click_on_the_organisation_settings_link

--- a/spec/features/organisation_settings_spec.rb
+++ b/spec/features/organisation_settings_spec.rb
@@ -33,7 +33,7 @@ feature "Organisation details" do
       then_i_see_the_root_page
     end
 
-    scenario "a user views the authentication tokens page", feature_token_management: true, js: true do
+    scenario "a user views the token management page", feature_token_management: true, js: true do
       when_i_click_on_the_organisation_settings_link
       and_i_see_api_tokens_details
 
@@ -68,21 +68,15 @@ feature "Organisation details" do
       then_i_see_the_organisation_details
       and_i_see_the_organisation_team_members
       and_i_see_the_contact_support_email
+      and_i_dont_see_api_tokens_details
     end
 
-    scenario "a user views the authentication tokens page", feature_token_management: true, js: true do
+    scenario "a user views the token management page", feature_token_management: true, js: true do
       when_i_click_on_the_organisation_settings_link
-      and_i_see_api_tokens_details
+      then_i_dont_see_api_tokens_details
 
-      and_i_click_on_view_docs_link do |window|
-        then_i_see_the_documentation(window)
-      end
-
-      when_i_click_on_manage_your_tokens_link
-      then_i_see_the_token_management_page
-
-      when_i_click_on_back_link
-      and_i_see_api_tokens_details
+      when_i_attempt_to_visit_the_token_management_page
+      then_i_see_the_unauthorized_message
     end
   end
 
@@ -101,11 +95,8 @@ feature "Organisation details" do
     end
 
     scenario "a user attempts to view the token management page", feature_token_management: true do
-      token_management_page.load
-
-      expect(page).to have_content(
-        "You do not have permission to perform this action",
-      )
+      when_i_attempt_to_visit_the_token_management_page
+      then_i_see_the_unauthorized_message
     end
   end
 
@@ -151,6 +142,42 @@ private
       "view a list of tokens, their description, expiry date, date last used",
     )
     expect(organisation_settings_page).to have_content(
+      "generate a new token and give it a name, a description (optional) and set an expiry date (optional) revoke a token",
+    )
+  end
+
+  def and_i_dont_see_api_tokens_details
+    expect(organisation_settings_page).not_to have_content("API Tokens")
+    expect(organisation_settings_page).not_to have_content(
+      "If you want to use the Register API to send your trainee data from your Students Record System directly to the Register service, you will need an API token.",
+    )
+    expect(organisation_settings_page).not_to have_content(
+      "What is an API token?",
+    )
+    expect(organisation_settings_page).not_to have_content(
+      "The API token is unique to your organisation and is a code that authenticates the transfer of your trainee data from your Student Record System directly into the Register service via the Register API (piece of software).",
+    )
+
+    expect("Your token is needed by the developers who are managing your Register API integration.")
+    expect(organisation_settings_page).not_to have_content(
+      "You can view and use the Register API technical documentation (opens in new tab).",
+    )
+    expect(organisation_settings_page).not_to have_content(
+      "How to manage your API token",
+    )
+    expect(organisation_settings_page).not_to have_content(
+      "The Register API is used to make trainee data transfer quicker and easier.",
+    )
+    expect(organisation_settings_page).not_to have_content(
+      "You must make sure the token is securely sent to the developers managing your Register API integration.",
+    )
+    expect(organisation_settings_page).not_to have_content(
+      "In the 'Manage your API token' screen, you can:",
+    )
+    expect(organisation_settings_page).not_to have_content(
+      "view a list of tokens, their description, expiry date, date last used",
+    )
+    expect(organisation_settings_page).not_to have_content(
       "generate a new token and give it a name, a description (optional) and set an expiry date (optional) revoke a token",
     )
   end
@@ -280,4 +307,14 @@ private
   def then_i_see_the_root_page
     expect(page).to have_content("Your trainee teachers")
   end
+
+  def then_i_see_the_unauthorized_message
+    expect(page).to have_content("You do not have permission to perform this action")
+  end
+
+  def when_i_attempt_to_visit_the_token_management_page
+    token_management_page.load
+  end
+
+  alias_method :then_i_dont_see_api_tokens_details, :and_i_dont_see_api_tokens_details
 end

--- a/spec/features/organisation_settings_spec.rb
+++ b/spec/features/organisation_settings_spec.rb
@@ -224,7 +224,7 @@ private
       expect(token_management_page).to have_content("Created by\t#{user.name} on #{Time.zone.today.to_fs(:govuk)}")
       expect(token_management_page).to have_content("Last used\t#{Time.zone.today.to_fs(:govuk)}")
       expect(token_management_page).not_to have_content("Revoked by")
-      expect(token_management_page).not_to have_content("Expires at")
+      expect(token_management_page).not_to have_content("Expires on")
       expect(token_management_page).not_to have_content("Expired")
     end
 
@@ -234,7 +234,7 @@ private
       expect(token_management_page).to have_content("Created by\t#{user.name} on #{Time.zone.today.to_fs(:govuk)}")
       expect(token_management_page).to have_content("Last used\t#{1.day.ago.to_date.to_fs(:govuk)}")
       expect(token_management_page).not_to have_content("Revoked by")
-      expect(token_management_page).to have_content("Expires at\t#{1.month.from_now.to_date.to_fs(:govuk)}")
+      expect(token_management_page).to have_content("Expires on\t#{1.month.from_now.to_date.to_fs(:govuk)}")
     end
 
     within("#token-#{token_three.id}") do
@@ -252,7 +252,7 @@ private
       expect(token_management_page).to have_content("Created by\t#{user.name} on #{Time.zone.today.to_fs(:govuk)}")
       expect(token_management_page).to have_content("Last used\t#{Time.zone.today.to_fs(:govuk)}")
       expect(token_management_page).to have_content("Revoked by\t#{user.name} on #{Time.zone.today.to_fs(:govuk)}")
-      expect(token_management_page).not_to have_content("Expires at")
+      expect(token_management_page).not_to have_content("Expires on")
       expect(token_management_page).not_to have_content("Expired")
     end
 

--- a/spec/features/organisation_settings_spec.rb
+++ b/spec/features/organisation_settings_spec.rb
@@ -116,18 +116,16 @@ private
   end
 
   def and_i_see_api_tokens_details
-    expect(organisation_settings_page).to have_content("API Tokens")
+    expect(organisation_settings_page).to have_content("Register API Tokens")
     expect(organisation_settings_page).to have_content(
-      "If you want to use the Register API to send your trainee data from your Students Record System directly to the Register service, you will need an API token.",
+      "You need an API token if you want to use the Register API to send your trainee data from your students record system directly to the Register service.",
     )
     expect(organisation_settings_page).to have_content(
-      "What is an API token?",
+      "The API token is unique to your organisation and is a code that authenticates the transfer of your trainee data from your student record system directly into the Register service.",
     )
     expect(organisation_settings_page).to have_content(
-      "The API token is unique to your organisation and is a code that authenticates the transfer of your trainee data from your Student Record System directly into the Register service via the Register API (piece of software).",
+      "Your token is needed by the developers who are managing your Register API integration.",
     )
-
-    expect("Your token is needed by the developers who are managing your Register API integration.")
     expect(organisation_settings_page).to have_content(
       "You can view and use the Register API technical documentation (opens in new tab).",
     )
@@ -152,18 +150,16 @@ private
   end
 
   def and_i_dont_see_api_tokens_details
-    expect(organisation_settings_page).not_to have_content("API Tokens")
+    expect(organisation_settings_page).not_to have_content("Register API Tokens")
     expect(organisation_settings_page).not_to have_content(
-      "If you want to use the Register API to send your trainee data from your Students Record System directly to the Register service, you will need an API token.",
+      "You need an API token if you want to use the Register API to send your trainee data from your students record system directly to the Register service.",
     )
     expect(organisation_settings_page).not_to have_content(
-      "What is an API token?",
+      "The API token is unique to your organisation and is a code that authenticates the transfer of your trainee data from your student record system directly into the Register service.",
     )
     expect(organisation_settings_page).not_to have_content(
-      "The API token is unique to your organisation and is a code that authenticates the transfer of your trainee data from your Student Record System directly into the Register service via the Register API (piece of software).",
+      "Your token is needed by the developers who are managing your Register API integration.",
     )
-
-    expect("Your token is needed by the developers who are managing your Register API integration.")
     expect(organisation_settings_page).not_to have_content(
       "You can view and use the Register API technical documentation (opens in new tab).",
     )

--- a/spec/policies/authentication_token_policy_spec.rb
+++ b/spec/policies/authentication_token_policy_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AuthenticationTokenPolicy, type: :policy do
     let(:lead_partner_user_context) { UserWithOrganisationContext.new(user: lead_partner_user, session: {}) }
 
     permissions :index? do
-      it { is_expected.to permit(lead_partner_user_context) }
+      it { is_expected.not_to permit(lead_partner_user_context) }
     end
   end
 
@@ -59,8 +59,8 @@ RSpec.describe AuthenticationTokenPolicy, type: :policy do
 
       subject { described_class.new(lead_partner_user_context, AuthenticationToken) }
 
-      it "returns only the authentication tokens that belong to the LeadPartner provider of the current user" do
-        expect(subject.resolve).to match_array(provider_user_authentication_tokens)
+      it "returns empty" do
+        expect(subject.resolve).to be_empty
       end
     end
 


### PR DESCRIPTION
### Context

[8272-create-new-self-serve-token-management-index-page
](https://trello.com/c/epDJSjwz/8272-create-new-self-serve-token-management-index-page)

Follow up PR

### Changes proposed in this pull request

* Order tokens by `status` and `last_used_at`
* Make content changes to index page
* Refactor `AuthenticationTokenPolicy` to forbid access to Lead Partners
* Refactor `AddAttributesToAutheticationTokens`


### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
