### PR TITLE
[8297] Add a Cron job to expire Authentication tokens

### DIFF
--- a/app/controllers/authentication_tokens_controller.rb
+++ b/app/controllers/authentication_tokens_controller.rb
@@ -4,13 +4,13 @@ class AuthenticationTokensController < ApplicationController
   before_action { require_feature_flag(:token_management) }
 
   def index
-    @tokens = authorize(tokens).by_status_and_last_used_at
+    authorize(tokens)
   end
 
 private
 
   def tokens
-    policy_scope(AuthenticationToken)
+    @tokens ||= policy_scope(AuthenticationToken)
       .includes(:provider, :created_by, :revoked_by)
       .by_status_and_last_used_at
   end

--- a/app/controllers/authentication_tokens_controller.rb
+++ b/app/controllers/authentication_tokens_controller.rb
@@ -4,13 +4,13 @@ class AuthenticationTokensController < ApplicationController
   before_action { require_feature_flag(:token_management) }
 
   def index
-    authorize(tokens)
+    @tokens = authorize(tokens).by_status_and_last_used_at
   end
 
 private
 
   def tokens
-    @tokens ||= policy_scope(AuthenticationToken)
+    policy_scope(AuthenticationToken)
       .includes(:provider, :created_by, :revoked_by)
       .by_status_and_last_used_at
   end

--- a/app/jobs/authentication_tokens/expire_tokens_job.rb
+++ b/app/jobs/authentication_tokens/expire_tokens_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AuthenticationTokens
+  class ExpireTokensJob < ApplicationJob
+    def perform
+      AuthenticationToken.will_expire(Date.current).update_all(status: :expired)
+    end
+  end
+end

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -60,7 +60,7 @@ class AuthenticationToken < ApplicationRecord
 
   scope :will_expire, lambda { |date = nil|
     if date.present?
-      active.where(expires_at: date)
+      active.where(expires_at: ..date)
     else
       active.where.not(expires_at: nil)
     end

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -58,6 +58,14 @@ class AuthenticationToken < ApplicationRecord
   belongs_to :created_by, class_name: "User"
   belongs_to :revoked_by, class_name: "User", optional: true
 
+  scope :will_expire, lambda { |date = nil|
+    if date.present?
+      active.where(expires_at: date)
+    else
+      active.where.not(expires_at: nil)
+    end
+  }
+
   validates :hashed_token, presence: true, uniqueness: true
   validates :name, presence: true, length: { maximum: 200 }
 

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -25,7 +25,7 @@ remove_duplicate_dead_jobs:
 # Jobs that run once a day at a specific time, sorted by their running time
 expire_authentication_tokens:
   cron: "0 0 * * *" # Every day at 00:00 (midnight).
-  class: "AuthenticationTokens::ExpireTokensJob "
+  class: "AuthenticationTokens::ExpireTokensJob"
   queue: default
 truncate_activerecord_session_store:
   cron: "0 0 * * *" # Every day at 00:00 (midnight).

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -1,5 +1,4 @@
 # Jobs that run once a month at a specific time, sorted by their running time
-
 delete_cancelled_and_failed_bulk_update_trainee_uploads:
   cron: "0 0 1 * *" # Every month at 00:00 (midnight).
   class: "BulkUpdate::AddTrainees::RemoveCancelledAndFailedJob"
@@ -24,6 +23,10 @@ remove_duplicate_dead_jobs:
   queue: default
 
 # Jobs that run once a day at a specific time, sorted by their running time
+expire_authentication_tokens:
+  cron: "0 0 * * *" # Every day at 00:00 (midnight).
+  class: "AuthenticationTokens::ExpireTokensJob "
+  queue: default
 truncate_activerecord_session_store:
   cron: "0 0 * * *" # Every day at 00:00 (midnight).
   class: "SessionStoreTruncateJob"

--- a/db/migrate/20250324100449_add_expires_at_index_to_authentication_tokens.rb
+++ b/db/migrate/20250324100449_add_expires_at_index_to_authentication_tokens.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddExpiresAtIndexToAuthenticationTokens < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :authentication_tokens, :expires_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_21_143706) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_24_100449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -138,6 +138,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_21_143706) do
     t.bigint "revoked_by_id"
     t.string "status", default: "active"
     t.index ["created_by_id"], name: "index_authentication_tokens_on_created_by_id"
+    t.index ["expires_at"], name: "index_authentication_tokens_on_expires_at"
     t.index ["hashed_token"], name: "index_authentication_tokens_on_hashed_token", unique: true
     t.index ["provider_id"], name: "index_authentication_tokens_on_provider_id"
     t.index ["revoked_by_id"], name: "index_authentication_tokens_on_revoked_by_id"

