### PR TITLE
[8294] Remove some internal Register fields from API responses

### DIFF
--- a/app/serializers/api/v0_1/trainee_serializer.rb
+++ b/app/serializers/api/v0_1/trainee_serializer.rb
@@ -41,7 +41,6 @@ module Api
         applying_for_grant
         applying_for_scholarship
         bursary_tier
-        withdraw_date
         withdraw_reasons_details
         withdraw_reasons_dfe_details
       ].freeze

--- a/app/serializers/api/v0_1/trainee_serializer.rb
+++ b/app/serializers/api/v0_1/trainee_serializer.rb
@@ -5,19 +5,35 @@ module Api
     class TraineeSerializer
       EXCLUDED_ATTRIBUTES = %w[
         id
+        iqts_country
+        additional_dttp_data
+        course_uuid
+        commencement_status
+        created_from_dttp
+        created_from_hesa
+        discarded_at
+        hesa_updated_at
+        hesa_editable
         slug
+        slug_sent_to_dqt_at
         state
+        submission_ready
         progress
         provider_id
         dttp_id
         placement_assignment_dttp_id
+        placement_detail
         dttp_update_sha
         dormancy_dttp_id
         lead_partner_id
+        lead_partner_not_applicable
         employing_school_id
+        employing_school_not_applicable
         course_allocation_subject_id
         start_academic_cycle_id
         end_academic_cycle_id
+        ebacc
+        region
         hesa_trn_submission_id
         application_choice_id
         apply_application_id
@@ -25,6 +41,7 @@ module Api
         applying_for_grant
         applying_for_scholarship
         bursary_tier
+        withdraw_date
         withdraw_reasons_details
         withdraw_reasons_dfe_details
       ].freeze

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3531,8 +3531,17 @@ Deletes an existing degree for this trainee.
         The trainee’s record state (read-only).
       </p>
       <p class="govuk-body">
-        Example: <code>submitted_for_trn</code>
+        Possible values:
       </p>
+      <ul>
+        <li><code>draft</code></li>
+        <li><code>submitted_for_trn</code></li>
+        <li><code>trn_received</code></li>
+        <li><code>recommended_for_award</code></li>
+        <li><code>withdrawn</code></li>
+        <li><code>deferred</code></li>
+        <li><code>awarded</code></li>
+      </ul>
     </dd>
   </div>
 </dl>

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3509,8 +3509,16 @@ Deletes an existing degree for this trainee.
         Where the trainee record originally came from when it was created (read-only).
       </p>
       <p class="govuk-body">
-        Example: <code>api</code>
+        Possible values:
       </p>
+      <ul>
+        <li><code>manual</code></li>
+        <li><code>api</code></li>
+        <li><code>csv</code></li>
+        <li><code>hesa</code></li>
+        <li><code>apply</code></li>
+        <li><code>dttp</code></li>
+      </ul>
     </dd>
   </div>
   <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3283,6 +3283,34 @@ Deletes an existing degree for this trainee.
     </dd>
   </div>
   <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>course_min_age</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        integer
+      </p>
+      <p class="govuk-body">
+        The lower bound of the age range of children taught on the course (read-only).
+      </p>
+      <p class="govuk-body">
+        Example: <code>7</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>course_max_age</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        integer
+      </p>
+      <p class="govuk-body">
+        The upper bound of the age range of children taught on the course (read-only).
+      </p>
+      <p class="govuk-body">
+        Example: <code>11</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
     <dt class="govuk-summary-list__key"><code>course_age_range</code></dt>
     <dd class="govuk-summary-list__value">
       <p class="govuk-body">
@@ -3443,7 +3471,62 @@ Deletes an existing degree for this trainee.
       </p>
     </dd>
   </div>
-
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>reinstate_date</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        date
+      </p>
+      <p class="govuk-body">
+        The trainee’s reinstate date. (read-only)
+      </p>
+      <p class="govuk-body">
+        Example: <code>2023-10-01</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>course_education_phase</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        string
+      </p>
+      <p class="govuk-body">
+        The trainee’s course education phase. (read-only)
+      </p>
+      <p class="govuk-body">
+        Example: <code>primary</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>record_source</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        string
+      </p>
+      <p class="govuk-body">
+        The trainee’s record source. (read-only)
+      </p>
+      <p class="govuk-body">
+        Example: <code>api</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>state</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        string
+      </p>
+      <p class="govuk-body">
+        The trainee’s record state. (read-only)
+      </p>
+      <p class="govuk-body">
+        Example: <code>submitted_for_trn</code>
+      </p>
+    </dd>
+  </div>
 </dl>
 
 ### Placement object
