### PR TITLE
[8103] - API guidance content update

### DIFF
--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3545,7 +3545,7 @@ Deletes an existing degree for this trainee.
         string (limited to 2 characters), required if degree is from the UK
       </p>
       <p class="govuk-body">
-        The grade of the degree. Coded according to <a href="https://www.hesa.ac.uk/collection/c24053/e/degclss">HESA degree class field</a>
+        The grade of the degree. Only the highest previous degree qualification should be submitted. Coded according to <a href="https://www.hesa.ac.uk/collection/c24053/e/degclss">HESA degree class field</a>
       </p>
       <p class="govuk-body">
         Example: <code>02</code>

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -3615,7 +3615,7 @@ Deletes an existing degree for this trainee.
         string (limited to 2 characters), required if degree is from the UK
       </p>
       <p class="govuk-body">
-        The grade of the degree. Coded according to <a href="https://www.hesa.ac.uk/collection/c24053/e/degclss">HESA degree class field</a>
+        The grade of the degree. Only the highest previous degree qualification should be submitted. Coded according to <a href="https://www.hesa.ac.uk/collection/c24053/e/degclss">HESA degree class field</a>
       </p>
       <p class="govuk-body">
         Example: <code>02</code>


### PR DESCRIPTION
### Context

The guidance for submitting trainee previous  degree qualifications needs to be updated to specify that only the highest previous degree qualification should be submitted via API or CSV.

### Changes proposed in this pull request

updates API guidance

### Guidance to review

check the changes here match the requests made in the [trello ticket](https://trello.com/c/4AvMhbP2/8103-update-guidance-for-submitting-only-the-highest-degree-qualification-via-api-or-csv)