--- a/spec/jobs/authentication_tokens/expire_tokens_job_spec.rb
+++ b/spec/jobs/authentication_tokens/expire_tokens_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AuthenticationTokens::ExpireTokensJob do
+  subject { described_class }
+
+  describe "#perform" do
+    let!(:token_will_expire_today) { create(:authentication_token, expires_at: Date.current) }
+    let!(:token_will_expire_in_the_future) { create(:authentication_token, :will_expire) }
+    let!(:token_wont_expire) { create(:authentication_token) }
+    let!(:token_expired) { create(:authentication_token, :expired) }
+    let!(:token_revoked) { create(:authentication_token, :revoked) }
+
+    it do
+      expect {
+        subject.perform_now
+      }.to change {
+        token_will_expire_today.reload.status
+      }.from("active").to("expired")
+        .and not_change {
+          token_will_expire_in_the_future.reload.status
+        }
+        .and not_change {
+          token_wont_expire.reload.status
+        }
+        .and not_change {
+          token_expired.reload.status
+        }
+        .and not_change {
+          token_revoked.reload.status
+        }
+    end
+  end
+end

--- a/spec/jobs/authentication_tokens/expire_tokens_job_spec.rb
+++ b/spec/jobs/authentication_tokens/expire_tokens_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe AuthenticationTokens::ExpireTokensJob do
 
   describe "#perform" do
     let!(:token_will_expire_today) { create(:authentication_token, expires_at: Date.current) }
+    let!(:token_should_have_expired_in_the_past) { create(:authentication_token, expires_at: 1.day.ago) }
     let!(:token_will_expire_in_the_future) { create(:authentication_token, :will_expire) }
     let!(:token_wont_expire) { create(:authentication_token) }
     let!(:token_expired) { create(:authentication_token, :expired) }
@@ -18,6 +19,9 @@ RSpec.describe AuthenticationTokens::ExpireTokensJob do
       }.to change {
         token_will_expire_today.reload.status
       }.from("active").to("expired")
+        .and change {
+          token_should_have_expired_in_the_past.reload.status
+        }.from("active").to("expired")
         .and not_change {
           token_will_expire_in_the_future.reload.status
         }

--- a/spec/models/authentication_token_spec.rb
+++ b/spec/models/authentication_token_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe AuthenticationToken do
     describe "::will_expire" do
       let!(:active_token) { create(:authentication_token) }
       let!(:active_token_will_expire_today) { create(:authentication_token, expires_at: date) }
+      let!(:active_token_should_have_expired_yesterday) { create(:authentication_token, expires_at: 1.day.ago) }
       let!(:active_token_will_expire_in_the_future) { create(:authentication_token, :will_expire) }
       let!(:expired_token) { create(:authentication_token, :expired) }
       let!(:revoked_token) { create(:authentication_token, :will_expire, :revoked) }
@@ -40,14 +41,18 @@ RSpec.describe AuthenticationToken do
 
       context "when date is present" do
         it "returns only the active tokens which will expire at the provided date" do
-          expect(described_class.will_expire(date)).to contain_exactly(active_token_will_expire_today)
+          expect(described_class.will_expire(date)).to contain_exactly(
+            active_token_will_expire_today, active_token_should_have_expired_yesterday
+          )
         end
       end
 
       context "when date is not present" do
         it "returns all the active tokens with an expired_at date" do
           expect(described_class.will_expire).to contain_exactly(
-            active_token_will_expire_today, active_token_will_expire_in_the_future
+            active_token_will_expire_today,
+            active_token_should_have_expired_yesterday,
+            active_token_will_expire_in_the_future,
           )
         end
       end

--- a/spec/models/authentication_token_spec.rb
+++ b/spec/models/authentication_token_spec.rb
@@ -28,6 +28,32 @@ RSpec.describe AuthenticationToken do
     it { is_expected.to belong_to(:revoked_by).optional }
   end
 
+  describe "scopes" do
+    describe "::will_expire" do
+      let!(:active_token) { create(:authentication_token) }
+      let!(:active_token_will_expire_today) { create(:authentication_token, expires_at: date) }
+      let!(:active_token_will_expire_in_the_future) { create(:authentication_token, :will_expire) }
+      let!(:expired_token) { create(:authentication_token, :expired) }
+      let!(:revoked_token) { create(:authentication_token, :will_expire, :revoked) }
+
+      let(:date) { Time.current.to_date }
+
+      context "when date is present" do
+        it "returns only the active tokens which will expire at the provided date" do
+          expect(described_class.will_expire(date)).to contain_exactly(active_token_will_expire_today)
+        end
+      end
+
+      context "when date is not present" do
+        it "returns all the active tokens with an expired_at date" do
+          expect(described_class.will_expire).to contain_exactly(
+            active_token_will_expire_today, active_token_will_expire_in_the_future
+          )
+        end
+      end
+    end
+  end
+
   describe ".create_with_random_token" do
     let(:token) { "Bearer #{described_class.create_with_random_token(provider_id: provider.id, name: 'Provider test token', created_by: user)}" }
 


### PR DESCRIPTION
### Context

[8297-add-a-cron-job-to-expire-authentication-tokens](https://trello.com/c/7zPcVuKz/8297-add-a-cron-job-to-expire-authentication-tokens)

Based on the `expires_at` date, set the status of relevant `active` tokens as `expired`

### Changes proposed in this pull request

* Add `will_expire` scope to `AuthenticationToken`
* Add `AuthenticationTokens:: ExpireTokensJob`
* Add `expires_at` index to `AuthenticationToken`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