@@ -3619,6 +3702,20 @@ Deletes an existing degree for this trainee.
       </p>
       <p class="govuk-body">
         Example: <code>2012-07-31</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>locale_code</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        string
+      </p>
+      <p class="govuk-body">
+        The locale code `uk` or `non_uk` (read-only).
+      </p>
+      <p class="govuk-body">
+        Example: <code>uk</code>
       </p>
     </dd>
   </div>

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3520,7 +3520,7 @@ Deletes an existing degree for this trainee.
         string
       </p>
       <p class="govuk-body">
-        The trainee’s record state. (read-only)
+        The trainee’s record state (read-only).
       </p>
       <p class="govuk-body">
         Example: <code>submitted_for_trn</code>

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3492,7 +3492,7 @@ Deletes an existing degree for this trainee.
         string
       </p>
       <p class="govuk-body">
-        The trainee’s course education phase. (read-only)
+        The trainee’s course education phase (read-only).
       </p>
       <p class="govuk-body">
         Example: <code>primary</code>

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3506,7 +3506,7 @@ Deletes an existing degree for this trainee.
         string
       </p>
       <p class="govuk-body">
-        The trainee’s record source. (read-only)
+        Where the trainee record originally came from when it was created (read-only).
       </p>
       <p class="govuk-body">
         Example: <code>api</code>

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3475,7 +3475,7 @@ Deletes an existing degree for this trainee.
     <dt class="govuk-summary-list__key"><code>reinstate_date</code></dt>
     <dd class="govuk-summary-list__value">
       <p class="govuk-body">
-        date
+        string
       </p>
       <p class="govuk-body">
         The date that a deferred trainee returned to the course (read-only).

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3478,7 +3478,7 @@ Deletes an existing degree for this trainee.
         date
       </p>
       <p class="govuk-body">
-        The trainee’s reinstate date. (read-only)
+        The date that a deferred trainee returned to the course (read-only).
       </p>
       <p class="govuk-body">
         Example: <code>2023-10-01</code>

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -3513,7 +3513,62 @@ Deletes an existing degree for this trainee.
       </p>
     </dd>
   </div>
-
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>reinstate_date</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        date
+      </p>
+      <p class="govuk-body">
+        The trainee’s reinstate date. (read-only)
+      </p>
+      <p class="govuk-body">
+        Example: <code>2023-10-01</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>course_education_phase</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        string
+      </p>
+      <p class="govuk-body">
+        The trainee’s course education phase. (read-only)
+      </p>
+      <p class="govuk-body">
+        Example: <code>primary</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>record_source</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        string
+      </p>
+      <p class="govuk-body">
+        The trainee’s record source. (read-only)
+      </p>
+      <p class="govuk-body">
+        Example: <code>api</code>
+      </p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+    <dt class="govuk-summary-list__key"><code>state</code></dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        string
+      </p>
+      <p class="govuk-body">
+        The trainee’s record state. (read-only)
+      </p>
+      <p class="govuk-body">
+        Example: <code>submitted_for_trn</code>
+      </p>
+    </dd>
+  </div>
 </dl>
 
 ### Placement object

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -3551,8 +3551,16 @@ Deletes an existing degree for this trainee.
         The trainee’s record source. (read-only)
       </p>
       <p class="govuk-body">
-        Example: <code>api</code>
+        Possible values:
       </p>
+      <ul>
+        <li><code>manual</code></li>
+        <li><code>api</code></li>
+        <li><code>csv</code></li>
+        <li><code>hesa</code></li>
+        <li><code>apply</code></li>
+        <li><code>dttp</code></li>
+      </ul>
     </dd>
   </div>
   <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -3573,8 +3573,17 @@ Deletes an existing degree for this trainee.
         The trainee’s record state. (read-only)
       </p>
       <p class="govuk-body">
-        Example: <code>submitted_for_trn</code>
+        Possible values:
       </p>
