### PR TITLE
[8304] Withdraw endpoint not behaving as expected

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -185,10 +185,10 @@ class Trainee < ApplicationRecord
 
   has_many :placements, dependent: :destroy, inverse_of: :trainee
 
-  # this is the old relation which will be retired
+  # This is the old relation which will be retired
   has_many :trainee_withdrawal_reasons, inverse_of: :trainee
   has_many :withdrawal_reasons, through: :trainee_withdrawal_reasons
-  # going forward, withdrawal_reasons  belong to a a trainee's withdrawal record within "trainee_withdrawals"
+  # Going forward, withdrawal_reasons belong to a trainee's withdrawal record within "trainee_withdrawals"
   has_many :trainee_withdrawals, dependent: :destroy
 
   has_many :potential_duplicate_trainees, dependent: :destroy

--- a/app/serializers/api/v0_1/trainee_serializer.rb
+++ b/app/serializers/api/v0_1/trainee_serializer.rb
@@ -51,6 +51,7 @@ module Api
             training_route: training_route,
             nationality: nationality,
             training_initiative: training_initiative,
+            withdraw_date: @trainee.current_withdrawal&.date&.iso8601,
             withdraw_reasons: withdraw_reasons,
             withdrawal_trigger: @trainee.current_withdrawal&.trigger,
             withdrawal_future_interest: @trainee.current_withdrawal&.future_interest,
@@ -223,7 +224,7 @@ module Api
       end
 
       def withdraw_reasons
-        @trainee.withdrawal_reasons&.map(&:name)
+        @trainee.current_withdrawal_reasons&.map(&:name)
       end
 
       delegate :ethnic_group, :disability_disclosure, :course_education_phase, :trainee_start_date, to: :@trainee

--- a/app/services/api/trainees/withdraw_response.rb
+++ b/app/services/api/trainees/withdraw_response.rb
@@ -46,8 +46,8 @@ module Api
         assign_attributes(params)
 
         if valid?
-          update!(attributes_to_save.except(:trigger, :future_interest, :withdrawal_reasons, :another_reason))
-          trainee.trainee_withdrawals.create!(attributes_to_save.except(:withdraw_date))
+          update!(attributes_to_save.except(:trigger, :future_interest, :withdrawal_reasons, :another_reason, :withdraw_date))
+          trainee.trainee_withdrawals.create!(attributes_to_save.except(:withdraw_date).merge(date: attributes_to_save[:withdraw_date]))
           withdraw!
           ::Trainees::Withdraw.call(trainee:)
           true

--- a/spec/requests/api/v0_1/trainees/post_withdraw_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_withdraw_spec.rb
@@ -55,8 +55,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
             headers: { Authorization: "Bearer #{token}", **json_headers },
             params: params.to_json,
           )
-        } .to change { trainee.reload.withdraw_date }.from(nil)
-        .and change { trainee.reload.state }.from("trn_received").to("withdrawn")
+        } .to change { trainee.reload.state }.from("trn_received").to("withdrawn")
       end
 
       it "calls the dqt withdraw service" do

--- a/spec/requests/api/v1_0_pre/trainees/post_withdraw_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_withdraw_spec.rb
@@ -25,13 +25,16 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
     context "with a withdrawable trainee" do
       let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :trn_received, provider:) }
       let(:reason) { create(:withdrawal_reason, :provider) }
+      let(:withdraw_date) { Time.zone.today.iso8601 }
+      let(:trigger) { "provider" }
+      let(:future_interest) { "no" }
       let(:params) do
         {
           data: {
             reasons: [reason.name],
-            withdraw_date: Time.zone.now.iso8601,
-            trigger: "provider",
-            future_interest: "no",
+            withdraw_date: withdraw_date,
+            trigger: trigger,
+            future_interest: future_interest,
           },
         }
       end
@@ -46,6 +49,10 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
         expect(response).to have_http_status(:ok)
 
         expect(response.parsed_body.dig(:data, :trainee_id)).to eql(trainee_id)
+        expect(response.parsed_body.dig(:data, :withdraw_reasons)).to include(reason.name)
+        expect(response.parsed_body.dig(:data, :withdraw_date)).to eq(withdraw_date)
+        expect(response.parsed_body.dig(:data, :withdrawal_trigger)).to eq(trigger)
+        expect(response.parsed_body.dig(:data, :withdrawal_future_interest)).to eq(future_interest)
       end
 
       it "change the trainee", openapi: false do

--- a/spec/requests/api/v1_0_pre/trainees/post_withdraw_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_withdraw_spec.rb
@@ -62,8 +62,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
             headers: { Authorization: "Bearer #{token}", **json_headers },
             params: params.to_json,
           )
-        } .to change { trainee.reload.withdraw_date }.from(nil)
-        .and change { trainee.reload.state }.from("trn_received").to("withdrawn")
+        } .to change { trainee.reload.state }.from("trn_received").to("withdrawn")
       end
 
       it "calls the dqt withdraw service", openapi: false do

--- a/spec/services/api/trainees/withdraw_response_spec.rb
+++ b/spec/services/api/trainees/withdraw_response_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe Api::Trainees::WithdrawResponse do
-  let(:version) { "v0.1" }
+  let(:version) { "v1.0-pre" }
   let(:withdraw_response) { described_class.call(trainee:, params:, version:) }
   let(:params) do
     {
@@ -18,7 +18,7 @@ describe Api::Trainees::WithdrawResponse do
   let(:reasons) { [reason.name] }
   let(:trigger) { "provider" }
   let(:future_interest) { "no" }
-  let(:withdraw_date) { Time.zone.now.iso8601 }
+  let(:withdraw_date) { Time.zone.today.iso8601 }
   let(:another_reason) { "" }
 
   subject { withdraw_response }
@@ -35,7 +35,7 @@ describe Api::Trainees::WithdrawResponse do
       expect {
         subject
       } .to change { trainee.reload.current_withdrawal&.trigger }.from(nil).to("provider")
-      .and change { trainee.reload.withdraw_date }.from(nil)
+      .and change { trainee.reload.current_withdrawal&.date&.iso8601 }.from(nil).to(withdraw_date)
       .and change { trainee.reload.current_withdrawal&.future_interest }.from(nil).to("no")
       .and change { trainee.reload.state }.from("trn_received").to("withdrawn")
       .and change { trainee.reload.current_withdrawal_reasons&.pluck(:name) }.from(nil).to(reasons)


### PR DESCRIPTION
### Context

See the [Trello ticket](https://trello.com/c/RvM5FM9A/8304-withdraw-endpoint-not-behaving-as-expected)

### Changes proposed in this pull request

* Update the tests for the withdraw endpoint
* Return the withdraw reasons in the trainee serializer, and the correct withdraw date
* Fix the setting of the withdraw date  

### Guidance to review

* Has anything been missed?
* Is this consistent with the withdraw process through the web UI?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