+      <ul>
+        <li><code>draft</code></li>
+        <li><code>submitted_for_trn</code></li>
+        <li><code>trn_received</code></li>
+        <li><code>recommended_for_award</code></li>
+        <li><code>withdrawn</code></li>
+        <li><code>deferred</code></li>
+        <li><code>awarded</code></li>
+      </ul>
     </dd>
   </div>
 </dl>

--- a/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
@@ -152,12 +152,12 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     it "sets the correct school attributes" do
       post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
 
-      parsed_body = response.parsed_body[:data]
+      trainee = Trainee.last
 
-      expect(parsed_body[:lead_partner_not_applicable]).to be(true)
-      expect(parsed_body[:lead_partner]).to be_nil
-      expect(parsed_body[:employing_school_not_applicable]).to be(true)
-      expect(parsed_body[:employing_school]).to be_nil
+      expect(trainee.lead_partner_not_applicable).to be(true)
+      expect(trainee.lead_partner_id).to be_nil
+      expect(trainee.employing_school_not_applicable).to be(true)
+      expect(trainee.employing_school_id).to be_nil
     end
 
     it "creates the degrees if provided in the request body" do
@@ -219,8 +219,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
         end
 
         it "sets lead_partner_not_applicable and employing_school_not_applicable to false" do
-          expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-          expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+          trainee = Trainee.last
+
+          expect(trainee.lead_partner_not_applicable).to be(true)
+          expect(trainee.employing_school_not_applicable).to be(true)
         end
       end
 
@@ -242,7 +244,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
           end
 
           it "sets lead_partner_not_applicable to true" do
-            expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
+            trainee = Trainee.last
+
+            expect(trainee.lead_partner_not_applicable).to be(true)
           end
         end
 
@@ -265,7 +269,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             end
 
             it "sets lead_partner_not_applicable to false" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(false)
+              trainee = Trainee.last
+
+              expect(trainee.lead_partner_not_applicable).to be(false)
             end
           end
 
@@ -279,7 +285,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             end
 
             it "sets lead_partner_not_applicable to true" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
+              trainee = Trainee.last
+
+              expect(trainee.lead_partner_not_applicable).to be(true)
             end
           end
         end
@@ -301,7 +309,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             end
 
             it "sets employing_school_not_applicable to true" do
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+              trainee = Trainee.last
+
+              expect(trainee.employing_school_not_applicable).to be(true)
             end
           end
 
@@ -322,7 +332,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             end
 
             it "sets employing_school_not_applicable to false" do
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
+              trainee = Trainee.last
+
+              expect(trainee.employing_school_not_applicable).to be(false)
             end
           end
         end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -400,8 +400,10 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         end
 
         it "sets the lead_partner_not_applicable and employing_school_not_applicable to true" do
-          expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-          expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+          trainee.reload
+
+          expect(trainee.lead_partner_not_applicable).to be(true)
+          expect(trainee.employing_school_not_applicable).to be(true)
         end
 
         context "with existing lead_partner_not_applicable and employing_school_not_applicable set to true" do
@@ -422,8 +424,10 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           end
 
           it "does not change lead_partner_not_applicable and employing_school_not_applicable" do
-            expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-            expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+            trainee.reload
+
+            expect(trainee.lead_partner_not_applicable).to be(true)
+            expect(trainee.employing_school_not_applicable).to be(true)
           end
         end
       end
@@ -445,8 +449,10 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           end
 
           it "sets lead_partner_not_applicable to true and employing_school_not_applicable to true" do
-            expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-            expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+            trainee.reload
+
+            expect(trainee.lead_partner_not_applicable).to be(true)
+            expect(trainee.employing_school_not_applicable).to be(true)
           end
         end
 
@@ -469,8 +475,10 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
             end
 
             it "sets lead_partner_not_applicable to false and employing_school_not_applicable to true" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(false)
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+              trainee.reload
+
+              expect(trainee.lead_partner_not_applicable).to be(false)
+              expect(trainee.employing_school_not_applicable).to be(true)
             end
           end
 
@@ -479,7 +487,10 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
             it "sets lead_partner_urn to nil and lead_partner_not_applicable to true" do
               expect(response.parsed_body[:data][:lead_partner_urn]).to be_nil
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
+
+              trainee.reload
+
+              expect(trainee.lead_partner_not_applicable).to be(true)
             end
           end
         end
@@ -500,8 +511,10 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           end
 
           it "sets lead_partner_not_applicable and employing_school_not_applicable to true" do
-            expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-            expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+            trainee.reload
+
+            expect(trainee.lead_partner_not_applicable).to be(true)
+            expect(trainee.employing_school_not_applicable).to be(true)
           end
         end
 
@@ -524,8 +537,10 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
             end
 
             it "sets lead_partner_not_applicable to true and employing_school_not_applicable to false" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
+              trainee.reload
+
+              expect(trainee.lead_partner_not_applicable).to be(true)
+              expect(trainee.employing_school_not_applicable).to be(false)
             end
           end
 
@@ -538,8 +553,10 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
             end
 
             it "sets lead_partner_not_applicable and employing_school_not_applicable to true" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+              trainee.reload
+
+              expect(trainee.lead_partner_not_applicable).to be(true)
+              expect(trainee.employing_school_not_applicable).to be(true)
             end
           end
         end

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -141,12 +141,14 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     it "sets the correct lead partner and employing school attributes" do
       post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
-      parsed_body = response.parsed_body[:data]
+      response.parsed_body[:data]
 
-      expect(parsed_body[:lead_partner_not_applicable]).to be(true)
-      expect(parsed_body[:lead_partner]).to be_nil
-      expect(parsed_body[:employing_school_not_applicable]).to be(true)
-      expect(parsed_body[:employing_school]).to be_nil
+      trainee = Trainee.last
+
+      expect(trainee.lead_partner_not_applicable).to be(true)
+      expect(trainee.lead_partner_id).to be_nil
+      expect(trainee.employing_school_not_applicable).to be(true)
+      expect(trainee.employing_school_id).to be_nil
     end
 
     it "creates the degrees if provided in the request body" do
@@ -194,8 +196,10 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
         end
 
         it "sets lead_partner_not_applicable and employing_school_not_applicable to false" do
-          expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-          expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+          trainee = Trainee.last
+
+          expect(trainee.lead_partner_not_applicable).to be(true)
+          expect(trainee.employing_school_not_applicable).to be(true)
         end
       end
 
@@ -217,7 +221,9 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
         end
 
         it "sets lead_partner_not_applicable to false" do
-          expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(false)
+          trainee = Trainee.last
+
+          expect(trainee.lead_partner_not_applicable).to be(false)
         end
       end
 
@@ -238,7 +244,9 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
           end
 
           it "sets lead_partner_not_applicable to true" do
-            expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
+            trainee = Trainee.last
+
+            expect(trainee.lead_partner_not_applicable).to be(true)
           end
         end
 
@@ -261,7 +269,9 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
             end
 
             it "sets lead_partner_not_applicable to false" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(false)
+              trainee = Trainee.last
+
+              expect(trainee.lead_partner_not_applicable).to be(false)
             end
           end
 
@@ -274,7 +284,9 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
             end
 
             it "sets lead_partner_not_applicable to true" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
+              trainee = Trainee.last
+
+              expect(trainee.lead_partner_not_applicable).to be(true)
             end
           end
         end
@@ -295,7 +307,9 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
             end
 
             it "sets employing_school_not_applicable to true" do
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+              trainee = Trainee.last
+
+              expect(trainee.employing_school_not_applicable).to be(true)
             end
           end
 
@@ -316,7 +330,9 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
             end
 
             it "sets employing_school_not_applicable to false" do
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
+              trainee = Trainee.last
+
+              expect(trainee.employing_school_not_applicable).to be(false)
             end
           end
 
@@ -339,7 +355,9 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
             end
 
             it "sets employing_school_not_applicable to false" do
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
+              trainee = Trainee.last
+
+              expect(trainee.employing_school_not_applicable).to be(false)
             end
 
             it "sets lead_partner_urn to lead_partner#urn" do

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -141,8 +141,6 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
     it "sets the correct lead partner and employing school attributes" do
       post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
 
-      response.parsed_body[:data]
-
       trainee = Trainee.last
 
       expect(trainee.lead_partner_not_applicable).to be(true)

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -432,8 +432,10 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
         end
 
         it "sets the lead_partner_not_applicable and employing_school_not_applicable to true" do
-          expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-          expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+          trainee.reload
+
+          expect(trainee.lead_partner_not_applicable).to be(true)
+          expect(trainee.employing_school_not_applicable).to be(true)
         end
 
         context "with existing lead_partner_not_applicable and employing_school_not_applicable set to true" do
@@ -454,8 +456,10 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
           end
 
           it "does not change lead_partner_not_applicable and employing_school_not_applicable" do
-            expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-            expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+            trainee.reload
+
+            expect(trainee.lead_partner_not_applicable).to be(true)
+            expect(trainee.employing_school_not_applicable).to be(true)
           end
         end
       end
@@ -477,8 +481,10 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
           end
 
           it "sets lead_partner_not_applicable to true and employing_school_not_applicable to true" do
-            expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-            expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+            trainee.reload
+
+            expect(trainee.lead_partner_not_applicable).to be(true)
+            expect(trainee.employing_school_not_applicable).to be(true)
           end
         end
 
@@ -501,8 +507,10 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
             end
 
             it "sets lead_partner_not_applicable to false and employing_school_not_applicable to true" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(false)
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+              trainee.reload
+
+              expect(trainee.lead_partner_not_applicable).to be(false)
+              expect(trainee.employing_school_not_applicable).to be(true)
             end
           end
 
@@ -511,7 +519,10 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
 
             it "sets lead_partner_urn to nil and lead_partner_not_applicable to true" do
               expect(response.parsed_body[:data][:lead_partner_urn]).to be_nil
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
+
+              trainee.reload
+
+              expect(trainee.lead_partner_not_applicable).to be(true)
             end
           end
         end
@@ -532,8 +543,10 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
           end
 
           it "sets lead_partner_not_applicable and employing_school_not_applicable to true" do
-            expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-            expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+            trainee.reload
+
+            expect(trainee.lead_partner_not_applicable).to be(true)
+            expect(trainee.employing_school_not_applicable).to be(true)
           end
         end
 
@@ -556,8 +569,10 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
             end
 
             it "sets lead_partner_not_applicable to true and employing_school_not_applicable to false" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
+              trainee.reload
+
+              expect(trainee.lead_partner_not_applicable).to be(true)
+              expect(trainee.employing_school_not_applicable).to be(false)
             end
           end
 
@@ -570,8 +585,10 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
             end
 
             it "sets lead_partner_not_applicable and employing_school_not_applicable to true" do
-              expect(response.parsed_body[:data][:lead_partner_not_applicable]).to be(true)
-              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
+              trainee.reload
+
+              expect(trainee.lead_partner_not_applicable).to be(true)
+              expect(trainee.employing_school_not_applicable).to be(true)
             end
           end
         end

--- a/spec/serializers/api/v0_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/trainee_serializer_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Api::V01::TraineeSerializer do
         itt_end_date
         trn
         submitted_for_trn_at
+        withdraw_date
         withdraw_reasons
         withdrawal_trigger
         withdrawal_future_interest

--- a/spec/serializers/api/v0_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/trainee_serializer_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Api::V01::TraineeSerializer do
         itt_end_date
         trn
         submitted_for_trn_at
-        withdraw_date
         withdraw_reasons
         withdrawal_trigger
         withdrawal_future_interest
@@ -47,22 +46,8 @@ RSpec.describe Api::V01::TraineeSerializer do
         awarded_at
         training_initiative
         study_mode
-        ebacc
-        region
         course_education_phase
-        course_uuid
-        lead_partner_not_applicable
-        employing_school_not_applicable
-        submission_ready
-        commencement_status
-        discarded_at
-        additional_dttp_data
-        hesa_updated_at
         record_source
-        iqts_country
-        hesa_editable
-        slug_sent_to_dqt_at
-        placement_detail
         ukprn
         course_qualification
         course_title
@@ -89,8 +74,6 @@ RSpec.describe Api::V01::TraineeSerializer do
         application_id
         ethnic_background
         additional_ethnic_background
-        created_from_dttp
-        created_from_hesa
         bursary_level
         funding_method
         itt_qualification_aim


### PR DESCRIPTION
### Context

[8294-remove-some-internal-register-fields-from-api-responses](https://trello.com/c/xh4OHX8A/8294-remove-some-internal-register-fields-from-api-responses)

### Changes proposed in this pull request

* Exclude various attributes from `TraineeSerializer`
* Update reference docs

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
