### PR TITLE
[8310] Add deferral reason to API endpoint POST /trainees/{trainee_id}/defer

### DIFF
--- a/app/controllers/api/trainees/deferrals_controller.rb
+++ b/app/controllers/api/trainees/deferrals_controller.rb
@@ -22,7 +22,7 @@ module Api
       end
 
       def deferral_params
-        params.require(:data).permit(:defer_date)
+        params.require(:data).permit(:defer_date, :defer_reason)
       end
 
       def model = :trainee

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -21,6 +21,7 @@
 # Indexes
 #
 #  index_authentication_tokens_on_created_by_id            (created_by_id)
+#  index_authentication_tokens_on_expires_at               (expires_at)
 #  index_authentication_tokens_on_hashed_token             (hashed_token) UNIQUE
 #  index_authentication_tokens_on_provider_id              (provider_id)
 #  index_authentication_tokens_on_revoked_by_id            (revoked_by_id)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -24,6 +24,7 @@
 #  created_from_hesa               :boolean          default(FALSE), not null
 #  date_of_birth                   :date
 #  defer_date                      :date
+#  defer_reason                    :string
 #  disability_disclosure           :integer
 #  discarded_at                    :datetime
 #  diversity_disclosure            :integer

--- a/app/services/api/trainees/deferral_service.rb
+++ b/app/services/api/trainees/deferral_service.rb
@@ -8,10 +8,12 @@ module Api
       include ServicePattern
 
       attribute :defer_date
+      attribute :defer_reason
 
       attr_reader :trainee
 
       validates :defer_date, presence: true, date: true
+      validates :defer_reason, length: { maximum: 500 }
 
       validates_with DeferralValidator
 
@@ -36,6 +38,7 @@ module Api
       def trainee_attributes
         {}.tap do |hash|
           hash[:defer_date]         = defer_date
+          hash[:defer_reason]       = defer_reason
           hash[:trainee_start_date] = itt_start_date if itt_start_date.is_a?(Date)
         end
       end

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -192,6 +192,7 @@ current academic cycle.
           "withdraw_date": null,
 
           "defer_date": "2023-10-17",
+          "defer_reason": null,
           "recommended_for_award_at": null,
           "trainee_start_date": "2023-09-04",
           "reinstate_date": null,
@@ -347,6 +348,7 @@ Get a single trainee.
         "state": "deferred",
         "withdraw_date": null,
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": null,
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -851,6 +853,7 @@ Trainee details
         "state": "deferred",
         "withdraw_date": null,
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": null,
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -991,6 +994,7 @@ Trainee details
           "withdraw_date": null,
 
           "defer_date": null,
+          "defer_reason": null,
           "recommended_for_award_at": null,
           "trainee_start_date": "2023-01-01",
           "reinstate_date": null,
@@ -1460,6 +1464,7 @@ Recommendation details
         "withdraw_date": null,
 
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": "2024-06-17T09:05:48Z",
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -1630,6 +1635,20 @@ Deferral details
     </p>
   </dd>
 </div>
+<div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+  <dt class="govuk-summary-list__key"><code>defer_reason</code></dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+      string (limited to 500 characters)
+    </p>
+    <p class="govuk-body">
+      The reason that the Trainee deferred.
+    </p>
+    <p class="govuk-body">
+      Example: <code>Cannot attend course</code>
+    </p>
+  </dd>
+</div>
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">Example request body</span></summary>
@@ -1637,7 +1656,8 @@ Deferral details
     <pre class="json-code-sample">
     {
       "data": {
-        "defer_date": "2024-06-17"
+        "defer_date": "2024-06-17",
+        "defer_reason": null,
       }
     }
     </pre>

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -3809,6 +3809,10 @@ Deletes an existing degree for this trainee.
       <td class="govuk-table__cell govuk-table__cell--numeric">3</td>
     </tr>
     <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Trainee.properties.defer_reason.maxLength</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">500</td>
+    </tr>
+    <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Trainee.properties.disability1.maxLength</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">2</td>
     </tr>

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -3856,6 +3856,10 @@ Deletes an existing degree for this trainee.
       <td class="govuk-table__cell govuk-table__cell--numeric">3</td>
     </tr>
     <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Trainee.properties.defer_reason.maxLength</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">500</td>
+    </tr>
+    <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Trainee.properties.disability1.maxLength</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">2</td>
     </tr>

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -1665,7 +1665,7 @@ Deferral details
     {
       "data": {
         "defer_date": "2024-06-17",
-        "defer_reason": null,
+        "defer_reason": "The trainee's circumstances changed so they want to defer"
       }
     }
     </pre>

--- a/app/views/api_docs/reference/v1.0-pre/_reference.md
+++ b/app/views/api_docs/reference/v1.0-pre/_reference.md
@@ -156,6 +156,7 @@ current academic cycle.
           "state": "deferred",
           "withdraw_date": null,
           "defer_date": "2023-10-17",
+          "defer_reason": null,
           "recommended_for_award_at": null,
           "trainee_start_date": "2023-09-04",
           "reinstate_date": null,
@@ -312,6 +313,7 @@ Get a single trainee.
         "state": "deferred",
         "withdraw_date": null,
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": null,
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -823,6 +825,7 @@ Trainee details
         "submitted_for_trn_at": "2024-09-11T15:12:45.345Z",
         "withdraw_date": null,
         "defer_date": null,
+        "defer_reason": null,
         "recommended_for_award_at": null,
         "trainee_start_date": "2023-01-01",
         "reinstate_date": null,
@@ -972,6 +975,7 @@ Trainee details
           "submitted_for_trn_at": "2024-09-11T15:12:45.345Z",
           "withdraw_date": null,
           "defer_date": null,
+          "defer_reason": null,
           "recommended_for_award_at": null,
           "trainee_start_date": "2023-01-01",
           "reinstate_date": null,
@@ -1468,6 +1472,7 @@ Recommendation details
         "state": "recommended_for_award",
         "withdraw_date": null,
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": "2024-06-17T09:05:48Z",
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -1638,6 +1643,20 @@ Deferral details
     </p>
   </dd>
 </div>
+<div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+  <dt class="govuk-summary-list__key"><code>defer_reason</code></dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+      string (limited to 500 characters)
+    </p>
+    <p class="govuk-body">
+      The reason that the Trainee deferred.
+    </p>
+    <p class="govuk-body">
+      Example: <code>Cannot attend course</code>
+    </p>
+  </dd>
+</div>
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">Example request body</span></summary>
@@ -1645,7 +1664,8 @@ Deferral details
     <pre class="json-code-sample">
     {
       "data": {
-        "defer_date": "2024-06-17"
+        "defer_date": "2024-06-17",
+        "defer_reason": null,
       }
     }
     </pre>
@@ -1685,6 +1705,7 @@ Deferral details
         "state": "recommended_for_award",
         "withdraw_date": null,
         "defer_date": "2024-06-17",
+        "defer_reason": null,
         "recommended_for_award_at": nil,
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -1966,6 +1987,7 @@ Withdraw details
         "state": "deferred",
         "withdraw_date": null,
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": null,
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -2155,6 +2177,7 @@ Deletes an existing degree for this trainee.
         "withdrawal_reasons": null,
         "withdrawal_another_reason": null,
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": null,
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -2339,6 +2362,7 @@ Trainee details
         "withdrawal_reasons": null,
         "withdrawal_another_reason": null,
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": null,
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,
@@ -2814,6 +2838,7 @@ Deletes an existing placement for this trainee.
         "withdrawal_reasons": null,
         "withdrawal_another_reason": null,
         "defer_date": "2023-10-17",
+        "defer_reason": null,
         "recommended_for_award_at": null,
         "trainee_start_date": "2023-09-04",
         "reinstate_date": null,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -243,6 +243,7 @@ shared:
     - created_from_hesa
     - date_of_birth
     - defer_date
+    - defer_reason
     - disability_disclosure
     - discarded_at
     - diversity_disclosure

--- a/db/migrate/20250326142810_add_defer_reason_to_trainees.rb
+++ b/db/migrate/20250326142810_add_defer_reason_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeferReasonToTrainees < ActiveRecord::Migration[7.2]
+  def change
+    add_column :trainees, :defer_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_24_100449) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_26_142810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -992,6 +992,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_24_100449) do
     t.integer "application_choice_id"
     t.text "provider_trainee_id"
     t.bigint "lead_partner_id"
+    t.string "defer_reason"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_allocation_subject_id"], name: "index_trainees_on_course_allocation_subject_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"

--- a/public/openapi/v0.1.yaml
+++ b/public/openapi/v0.1.yaml
@@ -347,6 +347,8 @@ paths:
                           nullable: true
                         withdrawal_another_reason:
                           nullable: true
+                        defer_reason:
+                          nullable: true
                       required:
                       - first_names
                       - last_name
@@ -441,13 +443,13 @@ paths:
                 - meta
               example:
                 data:
-                - first_names: Jamey
-                  last_name: Hamill
-                  date_of_birth: '1994-05-27'
+                - first_names: Teresita
+                  last_name: Bergnaum
+                  date_of_birth: '1967-01-26'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Jamey.Hamill@example.com
-                  middle_names: Price
+                  email: Teresita.Bergnaum@example.com
+                  middle_names: Connelly
                   training_route:
                   sex: '10'
                   diversity_disclosure: diversity_not_disclosed
@@ -456,15 +458,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-24'
+                  itt_start_date: '2024-08-27'
                   outcome_date:
-                  itt_end_date: '2025-07-23'
+                  itt_end_date: '2025-07-14'
                   trn:
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-09-08'
+                  trainee_start_date: '2024-09-03'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -493,14 +495,15 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-334
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-24'
+                  course_itt_start_date: '2024-08-27'
                   course_age_range:
-                  expected_end_date: '2025-07-23'
+                  expected_end_date: '2025-07-14'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -527,17 +530,17 @@ paths:
                     uk_degree_uuid: 3e042de2-a453-47dc-9452-90a23399e9ee
                     subject_uuid: b78270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                    degree_id: all6rp0dssieq2wg5ve26h64
+                    degree_id: l0pn3chfvqheqrnkjsvzt7hy
                   state: submitted_for_trn
-                  trainee_id: q4kkuakxlvo0yt5q96djbx50
+                  trainee_id: vrmzatstmi8xrlgadjxxqzwc
                   application_id:
-                - first_names: Adela
-                  last_name: Larkin
-                  date_of_birth: '1979-03-05'
+                - first_names: Francine
+                  last_name: Parisian
+                  date_of_birth: '1975-05-17'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Adela.Larkin@example.com
-                  middle_names: Hand
+                  email: Francine.Parisian@example.com
+                  middle_names: Terry
                   training_route:
                   sex: '10'
                   diversity_disclosure: diversity_not_disclosed
@@ -546,15 +549,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-29'
+                  itt_start_date: '2024-08-04'
                   outcome_date:
-                  itt_end_date: '2026-07-15'
+                  itt_end_date: '2026-07-23'
                   trn:
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-29'
+                  trainee_start_date: '2024-08-07'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -583,14 +586,15 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-332
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-29'
+                  course_itt_start_date: '2024-08-04'
                   course_age_range:
-                  expected_end_date: '2026-07-15'
+                  expected_end_date: '2026-07-23'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -617,17 +621,17 @@ paths:
                     uk_degree_uuid: ef695652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 438270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: vwb0flpcyy7lprdoxh3ly44i
+                    degree_id: 759rd0755jn9r4t7jqqyet9r
                   state: submitted_for_trn
-                  trainee_id: 9t02bvell3u7frm4z74a525q
+                  trainee_id: tjjt6ngqcjgkz9wziq307xgf
                   application_id:
-                - first_names: Andreas
-                  last_name: Gorczany
-                  date_of_birth: '1975-02-07'
+                - first_names: Leif
+                  last_name: Brekke
+                  date_of_birth: '1997-06-10'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Andreas.Gorczany@example.com
-                  middle_names: Farrell
+                  email: Leif.Brekke@example.com
+                  middle_names: Maggio
                   training_route:
                   sex: '12'
                   diversity_disclosure: diversity_not_disclosed
@@ -636,15 +640,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-14'
+                  itt_start_date: '2024-08-07'
                   outcome_date:
-                  itt_end_date: '2026-07-09'
-                  trn: '6668504'
+                  itt_end_date: '2026-07-07'
+                  trn: '9480898'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-17'
+                  trainee_start_date: '2024-08-14'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -663,7 +667,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '1698802260900'
+                  hesa_id: '1393782982477'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -673,20 +677,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-329
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-14'
+                  course_itt_start_date: '2024-08-07'
                   course_age_range: '13916'
-                  expected_end_date: '2026-07-09'
+                  expected_end_date: '2026-07-07'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: C
-                  previous_last_name: Langworth
+                  previous_last_name: Fahey
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -717,17 +722,17 @@ paths:
                     uk_degree_uuid: 676a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 898270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: axt0pt1ml13k75f78vbe7vzv
+                    degree_id: ui3u4ek1rr6d94vgrx5aeanw
                   state: trn_received
-                  trainee_id: 3wxoyskjiog2nkqby7usyjr1
+                  trainee_id: f8pwx04mwdzn6bljt5hqczfv
                   application_id:
-                - first_names: Coy
-                  last_name: Aufderhar
-                  date_of_birth: '1982-05-27'
+                - first_names: Wiley
+                  last_name: Denesik
+                  date_of_birth: '2003-02-08'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Coy.Aufderhar@example.com
-                  middle_names: Bernhard
+                  email: Wiley.Denesik@example.com
+                  middle_names: Kuvalis
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -736,15 +741,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-27'
+                  itt_start_date: '2024-08-02'
                   outcome_date:
-                  itt_end_date: '2026-07-04'
-                  trn: '3746708'
+                  itt_end_date: '2026-07-19'
+                  trn: '9910603'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-09-01'
+                  trainee_start_date: '2024-08-07'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -763,7 +768,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '2983104752473'
+                  hesa_id: '5430014709296'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -773,20 +778,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-326
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-27'
+                  course_itt_start_date: '2024-08-02'
                   course_age_range: '13912'
-                  expected_end_date: '2026-07-04'
+                  expected_end_date: '2026-07-19'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: '8'
-                  previous_last_name: Johnston
+                  previous_last_name: Lang
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -817,17 +823,17 @@ paths:
                     uk_degree_uuid: 4b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 9d8670f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
-                    degree_id: 0yry58hkaehwrcjos3j3lh0j
+                    degree_id: umz3cs557ne80a5zx7en8rri
                   state: trn_received
-                  trainee_id: u0wbzymoevekkbt1xrsk36wc
+                  trainee_id: 4w3rjexeppg5q0jqzjkbnxe1
                   application_id:
-                - first_names: Gavin
-                  last_name: Dicki
-                  date_of_birth: '2000-03-29'
+                - first_names: Nathanial
+                  last_name: Rice
+                  date_of_birth: '1971-08-22'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Gavin.Dicki@example.com
-                  middle_names: Labadie
+                  email: Nathanial.Rice@example.com
+                  middle_names: Greenholt
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -836,15 +842,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-29'
+                  itt_start_date: '2024-08-12'
                   outcome_date:
-                  itt_end_date: '2026-07-23'
-                  trn: '6910814'
+                  itt_end_date: '2026-07-11'
+                  trn: '8049521'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-09-04'
+                  trainee_start_date: '2024-08-26'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -863,7 +869,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '1281301358018'
+                  hesa_id: '1222202436259'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -873,20 +879,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-323
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-29'
+                  course_itt_start_date: '2024-08-12'
                   course_age_range: '13914'
-                  expected_end_date: '2026-07-23'
+                  expected_end_date: '2026-07-11'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: D
-                  previous_last_name: Hilll
+                  previous_last_name: Lind
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -917,17 +924,17 @@ paths:
                     uk_degree_uuid: 0f6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: d58370f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: 9lebs9d9eti281c445ksfcaf
+                    degree_id: 817d8l19qd20bbuvkalw6n12
                   state: trn_received
-                  trainee_id: anfvxp51hp45f32xxu6nuzox
+                  trainee_id: wewnjzpy9w49svlf2oh5a1aq
                   application_id:
-                - first_names: Leandro
-                  last_name: Larkin
-                  date_of_birth: '1993-09-08'
+                - first_names: Damion
+                  last_name: MacGyver
+                  date_of_birth: '1960-01-22'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Leandro.Larkin@example.com
-                  middle_names: Lowe
+                  email: Damion.MacGyver@example.com
+                  middle_names: DuBuque
                   training_route:
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -936,15 +943,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-31'
+                  itt_start_date: '2024-08-08'
                   outcome_date:
-                  itt_end_date: '2025-07-01'
-                  trn: '9407527'
+                  itt_end_date: '2025-07-26'
+                  trn: '3265674'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-09-15'
+                  trainee_start_date: '2024-08-22'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -963,7 +970,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '2837333044619'
+                  hesa_id: '3483614413277'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -973,20 +980,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-320
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-31'
+                  course_itt_start_date: '2024-08-08'
                   course_age_range: '13918'
-                  expected_end_date: '2025-07-01'
+                  expected_end_date: '2025-07-26'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: C
-                  previous_last_name: Barrows
+                  previous_last_name: Dickinson
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1017,17 +1025,17 @@ paths:
                     uk_degree_uuid: 1f6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 2b8370f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
-                    degree_id: f57hulqp4m2tl87vumzo8jnd
+                    degree_id: t5zjw0694zod81b26aknhy3b
                   state: trn_received
-                  trainee_id: jkxms4qp6s1gkepuw2omgct2
+                  trainee_id: mzev5nhke4c2afrid0ku7a92
                   application_id:
-                - first_names: Kieth
-                  last_name: Welch
-                  date_of_birth: '1965-07-14'
+                - first_names: Miquel
+                  last_name: Schamberger
+                  date_of_birth: '1971-08-29'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Kieth.Welch@example.com
-                  middle_names: Cremin
+                  email: Miquel.Schamberger@example.com
+                  middle_names: MacGyver
                   training_route:
                   sex: '10'
                   diversity_disclosure: diversity_not_disclosed
@@ -1036,15 +1044,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-11'
+                  itt_start_date: '2024-08-15'
                   outcome_date:
-                  itt_end_date: '2026-07-26'
-                  trn: '3243994'
+                  itt_end_date: '2026-07-14'
+                  trn: '2667989'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-15'
+                  trainee_start_date: '2024-08-19'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -1063,7 +1071,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '2306595020807'
+                  hesa_id: '7158943250229'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1073,20 +1081,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-317
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-11'
+                  course_itt_start_date: '2024-08-15'
                   course_age_range: '13911'
-                  expected_end_date: '2026-07-26'
+                  expected_end_date: '2026-07-14'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: '6'
-                  previous_last_name: O'Hara
+                  previous_last_name: Frami
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1117,17 +1126,17 @@ paths:
                     uk_degree_uuid: 3f6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: a38270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: pvc8oosbxuly0dfxqnfp2diq
+                    degree_id: y6tblctpef8xt4urb7mqiihl
                   state: trn_received
-                  trainee_id: 1fpi8v9p55wrfihrk2t8fays
+                  trainee_id: kth7vs29uoyiqe4wtamqm3gz
                   application_id:
-                - first_names: Demarcus
-                  last_name: Oberbrunner
-                  date_of_birth: '1961-11-22'
+                - first_names: Marion
+                  last_name: Franecki
+                  date_of_birth: '1993-07-23'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Demarcus.Oberbrunner@example.com
-                  middle_names: Gerlach
+                  email: Marion.Franecki@example.com
+                  middle_names: Stokes
                   training_route:
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -1136,15 +1145,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-08'
+                  itt_start_date: '2024-08-01'
                   outcome_date:
-                  itt_end_date: '2026-07-10'
-                  trn: '2463446'
+                  itt_end_date: '2026-07-29'
+                  trn: '7041699'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-10'
+                  trainee_start_date: '2024-08-02'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -1163,7 +1172,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '9147974291105'
+                  hesa_id: '9196535714235'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1173,20 +1182,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-314
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-08'
+                  course_itt_start_date: '2024-08-01'
                   course_age_range: '13915'
-                  expected_end_date: '2026-07-10'
+                  expected_end_date: '2026-07-29'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: C
-                  previous_last_name: Kassulke
+                  previous_last_name: Hermann
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1217,17 +1227,17 @@ paths:
                     uk_degree_uuid: 7ba49954-7595-437c-8df0-6a777c97307b
                     subject_uuid: 518770f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: qx5bv8ekn0x6sac64yvfnl3j
+                    degree_id: 1vxrbo629yqlvsmr6gnt8d3g
                   state: trn_received
-                  trainee_id: dam354sar5pg7q7lcsv4z9hi
+                  trainee_id: jyik1e5yva2rhrhd9ol1lrlw
                   application_id:
-                - first_names: Rae
-                  last_name: Lang
-                  date_of_birth: '1981-12-17'
+                - first_names: Nelly
+                  last_name: Lowe
+                  date_of_birth: '1962-04-29'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Rae.Lang@example.com
-                  middle_names: Streich
+                  email: Nelly.Lowe@example.com
+                  middle_names: Rosenbaum
                   training_route:
                   sex: '12'
                   diversity_disclosure: diversity_not_disclosed
@@ -1236,15 +1246,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-24'
+                  itt_start_date: '2024-08-30'
                   outcome_date:
-                  itt_end_date: '2025-07-03'
-                  trn: '7180039'
+                  itt_end_date: '2025-07-15'
+                  trn: '2155420'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-29'
+                  trainee_start_date: '2024-09-04'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -1263,7 +1273,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '2941739266947'
+                  hesa_id: '3128032973525'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1273,20 +1283,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-311
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-24'
+                  course_itt_start_date: '2024-08-30'
                   course_age_range: '13918'
-                  expected_end_date: '2025-07-03'
+                  expected_end_date: '2025-07-15'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: '9'
-                  previous_last_name: Hirthe
+                  previous_last_name: Smitham
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1317,17 +1328,17 @@ paths:
                     uk_degree_uuid: e5695652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 858270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: 9j786p81xmp4f6ml2zm5j30u
+                    degree_id: 9zmslznd0ufuljpw6kuxd9k2
                   state: trn_received
-                  trainee_id: bskeyo7k3jdf0pj41cs3r618
+                  trainee_id: 5gnc5m1ed8yxcbxnu568sgwd
                   application_id:
-                - first_names: Rea
-                  last_name: Moen
-                  date_of_birth: '1988-03-09'
+                - first_names: Gordon
+                  last_name: Kerluke
+                  date_of_birth: '1981-07-28'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Rea.Moen@example.com
-                  middle_names: Gulgowski
+                  email: Gordon.Kerluke@example.com
+                  middle_names: Kuhic
                   training_route:
                   sex: '96'
                   diversity_disclosure: diversity_not_disclosed
@@ -1336,15 +1347,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-13'
+                  itt_start_date: '2024-08-15'
                   outcome_date:
-                  itt_end_date: '2025-07-02'
-                  trn: '7909223'
+                  itt_end_date: '2025-07-27'
+                  trn: '2899321'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-19'
+                  trainee_start_date: '2024-08-21'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -1363,7 +1374,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '4046574084455'
+                  hesa_id: '8042194863713'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1373,20 +1384,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-308
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-13'
+                  course_itt_start_date: '2024-08-15'
                   course_age_range: '13909'
-                  expected_end_date: '2025-07-02'
+                  expected_end_date: '2025-07-27'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: D
-                  previous_last_name: Simonis
+                  previous_last_name: Ondricka
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1417,17 +1429,17 @@ paths:
                     uk_degree_uuid: 196a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: e8599844-7783-4707-b090-e7f9d5abc6bc
                     grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                    degree_id: 1nugmaoap5ybqo2zjnkha18d
+                    degree_id: inbna7vkt7eshceofgcg6sz3
                   state: trn_received
-                  trainee_id: s773qqslcz919e5u1azi7d8n
+                  trainee_id: ajsn5dwajc58d6b1f399frwp
                   application_id:
-                - first_names: Denver
-                  last_name: Wyman
-                  date_of_birth: '2000-11-17'
+                - first_names: Hobert
+                  last_name: Rohan
+                  date_of_birth: '1992-04-17'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Denver.Wyman@example.com
-                  middle_names: Gulgowski
+                  email: Hobert.Rohan@example.com
+                  middle_names: Raynor
                   training_route:
                   sex: '12'
                   diversity_disclosure: diversity_not_disclosed
@@ -1436,15 +1448,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-17'
+                  itt_start_date: '2024-08-30'
                   outcome_date:
-                  itt_end_date: '2026-07-19'
-                  trn: '3669815'
+                  itt_end_date: '2026-07-20'
+                  trn: '9567613'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-29'
+                  trainee_start_date: '2024-09-15'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -1463,7 +1475,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '5555653226995'
+                  hesa_id: '2037253202990'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1473,20 +1485,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-305
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-17'
+                  course_itt_start_date: '2024-08-30'
                   course_age_range: '13918'
-                  expected_end_date: '2026-07-19'
+                  expected_end_date: '2026-07-20'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: D
-                  previous_last_name: Yost
+                  previous_last_name: Hackett
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1517,17 +1530,17 @@ paths:
                     uk_degree_uuid: 316a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 2f8470f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: fgoenyk6agv98s1f6qp3w2ul
+                    degree_id: 9lxhzbvdmxurnrg9amwcsfrj
                   state: trn_received
-                  trainee_id: 9ozdp15qhzxf4ydgtrnyt97a
+                  trainee_id: 4mhevwdhu9nspwj86k7sd2a2
                   application_id:
-                - first_names: Jamel
-                  last_name: Morissette
-                  date_of_birth: '1959-10-08'
+                - first_names: Courtney
+                  last_name: Bailey
+                  date_of_birth: '1966-05-21'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Jamel.Morissette@example.com
-                  middle_names: Graham
+                  email: Courtney.Bailey@example.com
+                  middle_names: Dicki
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -1536,15 +1549,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-03'
+                  itt_start_date: '2024-08-30'
                   outcome_date:
-                  itt_end_date: '2025-07-28'
-                  trn: '6939975'
+                  itt_end_date: '2025-07-07'
+                  trn: '3731013'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-04'
+                  trainee_start_date: '2024-09-03'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -1563,7 +1576,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '8638794389861'
+                  hesa_id: '7092167562491'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1573,20 +1586,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-302
-                  ukprn: '61465306'
+                  defer_reason:
+                  ukprn: '58581439'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-03'
+                  course_itt_start_date: '2024-08-30'
                   course_age_range: '13909'
-                  expected_end_date: '2025-07-28'
+                  expected_end_date: '2025-07-07'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: D
-                  previous_last_name: Von
+                  previous_last_name: Effertz
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1617,9 +1631,9 @@ paths:
                     uk_degree_uuid: 4f6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: a58370f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: 2w2nbhh0nqphgvzdmb6n8bjk
+                    degree_id: hv09zmec9bhmsv5nd24fs7wp
                   state: trn_received
-                  trainee_id: yprpfehjf7hqsd8kg9nstq2t
+                  trainee_id: g8ktc1dsom8muuhglfxpy9nj
                   application_id:
                 meta:
                   current_page: 1
@@ -1964,6 +1978,8 @@ paths:
                         nullable: true
                       withdrawal_another_reason:
                         nullable: true
+                      defer_reason:
+                        nullable: true
                     required:
                     - first_names
                     - last_name
@@ -2132,7 +2148,7 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id:
-                  ukprn: '18449948'
+                  ukprn: '66903033'
                   ethnicity: '997'
                   course_qualification: QTS
                   course_title:
@@ -2166,7 +2182,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: u72FAvcKv6wTA9MMmjKDS2p9
+                    placement_id: T8djFDz8ximgdkqUh34DSCuG
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -2182,9 +2198,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: MvFZBMFJpTHY6uNuETuh11nM
+                    degree_id: v5GyaSLgMTp2bnuaTQB7zPft
                   state: submitted_for_trn
-                  trainee_id: AuPz5zmwJeaFteGQkdGDgX4X
+                  trainee_id: UV6ZdLqXUNxj5PjkYNQKQZub
                   disability1: '58'
                   disability2: '57'
                   lead_partner_not_applicable: true
@@ -2194,6 +2210,7 @@ paths:
                   withdrawal_trigger:
                   withdrawal_future_interest:
                   withdrawal_another_reason:
+                  defer_reason:
         '409':
           description: returns status code 409 (conflict) with the potential duplicates
             and does not create a trainee record
@@ -2435,6 +2452,8 @@ paths:
                           nullable: true
                         withdrawal_another_reason:
                           nullable: true
+                        defer_reason:
+                          nullable: true
                       required:
                       - first_names
                       - last_name
@@ -2511,13 +2530,13 @@ paths:
                 - error: Conflict
                   message: This trainee is already in Register
                 data:
-                - first_names: Dallas
-                  last_name: Konopelski
-                  date_of_birth: '2000-05-20'
+                - first_names: Nathalie
+                  last_name: Howe
+                  date_of_birth: '1969-04-08'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Dallas.Konopelski@example.com
-                  middle_names: Cummings
+                  email: Nathalie.Howe@example.com
+                  middle_names: Denesik
                   training_route: '11'
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -2528,13 +2547,13 @@ paths:
                   course_subject_one: '100346'
                   itt_start_date: '2025-01-01'
                   outcome_date:
-                  itt_end_date: '2027-07-12'
+                  itt_end_date: '2027-07-28'
                   trn:
                   submitted_for_trn_at:
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-12-08'
+                  trainee_start_date: '2024-11-29'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -2563,14 +2582,15 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 25/26-3
-                  ukprn: '19642955'
+                  defer_reason:
+                  ukprn: '74874387'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: undergrad
                   course_itt_start_date: '2025-01-01'
                   course_age_range:
-                  expected_end_date: '2027-07-12'
+                  expected_end_date: '2027-07-28'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -2597,9 +2617,9 @@ paths:
                     uk_degree_uuid: 5d6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 318070f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: r85cie1nsl27v6edbno8fhj3
+                    degree_id: 9rcaf6jqur3y3l57sajb0vf2
                   state: draft
-                  trainee_id: uohuo9xlx66bakzfsi9g7rqu
+                  trainee_id: 1yfmo7cfrb7cuwrss1sb13up
                   application_id:
         '422':
           description: return status code 422 with a meaningful error message
@@ -2819,7 +2839,7 @@ paths:
                 pg_apprenticeship_start_date: '2024-03-11'
                 ethnicity: '142'
                 lead_school_urn: '697414'
-                employing_school_urn: '449336'
+                employing_school_urn: '176214'
                 trn: '567899'
                 ethnic_group: mixed_ethnic_group
                 ethnic_background: Another Mixed background
@@ -2958,6 +2978,8 @@ paths:
                     nullable: true
                   provider_trainee_id:
                     type: string
+                  defer_reason:
+                    nullable: true
                   ukprn:
                     type: string
                   ethnicity:
@@ -3081,6 +3103,7 @@ paths:
                 - slug_sent_to_dqt_at
                 - placement_detail
                 - provider_trainee_id
+                - defer_reason
                 - ukprn
                 - ethnicity
                 - course_qualification
@@ -3115,13 +3138,13 @@ paths:
                 - trainee_id
                 - application_id
               example:
-                first_names: Ulysses
-                last_name: Champlin
-                date_of_birth: '1975-11-28'
+                first_names: Hellen
+                last_name: Connelly
+                date_of_birth: '1966-06-29'
                 created_at: '2024-09-15T12:34:56.000Z'
                 updated_at: '2024-09-15T12:34:56.000Z'
-                email: Ulysses.Champlin@example.com
-                middle_names: Mertz
+                email: Hellen.Connelly@example.com
+                middle_names: Christiansen
                 training_route:
                 sex: '11'
                 diversity_disclosure: diversity_not_disclosed
@@ -3157,7 +3180,7 @@ paths:
                 commencement_status:
                 discarded_at:
                 created_from_dttp: false
-                hesa_id: '8222873848302'
+                hesa_id: '3303408379909'
                 additional_dttp_data:
                 created_from_hesa: false
                 hesa_updated_at:
@@ -3167,7 +3190,8 @@ paths:
                 slug_sent_to_dqt_at:
                 placement_detail:
                 provider_trainee_id: 24/25-11
-                ukprn: '96857874'
+                defer_reason:
+                ukprn: '79605183'
                 ethnicity:
                 course_qualification: QTS
                 course_title:
@@ -3180,7 +3204,7 @@ paths:
                 lead_partner_urn:
                 fund_code: '2'
                 bursary_level: B
-                previous_last_name: Rippin
+                previous_last_name: Huels
                 itt_aim: '201'
                 course_study_mode: '01'
                 course_year: 2024
@@ -3241,7 +3265,7 @@ paths:
         required: true
         schema:
           type: string
-        example: LVTtXJCjyJxTc7LidWEd5fbF
+        example: nUqEts8eY8VbgzXHe2h5CFYK
       responses:
         '200':
           description: updates the trainee
@@ -3364,6 +3388,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                        nullable: true
+                      defer_reason:
                         nullable: true
                       ukprn:
                         type: string
@@ -3579,6 +3605,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -3668,7 +3695,8 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id:
-                  ukprn: '87041753'
+                  defer_reason:
+                  ukprn: '70344668'
                   ethnicity: '997'
                   disability1: '55'
                   course_qualification: QTS
@@ -3706,7 +3734,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: 8FjN8jb2iQT5wKv5XCsvr1bW
+                    placement_id: nXjLbqwzjrrfQJL4f1UP2CVq
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -3722,9 +3750,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: k3G54EDb68RLmiBqXw24uGz1
+                    degree_id: 9A1XFC8cVWc8LH57i13zW3CF
                   state: submitted_for_trn
-                  trainee_id: LVTtXJCjyJxTc7LidWEd5fbF
+                  trainee_id: nUqEts8eY8VbgzXHe2h5CFYK
                   application_id:
                   disability2: '57'
         '401':
@@ -3855,7 +3883,7 @@ paths:
                 nationality: FR
                 course_age_range: '13909'
                 lead_partner_urn: '900020'
-                employing_school_urn: '841870'
+                employing_school_urn: '859845'
                 ethnicity:
                 itt_start_date: '2023-01-01'
                 training_route:
@@ -3882,7 +3910,7 @@ paths:
         required: true
         schema:
           type: string
-        example: ozt2318jhrz8i9oxlho0qwgh
+        example: flny65dv684w1808ybloweaj
       requestBody:
         content:
           application/json:
@@ -3894,13 +3922,17 @@ paths:
                   properties:
                     defer_date:
                       type: string
+                    defer_reason:
+                      type: string
                   required:
                   - defer_date
+                  - defer_reason
               required:
               - data
             example:
               data:
                 defer_date: '2024-09-15'
+                defer_reason: vibmh0azdx2b6x13zfax5qnjqtakam89kaepeo8a50np141bkzs43gmtuympgmk6lt6sdvl3mu4y5l1h03yv7xzcjispiily9uvq7zk3yuiqcku36lnkjgzamd27vldyy9c8rbwry8lnlr0fejh5f5wffk9sucqvuyrxj3m1ql1wad2qoda6xrgx9c9ma7bhlokld1ey2uvi5ubhniw90ta1dzq81xu64gzobacgxfja65k2srvt0yih1r89g3xnsukuf03ifi6ok0ext4spt19zlhnfe8atxskel39pmqxncknepd9vvb56hhr3ag2b5bw1cqzjlu12fnkjwd4dza5ps4vxcs1ieywzzaqly6esko43imk44tkooj6jxjphct51p36agwywq1ro3npl9g67mxu802kbyacpvckz5k8p82jamq4szp2l7bfsjbjoi55dsnugj3ofxqvcdlk2yp6b7mu1wxov4kazqskatffswsxyrxsv
       responses:
         '200':
           description: defers a trainee
@@ -3915,6 +3947,8 @@ paths:
                       commencement_status:
                         nullable: true
                       defer_date:
+                        type: string
+                      defer_reason:
                         type: string
                       trainee_start_date:
                         type: string
@@ -4116,6 +4150,7 @@ paths:
                     required:
                     - commencement_status
                     - defer_date
+                    - defer_reason
                     - trainee_start_date
                     - first_names
                     - middle_names
@@ -4195,21 +4230,22 @@ paths:
                 data:
                   commencement_status:
                   defer_date: '2024-09-15'
-                  trainee_start_date: '2024-08-15'
-                  first_names: Stacy
-                  middle_names: Gulgowski
-                  last_name: Schmeler
-                  email: Stacy.Schmeler@example.com
+                  defer_reason: vibmh0azdx2b6x13zfax5qnjqtakam89kaepeo8a50np141bkzs43gmtuympgmk6lt6sdvl3mu4y5l1h03yv7xzcjispiily9uvq7zk3yuiqcku36lnkjgzamd27vldyy9c8rbwry8lnlr0fejh5f5wffk9sucqvuyrxj3m1ql1wad2qoda6xrgx9c9ma7bhlokld1ey2uvi5ubhniw90ta1dzq81xu64gzobacgxfja65k2srvt0yih1r89g3xnsukuf03ifi6ok0ext4spt19zlhnfe8atxskel39pmqxncknepd9vvb56hhr3ag2b5bw1cqzjlu12fnkjwd4dza5ps4vxcs1ieywzzaqly6esko43imk44tkooj6jxjphct51p36agwywq1ro3npl9g67mxu802kbyacpvckz5k8p82jamq4szp2l7bfsjbjoi55dsnugj3ofxqvcdlk2yp6b7mu1wxov4kazqskatffswsxyrxsv
+                  trainee_start_date: '2024-08-23'
+                  first_names: Isiah
+                  middle_names: Moen
+                  last_name: Paucek
+                  email: Isiah.Paucek@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '6335476'
+                  trn: '7690453'
                   region:
                   hesa_id:
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '1962-01-05'
+                  date_of_birth: '1980-06-17'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
@@ -4217,9 +4253,9 @@ paths:
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-15'
+                  itt_start_date: '2024-08-23'
                   outcome_date:
-                  itt_end_date: '2025-07-29'
+                  itt_end_date: '2025-07-21'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   recommended_for_award_at:
@@ -4245,14 +4281,14 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-555
-                  ukprn: '18380244'
+                  ukprn: '86932506'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-15'
+                  course_itt_start_date: '2024-08-23'
                   course_age_range:
-                  expected_end_date: '2025-07-29'
+                  expected_end_date: '2025-07-21'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -4279,9 +4315,9 @@ paths:
                     uk_degree_uuid: c6aeedca-9147-4e88-886a-a90302f3d097
                     subject_uuid: 318770f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: hgm2tndci9wu5h142w7t0tyu
+                    degree_id: b5oj303exva5no5gwzwpzh87
                   state: deferred
-                  trainee_id: wu9g51m7ked4nvje43t2pv6h
+                  trainee_id: tiwub7temlglnb30ee619g2b
                   application_id:
         '404':
           description: returns status code 404
@@ -4333,6 +4369,8 @@ paths:
                 errors:
                 - error: UnprocessableEntity
                   message: Defer date can't be blank
+                - error: UnprocessableEntity
+                  message: Defer reason is too long (maximum is 500 characters)
   "/api/{api_version}/trainees/{trainee_id}/degrees":
     get:
       summary: index
@@ -4350,7 +4388,7 @@ paths:
         required: true
         schema:
           type: string
-        example: hivuw8z6jn9neudvwikkdt5f
+        example: cbmk6m6kft2ue0cq9es2fmwj
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -4430,7 +4468,7 @@ paths:
         required: true
         schema:
           type: string
-        example: j1i031cbyhn1olcl3y7leadm
+        example: fte7s2v1yvxglyexihi8o7a9
       requestBody:
         content:
           application/json:
@@ -4551,7 +4589,7 @@ paths:
                   uk_degree_uuid:
                   subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                  degree_id: UhgLu4yNADFfUz6kzhi2GuRw
+                  degree_id: t19j7nUhX6F8MUTZ4v7JBign
         '404':
           description: does not create a new degree and returns a 404 status (not_found)
             status
@@ -4670,7 +4708,7 @@ paths:
                   uk_degree_uuid: ff695652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 2d8370f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                  degree_id: dysb781e9jcshgwia59urdwb
+                  degree_id: yn7bvsuquzlcn8k2ca13ytia
         '422':
           description: does not create a new degree and returns a 422 status (unprocessable_entity)
             status
@@ -4718,13 +4756,13 @@ paths:
         required: true
         schema:
           type: string
-        example: zdxfz6n1eisq0ktpak4ikizd
+        example: o4fahd97i0p1moqlz1cqz3q1
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: qd3fezwotcz66puc796s521h
+        example: 842a2n3kh72d8xlg1i00xi40
       responses:
         '200':
           description: deletes the degree and returns a 200 status (ok)
@@ -4840,6 +4878,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -4942,6 +4982,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -4969,13 +5010,13 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Chanda
-                  last_name: Schmitt
-                  date_of_birth: '1990-03-30'
+                  first_names: Cherri
+                  last_name: Wilderman
+                  date_of_birth: '1984-09-16'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Chanda.Schmitt@example.com
-                  middle_names: Aufderhar
+                  email: Cherri.Wilderman@example.com
+                  middle_names: Conroy
                   training_route:
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -5021,7 +5062,8 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-524
-                  ukprn: '19640743'
+                  defer_reason:
+                  ukprn: '76464167'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
@@ -5042,7 +5084,7 @@ paths:
                   placements: []
                   degrees: []
                   state: draft
-                  trainee_id: inwth2p1mlyai81xu5f2s6sb
+                  trainee_id: u6t2ix5vgeiumm2djkmlgz27
                   application_id:
         '404':
           description: does not delete the degree and returns a 404 status (not_found)
@@ -5091,7 +5133,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 0acj8u9xsn7k9uzgdo644nr2
+        example: 2y199tkmkawpx57apdzvjnps
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5167,7 +5209,7 @@ paths:
                   uk_degree_uuid: 2f6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: a38170f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
-                  degree_id: x95md5u236q8qwfotcxh9sxy
+                  degree_id: vgyyxwilnvz97fzh38tp93ak
         '404':
           description: returns status code 404 with a valid JSON response
           content:
@@ -5209,13 +5251,13 @@ paths:
         required: true
         schema:
           type: string
-        example: wl7ppdbac9880v33c3j0hpqy
+        example: 60qhrtkx8jmeu1bq90xs53mi
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: gt8gaxrud6pi6x1pjpbhvndo
+        example: yzqetg1bvv137r1yt5omp3yx
       requestBody:
         content:
           application/json:
@@ -5322,7 +5364,7 @@ paths:
                   uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 917f70f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
-                  degree_id: y9xx6gpk6udvp1qbofcqfna1
+                  degree_id: 7swvgd5zh7grlse0lnao96br
         '404':
           description: does not update the degree and returns a 404 status (not_found)
           content:
@@ -5389,7 +5431,7 @@ paths:
         required: true
         schema:
           type: string
-        example: jayyhqyhzkkjpfxlbuurawpa
+        example: jwmss2xv9h8k1fjzhvdgjg3k
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5445,7 +5487,7 @@ paths:
         required: true
         schema:
           type: string
-        example: cqhcgl1hyrqdbuk914cz8884
+        example: cg5nj0at5ul5lw2gfr5h68e1
       requestBody:
         content:
           application/json:
@@ -5467,9 +5509,9 @@ paths:
               - data
             example:
               data:
-                urn: '779331'
-                name: West Wisconsin College
-                postcode: WY3 8BF
+                urn: '384908'
+                name: Cronin Institute
+                postcode: RG2V 4BD
       responses:
         '201':
           description: creates a new placement and returns a 201 (created) status
@@ -5507,15 +5549,15 @@ paths:
                 - data
               example:
                 data:
-                  urn: '779331'
-                  name: West Wisconsin College
-                  address: URN 779331, WY3 8BF
-                  postcode: WY3 8BF
+                  urn: '384908'
+                  name: Cronin Institute
+                  address: URN 384908, RG2V 4BD
+                  postcode: RG2V 4BD
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: BnRtpWFzox5HKkC2RrGbv7RK
+                  placement_id: 2nucK5ed3GbkAvPeV9MX18qg
         '404':
-          description: does not create a new placement and returns a 422 status (unprocessable_entity)
+          description: does not create a new placement and returns a 404 status (not_found)
             status
           content:
             application/json:
@@ -5540,36 +5582,6 @@ paths:
                 errors:
                 - error: NotFound
                   message: Trainee(s) not found
-        '409':
-          description: returns a 409 (conflict) status
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        error:
-                          type: string
-                        message:
-                          type: string
-                      required:
-                      - error
-                      - message
-                  data:
-                    type: array
-                    items: {}
-                required:
-                - errors
-                - data
-              example:
-                errors:
-                - error: Conflict
-                  message: School has already been taken
-                data: []
         '422':
           description: does not create a new placements and returns a 422 status (unprocessable_entity)
             status
@@ -5613,13 +5625,13 @@ paths:
         required: true
         schema:
           type: string
-        example: bqczeg5l0rb9l08pp59o7mi6
+        example: j50kage6inr8qsj29u9yza6x
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: evz0xjlerju0tlch6cpr8qd8
+        example: s24egv6gy75nuwhlumm6d8hn
       responses:
         '200':
           description: removes the specified placement
@@ -5735,6 +5747,8 @@ paths:
                         type: string
                       provider_trainee_id:
                         type: string
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -5882,6 +5896,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -5919,13 +5934,13 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Austin
-                  last_name: Dach
-                  date_of_birth: '2006-05-09'
+                  first_names: Emmett
+                  last_name: Blick
+                  date_of_birth: '1969-09-13'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Austin.Dach@example.com
-                  middle_names: Haag
+                  email: Emmett.Blick@example.com
+                  middle_names: Heaney
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -5961,7 +5976,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '9719694602076'
+                  hesa_id: '4600621977560'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -5971,7 +5986,8 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail: has_placement_detail
                   provider_trainee_id: 24/25-534
-                  ukprn: '25263394'
+                  defer_reason:
+                  ukprn: '48645625'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
@@ -5984,7 +6000,7 @@ paths:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: D
-                  previous_last_name: Howell
+                  previous_last_name: Kihn
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -6000,16 +6016,16 @@ paths:
                   withdrawal_future_interest:
                   withdrawal_another_reason:
                   placements:
-                  - urn: '410091'
-                    name: Brookville 137 High
-                    address: URN 410091, Bernhardtown, YA4 2ZA
-                    postcode: YA4 2ZA
+                  - urn: '632468'
+                    name: Ostbarrow 137 High
+                    address: URN 632468, New Adrianchester, Y3D 2EN
+                    postcode: Y3D 2EN
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: 3ytzj326658xvux1qzpmg7ox
+                    placement_id: gbe64ftj3kk5pgh4jweehlay
                   degrees: []
                   state: draft
-                  trainee_id: evz0xjlerju0tlch6cpr8qd8
+                  trainee_id: s24egv6gy75nuwhlumm6d8hn
                   application_id:
         '404':
           description: returns status code 404 with a valid JSON response
@@ -6058,7 +6074,7 @@ paths:
         required: true
         schema:
           type: string
-        example: bn7cu523a4bt82b4xnou6vnq
+        example: 28ammqqnuhqj5jnit2eqxm6b
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -6096,13 +6112,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '544343'
-                  name: Ironston 139 High
-                  address: URN 544343, Diannashire, NV7 3JP
-                  postcode: NV7 3JP
+                  urn: '964801'
+                  name: Brighthurst 139 Secondary College
+                  address: URN 964801, Everettshire, WW4 6LA
+                  postcode: WW4 6LA
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: gls1tcgc3jqzax5ylz210e2r
+                  placement_id: 01p139krftf38wb58wbxv6o8
         '404':
           description: returns status code 404 with a valid JSON response
           content:
@@ -6144,13 +6160,13 @@ paths:
         required: true
         schema:
           type: string
-        example: 7am1tuec8adlzc6v61zwy809
+        example: 6099w9wcielngijycbn8d2m1
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: zj4t553jj1snd5hoxixnzjid
+        example: wm6wslfm8wfeh4m6rfdkabu7
       requestBody:
         content:
           application/json:
@@ -6170,13 +6186,12 @@ paths:
               - data
             example:
               data:
-                urn: '619056'
-                name: Northern Stehr Academy
-                postcode: GU1 1AA
+                urn: '488927'
+                name: East Daniel University
+                postcode: R4 1JW
       responses:
         '200':
-          description: partial update of an existing placement returns status code
-            200 (ok) status
+          description: updates the placement and returns a 200 (ok) status
           content:
             application/json:
               schema:
@@ -6212,13 +6227,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '312826'
-                  name: Mitchell College
-                  address: URN 312826, GU1 1AA
-                  postcode: GU1 1AA
+                  urn: '852133'
+                  name: East Daniel University
+                  address: URN 852133, R4 1JW
+                  postcode: R4 1JW
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: zx6ovxjl1e61y8lzq5nb04mv
+                  placement_id: 6099w9wcielngijycbn8d2m1
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -6245,36 +6260,6 @@ paths:
                 errors:
                 - error: NotFound
                   message: Trainee(s) not found
-        '409':
-          description: returns a 409 (conflict) status
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        error:
-                          type: string
-                        message:
-                          type: string
-                      required:
-                      - error
-                      - message
-                  data:
-                    type: array
-                    items: {}
-                required:
-                - errors
-                - data
-              example:
-                errors:
-                - error: Conflict
-                  message: School has already been taken
-                data: []
         '422':
           description: does not create a new placements and returns a 422 status (unprocessable_entity)
             status
@@ -6318,7 +6303,7 @@ paths:
         required: true
         schema:
           type: string
-        example: p8qb6twj4vjgia919noze9lt
+        example: mvvi96zkmezt7sa64nwf1tvt
       requestBody:
         content:
           application/json:
@@ -6413,7 +6398,7 @@ paths:
                       awarded_at:
                         nullable: true
                       training_initiative:
-                        type: string
+                        nullable: true
                       study_mode:
                         nullable: true
                       ebacc:
@@ -6452,6 +6437,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -6498,7 +6485,7 @@ paths:
                           type: object
                           properties:
                             uk_degree:
-                              nullable: true
+                              type: string
                             non_uk_degree:
                               nullable: true
                             created_at:
@@ -6512,7 +6499,7 @@ paths:
                             graduation_year:
                               type: integer
                             grade:
-                              nullable: true
+                              type: string
                             country:
                               nullable: true
                             other_grade:
@@ -6602,6 +6589,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -6630,38 +6618,38 @@ paths:
               example:
                 data:
                   recommended_for_award_at: '2024-09-15T12:34:56Z'
-                  first_names: Glennis
-                  middle_names: Huels
-                  last_name: Davis
-                  email: Glennis.Davis@example.com
+                  first_names: Edmond
+                  middle_names: Nikolaus
+                  last_name: Keeling
+                  email: Edmond.Keeling@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '9051676'
+                  trn: '3746992'
                   region:
                   hesa_id:
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
-                  date_of_birth: '1995-10-24'
+                  date_of_birth: '1968-09-02'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
-                  sex: '10'
+                  sex: '96'
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-03'
+                  itt_start_date: '2024-08-13'
                   outcome_date: '2024-09-15'
-                  itt_end_date: '2026-07-20'
+                  itt_end_date: '2025-07-09'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
-                  trainee_start_date: '2024-08-06'
+                  trainee_start_date: '2024-08-29'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
                   awarded_at:
-                  training_initiative: '009'
+                  training_initiative:
                   study_mode:
                   ebacc: false
                   course_education_phase: secondary
@@ -6680,44 +6668,45 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-577
-                  ukprn: '52142558'
+                  provider_trainee_id: 24/25-578
+                  defer_reason:
+                  ukprn: '82718545'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-03'
+                  course_itt_start_date: '2024-08-13'
                   course_age_range:
-                  expected_end_date: '2026-07-20'
+                  expected_end_date: '2025-07-09'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code:
                   bursary_level:
-                  nationality: TN
+                  nationality: KZ
                   withdraw_reasons: []
                   withdrawal_trigger:
                   withdrawal_future_interest:
                   withdrawal_another_reason:
                   placements: []
                   degrees:
-                  - uk_degree:
+                  - uk_degree: '213'
                     non_uk_degree:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    subject: '100875'
-                    institution: '0269'
-                    graduation_year: 1988
-                    grade:
+                    subject: '101168'
+                    institution: '0033'
+                    graduation_year: 2008
+                    grade: '14'
                     country:
                     other_grade:
-                    institution_uuid: f63d182c-1425-ec11-b6e6-000d3adf095a
-                    uk_degree_uuid: '0584565a-1c98-4c1d-ae64-c241542c0879'
-                    subject_uuid: 1d8470f0-5dce-e911-a985-000d3ab79618
-                    grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: cmbhu7tn0hw69msuzmpscxid
+                    institution_uuid: 61f3791d-7042-e811-80ff-3863bb3640b8
+                    uk_degree_uuid: 556a5652-c197-e711-80d8-005056ac45bb
+                    subject_uuid: bb8570f0-5dce-e911-a985-000d3ab79618
+                    grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
+                    degree_id: r5zf8053pxutstvpexkumaej
                   state: recommended_for_award
-                  trainee_id: 7t5is4apbqubxliqrni854im
+                  trainee_id: 39w0r11key1r3sn72bjiwrt1
                   application_id:
         '404':
           description: returns status code 404
@@ -6787,7 +6776,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 2jiyb34zb9j85nza62juik8a
+        example: 92f07g2st3gy3azqmjtgfidn
       responses:
         '200':
           description: uses the trainee serializer
@@ -6906,6 +6895,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -7163,26 +7154,27 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                 required:
                 - data
               example:
                 data:
                   commencement_status:
                   withdraw_date:
-                  first_names: Ulysses
-                  middle_names: Yost
-                  last_name: Bergnaum
-                  email: Ulysses.Bergnaum@example.com
+                  first_names: Ardath
+                  middle_names: Parker
+                  last_name: Hane
+                  email: Ardath.Hane@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '7241438'
+                  trn: '3016327'
                   region:
-                  hesa_id: '9882031103911'
+                  hesa_id: '7473079010989'
                   course_subject_one: mathematics
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '1984-02-26'
+                  date_of_birth: '1968-06-06'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route: assessment_only
@@ -7190,13 +7182,13 @@ paths:
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-13'
+                  itt_start_date: '2024-08-09'
                   outcome_date:
-                  itt_end_date: '2025-07-16'
+                  itt_end_date: '2025-07-15'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-13'
+                  trainee_start_date: '2024-08-10'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -7218,21 +7210,22 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-596
-                  ukprn: '54417026'
+                  provider_trainee_id: 24/25-597
+                  defer_reason:
+                  ukprn: '39071986'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-28'
+                  course_itt_start_date: '2024-08-02'
                   course_age_range: '13916'
-                  expected_end_date: '2026-07-26'
+                  expected_end_date: '2026-07-09'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: '8'
-                  previous_last_name: Berge
+                  previous_last_name: Cruickshank
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -7263,12 +7256,12 @@ paths:
                     uk_degree_uuid: 016a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 4d5548c7-9692-422f-b04b-e64dbac18947
                     grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                    degree_id: rpb4oab5d0tsv1gdvqgay24y
+                    degree_id: 0qwlq426gpltq295oqqrvjr2
                   state: trn_received
-                  trainee_id: 280ps9e20cl25ody0huo9fda
+                  trainee_id: n36ci30u7iwrek2vu8gj70md
                   application_id:
-                  id: 708
-                  dttp_id: 47f4f5e8-b824-4b6f-8ac4-f2ffc1fbbfe0
+                  id: 709
+                  dttp_id: a205716a-3b67-4632-9097-7f9389189f68
                   progress:
                     personal_details: true
                     contact_details: true
@@ -7282,10 +7275,10 @@ paths:
                     schools: true
                     funding: true
                     iqts_country: false
-                  provider_id: 525
+                  provider_id: 526
                   placement_assignment_dttp_id:
                   withdraw_reasons_details:
-                  slug: tcedvowtbq1ns7oewoqcd5ke
+                  slug: sdgv6qgi2l1wl3gvo35czz0j
                   dttp_update_sha:
                   dormancy_dttp_id:
                   employing_school_id:

--- a/public/openapi/v1.0-pre.yaml
+++ b/public/openapi/v1.0-pre.yaml
@@ -349,6 +349,8 @@ paths:
                           nullable: true
                         withdrawal_another_reason:
                           nullable: true
+                        defer_reason:
+                          nullable: true
                       required:
                       - first_names
                       - last_name
@@ -443,13 +445,13 @@ paths:
                 - meta
               example:
                 data:
-                - first_names: Ardelia
-                  last_name: Tremblay
-                  date_of_birth: '1980-10-30'
+                - first_names: Gladys
+                  last_name: Koelpin
+                  date_of_birth: '1970-12-07'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Ardelia.Tremblay@example.com
-                  middle_names: Schuster
+                  email: Gladys.Koelpin@example.com
+                  middle_names: Stiedemann
                   training_route:
                   sex: '10'
                   diversity_disclosure: diversity_not_disclosed
@@ -458,15 +460,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-28'
+                  itt_start_date: '2024-08-26'
                   outcome_date:
-                  itt_end_date: '2025-07-31'
+                  itt_end_date: '2025-07-19'
                   trn:
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-09-12'
+                  trainee_start_date: '2024-09-04'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -495,14 +497,15 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-334
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-28'
+                  course_itt_start_date: '2024-08-26'
                   course_age_range:
-                  expected_end_date: '2025-07-31'
+                  expected_end_date: '2025-07-19'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -529,17 +532,17 @@ paths:
                     uk_degree_uuid: 3e042de2-a453-47dc-9452-90a23399e9ee
                     subject_uuid: b78270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                    degree_id: 2xro6unb5ti4m8ybo3sbe2zh
+                    degree_id: 81wdtlnn3tnk0dz08c8fls1q
                   state: submitted_for_trn
-                  trainee_id: dsaqh5jxt8xgts3jswbree24
+                  trainee_id: bp4plkvlkrfwir5rqpe13ljh
                   application_id:
-                - first_names: Columbus
-                  last_name: Kassulke
-                  date_of_birth: '1968-05-18'
+                - first_names: Leeanne
+                  last_name: Shanahan
+                  date_of_birth: '1987-05-02'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Columbus.Kassulke@example.com
-                  middle_names: Graham
+                  email: Leeanne.Shanahan@example.com
+                  middle_names: Blanda
                   training_route:
                   sex: '10'
                   diversity_disclosure: diversity_not_disclosed
@@ -548,15 +551,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-08'
+                  itt_start_date: '2024-08-29'
                   outcome_date:
-                  itt_end_date: '2026-07-16'
+                  itt_end_date: '2026-07-08'
                   trn:
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-08'
+                  trainee_start_date: '2024-09-02'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -585,14 +588,15 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-332
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-08'
+                  course_itt_start_date: '2024-08-29'
                   course_age_range:
-                  expected_end_date: '2026-07-16'
+                  expected_end_date: '2026-07-08'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -619,17 +623,17 @@ paths:
                     uk_degree_uuid: ef695652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 438270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: cdg1pqdfkt25ti1x7obnry8q
+                    degree_id: 2cxs3rjb6fl2yxlqr08ruwkn
                   state: submitted_for_trn
-                  trainee_id: k51fr0qhrxaesryx26yzkcal
+                  trainee_id: 21tc6m2s2uuzj4ut0krzl3y9
                   application_id:
-                - first_names: Dylan
-                  last_name: Nienow
-                  date_of_birth: '1972-09-19'
+                - first_names: Ruthie
+                  last_name: Shields
+                  date_of_birth: '1961-01-19'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Dylan.Nienow@example.com
-                  middle_names: Lehner
+                  email: Ruthie.Shields@example.com
+                  middle_names: Klocko
                   training_route:
                   sex: '12'
                   diversity_disclosure: diversity_not_disclosed
@@ -638,15 +642,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-02'
+                  itt_start_date: '2024-08-18'
                   outcome_date:
-                  itt_end_date: '2026-07-05'
-                  trn: '7508469'
+                  itt_end_date: '2026-07-04'
+                  trn: '8715329'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-10'
+                  trainee_start_date: '2024-08-28'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -665,7 +669,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '9979123071817'
+                  hesa_id: '7099317731906'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -675,20 +679,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-329
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-02'
+                  course_itt_start_date: '2024-08-18'
                   course_age_range: '13916'
-                  expected_end_date: '2026-07-05'
+                  expected_end_date: '2026-07-04'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: C
-                  previous_last_name: Bayer
+                  previous_last_name: Ritchie
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -719,17 +724,17 @@ paths:
                     uk_degree_uuid: 676a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 898270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: q96djbx503qobfjxg2rwftqs
+                    degree_id: zt7hy3xa69h76rs55kd237p9
                   state: trn_received
-                  trainee_id: lvw4iuoy5ix9t02bvell3u7f
+                  trainee_id: 5o19u5mqj6418g5seiildt75
                   application_id:
-                - first_names: Florentino
-                  last_name: Jacobs
-                  date_of_birth: '1989-05-05'
+                - first_names: Brenton
+                  last_name: Barton
+                  date_of_birth: '1966-03-12'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Florentino.Jacobs@example.com
-                  middle_names: Oberbrunner
+                  email: Brenton.Barton@example.com
+                  middle_names: Brown
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -738,10 +743,10 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-24'
+                  itt_start_date: '2024-08-29'
                   outcome_date:
-                  itt_end_date: '2026-07-25'
-                  trn: '6152558'
+                  itt_end_date: '2026-07-09'
+                  trn: '5482413'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
@@ -765,7 +770,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '2188069880226'
+                  hesa_id: '4071073719398'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -775,20 +780,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-326
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-24'
+                  course_itt_start_date: '2024-08-29'
                   course_age_range: '13912'
-                  expected_end_date: '2026-07-25'
+                  expected_end_date: '2026-07-09'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: '8'
-                  previous_last_name: Stroman
+                  previous_last_name: Baumbach
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -819,17 +825,17 @@ paths:
                     uk_degree_uuid: 4b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 9d8670f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
-                    degree_id: ooo1gp0aqqnaxt0pt1ml13k7
+                    degree_id: z9wziq307xgfwx1s1d4yttdi
                   state: trn_received
-                  trainee_id: i05b3wxoyskjiog2nkqby7us
+                  trainee_id: klgcjlonsebj5p5p10fiq5m9
                   application_id:
-                - first_names: Isaias
-                  last_name: Bode
-                  date_of_birth: '1978-04-06'
+                - first_names: Dani
+                  last_name: Price
+                  date_of_birth: '1998-04-27'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Isaias.Bode@example.com
-                  middle_names: Jacobs
+                  email: Dani.Price@example.com
+                  middle_names: Kiehn
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -838,15 +844,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-12'
+                  itt_start_date: '2024-08-09'
                   outcome_date:
-                  itt_end_date: '2026-07-05'
-                  trn: '3897492'
+                  itt_end_date: '2026-07-21'
+                  trn: '6877099'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-12'
+                  trainee_start_date: '2024-08-22'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -865,7 +871,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '3609461983454'
+                  hesa_id: '4626221513807'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -875,20 +881,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-323
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-12'
+                  course_itt_start_date: '2024-08-09'
                   course_age_range: '13914'
-                  expected_end_date: '2026-07-05'
+                  expected_end_date: '2026-07-21'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: D
-                  previous_last_name: Johnson
+                  previous_last_name: Rohan
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -919,17 +926,17 @@ paths:
                     uk_degree_uuid: 0f6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: d58370f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: aa6j3o52x0yry58hkaehwrcj
+                    degree_id: t5hqczfvgxq9k934iyshr66y
                   state: trn_received
-                  trainee_id: 9eti281c445ksfcafv2zr4yb
+                  trainee_id: 1602sf9vb1spd0kxeebjmfsp
                   application_id:
-                - first_names: Gale
-                  last_name: Goodwin
-                  date_of_birth: '1979-05-25'
+                - first_names: Latoyia
+                  last_name: Wuckert
+                  date_of_birth: '1964-07-13'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Gale.Goodwin@example.com
-                  middle_names: Crona
+                  email: Latoyia.Wuckert@example.com
+                  middle_names: Hills
                   training_route:
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -938,15 +945,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-18'
+                  itt_start_date: '2024-08-22'
                   outcome_date:
-                  itt_end_date: '2025-07-04'
-                  trn: '2554183'
+                  itt_end_date: '2025-07-10'
+                  trn: '6635778'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-27'
+                  trainee_start_date: '2024-08-24'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -965,7 +972,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '5075271008557'
+                  hesa_id: '8411127776534'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -975,20 +982,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-320
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-18'
+                  course_itt_start_date: '2024-08-22'
                   course_age_range: '13918'
-                  expected_end_date: '2025-07-04'
+                  expected_end_date: '2025-07-10'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: C
-                  previous_last_name: Huels
+                  previous_last_name: Casper
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1019,17 +1027,17 @@ paths:
                     uk_degree_uuid: 1f6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 2b8370f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 377a46ea-d6c6-4e87-9728-c1f0dd0ef109
-                    degree_id: yrdo65xuns9tlucjwykqok00
+                    degree_id: zjkbnxe1s439qqbu68jwyptk
                   state: trn_received
-                  trainee_id: if57hulqp4m2tl87vumzo8jn
+                  trainee_id: oac3rbpm86xzpbvag60z8y3q
                   application_id:
-                - first_names: Milton
-                  last_name: Schumm
-                  date_of_birth: '1996-12-03'
+                - first_names: Rudolph
+                  last_name: Steuber
+                  date_of_birth: '2006-07-19'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Milton.Schumm@example.com
-                  middle_names: Grady
+                  email: Rudolph.Steuber@example.com
+                  middle_names: Beatty
                   training_route:
                   sex: '10'
                   diversity_disclosure: diversity_not_disclosed
@@ -1038,15 +1046,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-05'
+                  itt_start_date: '2024-08-18'
                   outcome_date:
-                  itt_end_date: '2026-07-12'
-                  trn: '1217636'
+                  itt_end_date: '2026-07-20'
+                  trn: '3024362'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-12'
+                  trainee_start_date: '2024-08-25'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -1065,7 +1073,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '4517056380224'
+                  hesa_id: '1804879187157'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1075,20 +1083,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-317
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-05'
+                  course_itt_start_date: '2024-08-18'
                   course_age_range: '13911'
-                  expected_end_date: '2026-07-12'
+                  expected_end_date: '2026-07-20'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: '6'
-                  previous_last_name: Davis
+                  previous_last_name: Maggio
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1119,17 +1128,17 @@ paths:
                     uk_degree_uuid: 3f6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: a38270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: ty0fbyyfndzi8ycbxj1y7ahp
+                    degree_id: jzpy9w49svlf2oh5a1aqhq8s
                   state: trn_received
-                  trainee_id: 0gxenipmp2bunpvc8oosbxul
+                  trainee_id: 69yjgci1m1wu53bxmzeqsjee
                   application_id:
-                - first_names: Sherwood
-                  last_name: Zulauf
-                  date_of_birth: '1964-06-06'
+                - first_names: Kaycee
+                  last_name: Purdy
+                  date_of_birth: '1972-05-21'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Sherwood.Zulauf@example.com
-                  middle_names: Turner
+                  email: Kaycee.Purdy@example.com
+                  middle_names: Schulist
                   training_route:
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -1138,15 +1147,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-04'
+                  itt_start_date: '2024-08-05'
                   outcome_date:
-                  itt_end_date: '2026-07-03'
-                  trn: '1733940'
+                  itt_end_date: '2026-07-20'
+                  trn: '3999436'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-04'
+                  trainee_start_date: '2024-08-08'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -1165,7 +1174,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '9185655419991'
+                  hesa_id: '9492544264638'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1175,20 +1184,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-314
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-04'
+                  course_itt_start_date: '2024-08-05'
                   course_age_range: '13915'
-                  expected_end_date: '2026-07-03'
+                  expected_end_date: '2026-07-20'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: C
-                  previous_last_name: Yundt
+                  previous_last_name: Torphy
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1219,17 +1229,17 @@ paths:
                     uk_degree_uuid: 7ba49954-7595-437c-8df0-6a777c97307b
                     subject_uuid: 518770f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: e8ace1wigorll2f7ro2vct57
+                    degree_id: 7a92zbc2ydrk7tcht32td48h
                   state: trn_received
-                  trainee_id: fl8ar1cdeuqx5bv8ekn0x6sa
+                  trainee_id: wfwugih5mxxo52q9du7wak4f
                   application_id:
-                - first_names: Yoko
-                  last_name: Heaney
-                  date_of_birth: '1964-03-22'
+                - first_names: Landon
+                  last_name: Zboncak
+                  date_of_birth: '2001-01-07'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Yoko.Heaney@example.com
-                  middle_names: Cronin
+                  email: Landon.Zboncak@example.com
+                  middle_names: Quigley
                   training_route:
                   sex: '12'
                   diversity_disclosure: diversity_not_disclosed
@@ -1238,15 +1248,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-04'
+                  itt_start_date: '2024-08-14'
                   outcome_date:
-                  itt_end_date: '2025-07-02'
-                  trn: '2093262'
+                  itt_end_date: '2025-07-16'
+                  trn: '3865315'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-12'
+                  trainee_start_date: '2024-08-15'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -1265,7 +1275,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '3027699540979'
+                  hesa_id: '1763723153694'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1275,20 +1285,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-311
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-04'
+                  course_itt_start_date: '2024-08-14'
                   course_age_range: '13918'
-                  expected_end_date: '2025-07-02'
+                  expected_end_date: '2025-07-16'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: '9'
-                  previous_last_name: Smith
+                  previous_last_name: Larkin
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1319,17 +1330,17 @@ paths:
                     uk_degree_uuid: e5695652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 858270f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 4182ef37-df1c-4f1e-9be6-feb66037f775
-                    degree_id: 5n9u1chczkj2cfw0q72ixbxh
+                    degree_id: wtamqm3gzowpf2ztsf3sza8c
                   state: trn_received
-                  trainee_id: g0uw4ah7botr14ovdkm9c19j
+                  trainee_id: jndmfsihj19hnw9922l47ith
                   application_id:
-                - first_names: Janna
-                  last_name: Abbott
-                  date_of_birth: '2005-05-18'
+                - first_names: Kelsi
+                  last_name: Luettgen
+                  date_of_birth: '1992-11-22'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Janna.Abbott@example.com
-                  middle_names: Bernier
+                  email: Kelsi.Luettgen@example.com
+                  middle_names: Reichel
                   training_route:
                   sex: '96'
                   diversity_disclosure: diversity_not_disclosed
@@ -1338,15 +1349,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-17'
+                  itt_start_date: '2024-08-04'
                   outcome_date:
-                  itt_end_date: '2025-07-21'
-                  trn: '8145504'
+                  itt_end_date: '2025-07-06'
+                  trn: '6714235'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-26'
+                  trainee_start_date: '2024-08-13'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -1365,7 +1376,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '5600881099707'
+                  hesa_id: '8479038747069'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1375,20 +1386,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-308
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-17'
+                  course_itt_start_date: '2024-08-04'
                   course_age_range: '13909'
-                  expected_end_date: '2025-07-21'
+                  expected_end_date: '2025-07-06'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: D
-                  previous_last_name: McClure
+                  previous_last_name: Kub
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1419,17 +1431,17 @@ paths:
                     uk_degree_uuid: 196a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: e8599844-7783-4707-b090-e7f9d5abc6bc
                     grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                    degree_id: 242as01f46lagusdjoqn3lzv
+                    degree_id: va2rhrhd9ol1lrlw1nyb129k
                   state: trn_received
-                  trainee_id: no5kuq6yfdqawd89aw1i8x1n
+                  trainee_id: 833vkdhkbde2elbv8bh397rg
                   application_id:
-                - first_names: Davida
-                  last_name: Purdy
-                  date_of_birth: '1971-12-31'
+                - first_names: Ehtel
+                  last_name: Strosin
+                  date_of_birth: '1962-11-29'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Davida.Purdy@example.com
-                  middle_names: Bergstrom
+                  email: Ehtel.Strosin@example.com
+                  middle_names: Wilderman
                   training_route:
                   sex: '12'
                   diversity_disclosure: diversity_not_disclosed
@@ -1438,15 +1450,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-21'
+                  itt_start_date: '2024-08-08'
                   outcome_date:
-                  itt_end_date: '2026-07-25'
-                  trn: '2667158'
+                  itt_end_date: '2026-07-23'
+                  trn: '4621280'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-09-03'
+                  trainee_start_date: '2024-08-23'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 16
@@ -1465,7 +1477,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '1406532929826'
+                  hesa_id: '6694101815141'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1475,20 +1487,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-305
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-21'
+                  course_itt_start_date: '2024-08-08'
                   course_age_range: '13918'
-                  expected_end_date: '2026-07-25'
+                  expected_end_date: '2026-07-23'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: D
-                  previous_last_name: Torphy
+                  previous_last_name: Runolfsson
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1519,17 +1532,17 @@ paths:
                     uk_degree_uuid: 316a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 2f8470f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: g0ztzigvqyhohb5tz1ug06jl
+                    degree_id: c5gnc5m1ed8yxcbxnu568sgw
                   state: trn_received
-                  trainee_id: e8877cis802w08p14kofgoen
+                  trainee_id: eywhbta72ozaso373ntyywuc
                   application_id:
-                - first_names: Truman
-                  last_name: Armstrong
-                  date_of_birth: '1998-10-07'
+                - first_names: Edgar
+                  last_name: Hartmann
+                  date_of_birth: '1970-08-01'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Truman.Armstrong@example.com
-                  middle_names: West
+                  email: Edgar.Hartmann@example.com
+                  middle_names: Schultz
                   training_route:
                   sex: '99'
                   diversity_disclosure: diversity_not_disclosed
@@ -1538,15 +1551,15 @@ paths:
                   additional_ethnic_background:
                   disability_disclosure:
                   course_subject_one: '100403'
-                  itt_start_date: '2024-08-15'
+                  itt_start_date: '2024-08-11'
                   outcome_date:
-                  itt_end_date: '2025-07-09'
-                  trn: '3178943'
+                  itt_end_date: '2025-07-30'
+                  trn: '4351643'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-25'
+                  trainee_start_date: '2024-08-12'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -1565,7 +1578,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '3593611079021'
+                  hesa_id: '6153320393516'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -1575,20 +1588,21 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-302
-                  ukprn: '40338867'
+                  defer_reason:
+                  ukprn: '11302712'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-15'
+                  course_itt_start_date: '2024-08-11'
                   course_age_range: '13909'
-                  expected_end_date: '2025-07-09'
+                  expected_end_date: '2025-07-30'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: D
-                  previous_last_name: Jones
+                  previous_last_name: Gorczany
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -1619,9 +1633,9 @@ paths:
                     uk_degree_uuid: 4f6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: a58370f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: x54na6tdrm6qhfe0ajncsmad
+                    degree_id: hg9armajsn5dwajc58d6b1f3
                   state: trn_received
-                  trainee_id: 3w792k5g4dely2w2nbhh0nqp
+                  trainee_id: tr69h38v8s5z6pmyqd03adw1
                   application_id:
                 meta:
                   current_page: 1
@@ -1967,6 +1981,8 @@ paths:
                         nullable: true
                       withdrawal_another_reason:
                         nullable: true
+                      defer_reason:
+                        nullable: true
                     required:
                     - first_names
                     - last_name
@@ -2108,7 +2124,7 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id:
-                  ukprn: '59872116'
+                  ukprn: '31973118'
                   ethnicity: '997'
                   disability1: '58'
                   disability2: '57'
@@ -2144,7 +2160,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: vCBH59rrNSbToe4pTDuBTjSs
+                    placement_id: g9xfTADHj1JreFWDGsCX7uko
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -2160,13 +2176,14 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: A9K6C4pM5xr9Seahb3skJzWY
+                    degree_id: 3GA7CFBYrD2ACM6bTqBH4STA
                   state: submitted_for_trn
-                  trainee_id: B5J5K5SvkRb4uDXaGdTfA4dJ
+                  trainee_id: 6yCFC5X45UrtqswzkDpmm31w
                   application_id:
                   withdrawal_trigger:
                   withdrawal_future_interest:
                   withdrawal_another_reason:
+                  defer_reason:
         '409':
           description: returns status code 409 (conflict) with the potential duplicates
             and does not create a trainee record
@@ -2398,6 +2415,8 @@ paths:
                           nullable: true
                         withdrawal_another_reason:
                           nullable: true
+                        defer_reason:
+                          nullable: true
                       required:
                       - first_names
                       - last_name
@@ -2479,13 +2498,13 @@ paths:
                 - error: Conflict
                   message: This trainee is already in Register
                 data:
-                - first_names: Dallas
-                  last_name: Konopelski
-                  date_of_birth: '2000-05-20'
+                - first_names: Nathalie
+                  last_name: Howe
+                  date_of_birth: '1969-04-08'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Dallas.Konopelski@example.com
-                  middle_names: Cummings
+                  email: Nathalie.Howe@example.com
+                  middle_names: Denesik
                   training_route: '11'
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -2496,13 +2515,13 @@ paths:
                   course_subject_one: '100346'
                   itt_start_date: '2025-01-01'
                   outcome_date:
-                  itt_end_date: '2027-07-12'
+                  itt_end_date: '2027-07-28'
                   trn:
                   submitted_for_trn_at:
                   withdraw_date:
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-12-08'
+                  trainee_start_date: '2024-11-29'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -2531,14 +2550,15 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 25/26-3
-                  ukprn: '19642955'
+                  defer_reason:
+                  ukprn: '74874387'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: undergrad
                   course_itt_start_date: '2025-01-01'
                   course_age_range:
-                  expected_end_date: '2027-07-12'
+                  expected_end_date: '2027-07-28'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -2565,9 +2585,9 @@ paths:
                     uk_degree_uuid: 5d6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 318070f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: r85cie1nsl27v6edbno8fhj3
+                    degree_id: 9rcaf6jqur3y3l57sajb0vf2
                   state: draft
-                  trainee_id: uohuo9xlx66bakzfsi9g7rqu
+                  trainee_id: 1yfmo7cfrb7cuwrss1sb13up
                   application_id:
         '422':
           description: return status code 422 with a meaningful error message
@@ -2774,13 +2794,13 @@ paths:
                 hesa_id: '0310261553101'
                 provider_trainee_id: 99157234/2/01
                 pg_apprenticeship_start_date: '2024-03-11'
-                lead_partner_ukprn: '81010816'
-                employing_school_urn: '365982'
-                lead_partner_urn: '729585'
+                lead_partner_ukprn: '12702964'
+                employing_school_urn: '712074'
+                lead_partner_urn: '662362'
                 course_subject_two: '101410'
                 course_subject_three: '100366'
                 ethnicity: '142'
-                middle_names: Moen
+                middle_names: Bradtke
                 trn: '123456'
                 diversity_disclosure: diversity_disclosed
   "/api/{api_version}/trainees/{trainee_id}":
@@ -2913,6 +2933,8 @@ paths:
                     nullable: true
                   provider_trainee_id:
                     type: string
+                  defer_reason:
+                    nullable: true
                   ukprn:
                     type: string
                   ethnicity:
@@ -3036,6 +3058,7 @@ paths:
                 - slug_sent_to_dqt_at
                 - placement_detail
                 - provider_trainee_id
+                - defer_reason
                 - ukprn
                 - ethnicity
                 - course_qualification
@@ -3070,13 +3093,13 @@ paths:
                 - trainee_id
                 - application_id
               example:
-                first_names: Gus
-                last_name: Kertzmann
-                date_of_birth: '1987-09-04'
+                first_names: Terresa
+                last_name: Morar
+                date_of_birth: '1964-02-18'
                 created_at: '2024-09-15T12:34:56.000Z'
                 updated_at: '2024-09-15T12:34:56.000Z'
-                email: Gus.Kertzmann@example.com
-                middle_names: Altenwerth
+                email: Terresa.Morar@example.com
+                middle_names: Harris
                 training_route:
                 sex: '96'
                 diversity_disclosure: diversity_not_disclosed
@@ -3112,7 +3135,7 @@ paths:
                 commencement_status:
                 discarded_at:
                 created_from_dttp: false
-                hesa_id: '7865684311872'
+                hesa_id: '7148941108724'
                 additional_dttp_data:
                 created_from_hesa: false
                 hesa_updated_at:
@@ -3122,7 +3145,8 @@ paths:
                 slug_sent_to_dqt_at:
                 placement_detail:
                 provider_trainee_id: 24/25-13
-                ukprn: '59404105'
+                defer_reason:
+                ukprn: '90416493'
                 ethnicity:
                 course_qualification: QTS
                 course_title:
@@ -3135,7 +3159,7 @@ paths:
                 lead_partner_urn:
                 fund_code: '7'
                 bursary_level: '4'
-                previous_last_name: Graham
+                previous_last_name: Kilback
                 itt_aim: '201'
                 course_study_mode: '01'
                 course_year: 2024
@@ -3196,7 +3220,7 @@ paths:
         required: true
         schema:
           type: string
-        example: KoZwq6odSDHGxPwvWpxmTeBj
+        example: CUMCjqKQQPWndX7UCYohVFWV
       responses:
         '200':
           description: updates the trainee
@@ -3321,11 +3345,13 @@ paths:
                       provider_trainee_id:
                         type: string
                         nullable: true
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
-                        nullable: true
                         type: string
+                        nullable: true
                       disability1:
                         type: string
                       course_qualification:
@@ -3539,6 +3565,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -3618,7 +3645,8 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id:
-                  ukprn: '21199146'
+                  defer_reason:
+                  ukprn: '58147656'
                   ethnicity: '997'
                   disability1: '55'
                   course_qualification: QTS
@@ -3656,7 +3684,7 @@ paths:
                     postcode:
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: gymVZ87i8ka7NTAYV7xXFoHo
+                    placement_id: 17Fy1bSCJLjABxuEpXnYByWP
                   degrees:
                   - uk_degree: '083'
                     non_uk_degree:
@@ -3672,9 +3700,9 @@ paths:
                     uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                    degree_id: QD4zRXsXbUYanF2v1L1XQpYd
+                    degree_id: CpNfuCxbph2CWKE7i2B4ianQ
                   state: submitted_for_trn
-                  trainee_id: KoZwq6odSDHGxPwvWpxmTeBj
+                  trainee_id: CUMCjqKQQPWndX7UCYohVFWV
                   application_id:
                   disability2: '57'
         '401':
@@ -3806,7 +3834,7 @@ paths:
                 nationality: FR
                 course_age_range: '13914'
                 lead_partner_urn: '900020'
-                employing_school_urn: '574860'
+                employing_school_urn: '649691'
                 ethnicity:
                 training_route:
                 disability1: '58'
@@ -3832,7 +3860,7 @@ paths:
         required: true
         schema:
           type: string
-        example: ksuo79xsiwcu4yc7gaj6vnvr
+        example: 72qckujpoklfrq1omm13gsll
       requestBody:
         content:
           application/json:
@@ -3866,6 +3894,8 @@ paths:
                         nullable: true
                       defer_date:
                         type: string
+                      defer_reason:
+                        nullable: true
                       trainee_start_date:
                         type: string
                       first_names:
@@ -4066,6 +4096,7 @@ paths:
                     required:
                     - commencement_status
                     - defer_date
+                    - defer_reason
                     - trainee_start_date
                     - first_names
                     - middle_names
@@ -4145,21 +4176,22 @@ paths:
                 data:
                   commencement_status:
                   defer_date: '2024-09-15'
-                  trainee_start_date: '2024-08-05'
-                  first_names: Clyde
-                  middle_names: Gislason
-                  last_name: Ernser
-                  email: Clyde.Ernser@example.com
+                  defer_reason:
+                  trainee_start_date: '2024-08-23'
+                  first_names: Qiana
+                  middle_names: Emmerich
+                  last_name: Douglas
+                  email: Qiana.Douglas@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '5062188'
+                  trn: '6837593'
                   region:
                   hesa_id:
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '2001-10-11'
+                  date_of_birth: '1967-04-05'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
@@ -4167,9 +4199,9 @@ paths:
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-04'
+                  itt_start_date: '2024-08-11'
                   outcome_date:
-                  itt_end_date: '2026-07-17'
+                  itt_end_date: '2026-07-22'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   recommended_for_award_at:
@@ -4195,14 +4227,14 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-557
-                  ukprn: '94917610'
+                  ukprn: '39478287'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-04'
+                  course_itt_start_date: '2024-08-11'
                   course_age_range:
-                  expected_end_date: '2026-07-17'
+                  expected_end_date: '2026-07-22'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -4229,9 +4261,9 @@ paths:
                     uk_degree_uuid: fd695652-c197-e711-80d8-005056ac45bb
                     subject_uuid: fd8370f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                    degree_id: bcrkeoy1fz1rrcmxuwpoq2zg
+                    degree_id: wwghigp9enaf9ahn7gs9opsl
                   state: deferred
-                  trainee_id: q3ld9w395bqf5m5cgqrayxko
+                  trainee_id: w3b6sedx9os37yx0ziffu3uj
                   application_id:
         '404':
           description: returns status code 404
@@ -4300,7 +4332,7 @@ paths:
         required: true
         schema:
           type: string
-        example: jayyhqyhzkkjpfxlbuurawpa
+        example: 6vdyf7dgr7eqhnms97vhc3tl
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -4380,7 +4412,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 76ztrrf2htbabe0u0pjojgv6
+        example: d9io2bx40kaqqokm0jk8axws
       requestBody:
         content:
           application/json:
@@ -4501,7 +4533,7 @@ paths:
                   uk_degree_uuid:
                   subject_uuid: 918170f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f
-                  degree_id: S9jB3463aQs7VbPPLLNDQczx
+                  degree_id: pGMWMynMb7JDm25koZnFBmYp
         '404':
           description: does not create a new degree and returns a 404 status (not_found)
             status
@@ -4620,7 +4652,7 @@ paths:
                   uk_degree_uuid: 0d6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 218270f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: 3d57e5f7-7904-4895-a982-ed953fff3f94
-                  degree_id: 38dhji7g4xlr3y5cdjs8cmgd
+                  degree_id: 8zpygzhetljknvj09w5cadlt
         '422':
           description: does not create a new degree and returns a 422 status (unprocessable_entity)
             status
@@ -4668,13 +4700,13 @@ paths:
         required: true
         schema:
           type: string
-        example: izzk1tg5wpplyqsx4jgzitk0
+        example: zo9a8tv187pazpvgyyxwilnv
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: y8vu3ytzj326658xvux1qzpm
+        example: kvv5nzbv10nrc6zbttfsq8ga
       responses:
         '200':
           description: deletes the degree and returns a 200 status (ok)
@@ -4790,6 +4822,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -4892,6 +4926,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -4919,13 +4954,13 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Jasper
-                  last_name: Bashirian
-                  date_of_birth: '2002-07-20'
+                  first_names: Aletha
+                  last_name: Lind
+                  date_of_birth: '1969-05-10'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Jasper.Bashirian@example.com
-                  middle_names: Walter
+                  email: Aletha.Lind@example.com
+                  middle_names: Johns
                   training_route:
                   sex: '11'
                   diversity_disclosure: diversity_not_disclosed
@@ -4971,7 +5006,8 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail:
                   provider_trainee_id: 24/25-526
-                  ukprn: '14599795'
+                  defer_reason:
+                  ukprn: '31977560'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
@@ -4992,7 +5028,7 @@ paths:
                   placements: []
                   degrees: []
                   state: draft
-                  trainee_id: 8qd8o5k7kj4uq8ahfsv4idux
+                  trainee_id: p3i8hmegp6gugcxydc5d8c19
                   application_id:
         '404':
           description: does not delete the degree and returns a 404 status (not_found)
@@ -5041,7 +5077,7 @@ paths:
         required: true
         schema:
           type: string
-        example: jitwfq0s3v8f0xj2cqy7v9gh
+        example: ygnrdpd9e3qhevjfhqmmrj1y
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5117,7 +5153,7 @@ paths:
                   uk_degree_uuid: 656a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 678570f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                  degree_id: 05mw19t8s41gxckoplr699b6
+                  degree_id: itrgxs466cnoograq8rbgq6k
         '404':
           description: returns status code 404 with a valid JSON response
           content:
@@ -5159,13 +5195,13 @@ paths:
         required: true
         schema:
           type: string
-        example: kbozj4t553jj1snd5hoxixnz
+        example: 1u0jk6f2z9fcqzxmzhlbqwyz
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: yo06g640ms2ou8eoo5wcrr3w
+        example: mfengc01beuaibpwnu7im9y6
       requestBody:
         content:
           application/json:
@@ -5272,7 +5308,7 @@ paths:
                   uk_degree_uuid: 1b6a5652-c197-e711-80d8-005056ac45bb
                   subject_uuid: 917f70f0-5dce-e911-a985-000d3ab79618
                   grade_uuid: aaba4427-287c-4610-a838-1970dd9090c1
-                  degree_id: y2l272xrq9r9qkndxh8gmrzh
+                  degree_id: 7t2vb9ctahsuc4bwt5nz6wcq
         '404':
           description: does not update the degree and returns a 404 status (not_found)
           content:
@@ -5339,7 +5375,7 @@ paths:
         required: true
         schema:
           type: string
-        example: isfunwn8z77c2q3uto9qqgxu
+        example: 67c42f4aghyuynw2ih0kj75p
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -5395,7 +5431,7 @@ paths:
         required: true
         schema:
           type: string
-        example: s47la1loaubihlgq1b2rsgi2
+        example: yqh3fi3iiqyjyym4wzsa37va
       requestBody:
         content:
           application/json:
@@ -5415,12 +5451,12 @@ paths:
               - data
             example:
               data:
-                urn: '317424'
-                name: Western Waelchi Institute
-                postcode: YS0R 3JA
+                urn: '150994'
+                name: Rolfson College
+                postcode: O2 3DQ
       responses:
         '201':
-          description: updates the progress attribute on the trainee
+          description: creates a new placement and returns a 201 (created) status
           content:
             application/json:
               schema:
@@ -5456,15 +5492,15 @@ paths:
                 - data
               example:
                 data:
-                  urn:
-                  name: Western Waelchi Institute
-                  address: YS0R 3JA
-                  postcode: YS0R 3JA
+                  urn: '150994'
+                  name: Rolfson College
+                  address: URN 150994, O2 3DQ
+                  postcode: O2 3DQ
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: LjU5dqzhCqqm1Sm1A7Tthp7V
+                  placement_id: ftRGBMtViYEdF1NHyovfcA9G
         '404':
-          description: does not create a new placement and returns a 422 status (unprocessable_entity)
+          description: does not create a new placement and returns a 404 status (not_found)
             status
           content:
             application/json:
@@ -5532,13 +5568,13 @@ paths:
         required: true
         schema:
           type: string
-        example: 9ygls1tcgc3jqzax5ylz210e
+        example: ksw6u3ckw176xkjgo9tspmn7
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: kxrw7t4abste1gikvl1porzo
+        example: znerl4ifk80h6j7odlgropsg
       responses:
         '200':
           description: removes the specified placement
@@ -5654,6 +5690,8 @@ paths:
                         type: string
                       provider_trainee_id:
                         type: string
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -5801,6 +5839,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -5838,13 +5877,13 @@ paths:
                 - data
               example:
                 data:
-                  first_names: Lindsay
-                  last_name: Metz
-                  date_of_birth: '1981-04-18'
+                  first_names: Jewel
+                  last_name: Robel
+                  date_of_birth: '1979-06-02'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  email: Lindsay.Metz@example.com
-                  middle_names: Muller
+                  email: Jewel.Robel@example.com
+                  middle_names: Greenholt
                   training_route:
                   sex: '10'
                   diversity_disclosure: diversity_not_disclosed
@@ -5880,7 +5919,7 @@ paths:
                   commencement_status:
                   discarded_at:
                   created_from_dttp: false
-                  hesa_id: '3933477446837'
+                  hesa_id: '8337575963767'
                   additional_dttp_data:
                   created_from_hesa: false
                   hesa_updated_at:
@@ -5890,7 +5929,8 @@ paths:
                   slug_sent_to_dqt_at:
                   placement_detail: has_placement_detail
                   provider_trainee_id: 24/25-536
-                  ukprn: '79541405'
+                  defer_reason:
+                  ukprn: '76133857'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
@@ -5903,7 +5943,7 @@ paths:
                   lead_partner_urn:
                   fund_code: '7'
                   bursary_level: '4'
-                  previous_last_name: Hauck
+                  previous_last_name: Homenick
                   itt_aim: '201'
                   course_study_mode: '01'
                   course_year: 2024
@@ -5919,16 +5959,16 @@ paths:
                   withdrawal_future_interest:
                   withdrawal_another_reason:
                   placements:
-                  - urn: '736443'
-                    name: Ostbarrow 146 High
-                    address: URN 736443, New Keenanland, AU8W 1ZL
-                    postcode: AU8W 1ZL
+                  - urn: '876986'
+                    name: Marblewald 146 High School
+                    address: URN 876986, North Gregoryview, K3 0JF
+                    postcode: K3 0JF
                     created_at: '2024-09-15T12:34:56.000Z'
                     updated_at: '2024-09-15T12:34:56.000Z'
-                    placement_id: 6vnqg94wqrplnrp19f6qlouw
+                    placement_id: supskq5kzknmfc33wg8cedgz
                   degrees: []
                   state: draft
-                  trainee_id: kxrw7t4abste1gikvl1porzo
+                  trainee_id: znerl4ifk80h6j7odlgropsg
                   application_id:
         '404':
           description: returns status code 404 with a valid JSON response
@@ -5977,7 +6017,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 6osj3gmd9z1f7q5depyayhik
+        example: uyrxj3m1ql1wad2qoda6xrgx
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -6015,13 +6055,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '197256'
-                  name: Mallowpond 148 Secondary College
-                  address: URN 197256, Freemanstad, P9 3LH
-                  postcode: P9 3LH
+                  urn: '141999'
+                  name: Mallowtown 148 High
+                  address: URN 141999, Lake Myrtisview, YN4 0BN
+                  postcode: YN4 0BN
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: qd4wk7bqukta0ebg87wtfprv
+                  placement_id: l1h03yv7xzcjispiily9uvq7
         '404':
           description: returns status code 404 with a valid JSON response
           content:
@@ -6063,13 +6103,13 @@ paths:
         required: true
         schema:
           type: string
-        example: kueoq34c72vh2o5uipygbl7a
+        example: fm8wfeh4m6rfdkabu76099w9
       - name: trainee_id
         in: path
         required: true
         schema:
           type: string
-        example: q907d4i43hldg5x1gh060fdx
+        example: icufbhr2g2smoblrhkwm6wsl
       requestBody:
         content:
           application/json:
@@ -6089,13 +6129,12 @@ paths:
               - data
             example:
               data:
-                urn: '456773'
-                name: Wilderman Academy
-                postcode: GU1 1AA
+                urn: '951659'
+                name: Kemmer Institute
+                postcode: WM1 4NW
       responses:
         '200':
-          description: partial update of an existing placement returns status code
-            200 (ok) status
+          description: updates the placement and returns a 200 (ok) status
           content:
             application/json:
               schema:
@@ -6131,13 +6170,13 @@ paths:
                 - data
               example:
                 data:
-                  urn: '323361'
-                  name: South Nebraska Academy
-                  address: URN 323361, GU1 1AA
-                  postcode: GU1 1AA
+                  urn: '727875'
+                  name: Kemmer Institute
+                  address: URN 727875, WM1 4NW
+                  postcode: WM1 4NW
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
-                  placement_id: 05gurjdfrjn8b60cz0dq0b4j
+                  placement_id: fm8wfeh4m6rfdkabu76099w9
         '404':
           description: does not create a new placement and returns a 422 status (unprocessable_entity)
             status
@@ -6207,7 +6246,7 @@ paths:
         required: true
         schema:
           type: string
-        example: 97sq7s42ybq8usp8wmqfr4tc
+        example: 5mdkvzj9lspgt0h58i6w64fp
       requestBody:
         content:
           application/json:
@@ -6341,6 +6380,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -6491,6 +6532,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -6519,19 +6561,19 @@ paths:
               example:
                 data:
                   recommended_for_award_at: '2024-09-15T12:34:56Z'
-                  first_names: Colton
-                  middle_names: Goyette
-                  last_name: Upton
-                  email: Colton.Upton@example.com
+                  first_names: Cheryl
+                  middle_names: Bartoletti
+                  last_name: Tremblay
+                  email: Cheryl.Tremblay@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '8061234'
+                  trn: '3265124'
                   region:
                   hesa_id:
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
-                  date_of_birth: '1972-06-08'
+                  date_of_birth: '1967-12-29'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
@@ -6539,13 +6581,13 @@ paths:
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-13'
+                  itt_start_date: '2024-08-16'
                   outcome_date: '2024-09-15'
-                  itt_end_date: '2025-07-07'
+                  itt_end_date: '2025-07-03'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   withdraw_date:
                   defer_date:
-                  trainee_start_date: '2024-08-13'
+                  trainee_start_date: '2024-08-17'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -6569,15 +6611,16 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-579
-                  ukprn: '81211759'
+                  provider_trainee_id: 24/25-580
+                  defer_reason:
+                  ukprn: '36098093'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-13'
+                  course_itt_start_date: '2024-08-16'
                   course_age_range:
-                  expected_end_date: '2025-07-07'
+                  expected_end_date: '2025-07-03'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
@@ -6604,9 +6647,9 @@ paths:
                     uk_degree_uuid: 356a5652-c197-e711-80d8-005056ac45bb
                     subject_uuid: a37f70f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 1bb9f02f-da6a-4184-8db0-d43b14ccaf1d
-                    degree_id: rdf4rdtjtrco9mazgito6n7a
+                    degree_id: lnqeh86wkicbbrcn0s1rie7t
                   state: recommended_for_award
-                  trainee_id: 3vib8opny2l7484bdq2q3odq
+                  trainee_id: qa6l67lsk90k1y5ztd396xt4
                   application_id:
         '404':
           description: returns status code 404
@@ -6676,7 +6719,7 @@ paths:
         required: true
         schema:
           type: string
-        example: jyptp2d78kryb7ki0uevgt8g
+        example: pqzypn9nc3ziey6798iaq33k
       responses:
         '200':
           description: returns status code 200 with a valid JSON response
@@ -6792,6 +6835,8 @@ paths:
                         nullable: true
                       provider_trainee_id:
                         type: string
+                      defer_reason:
+                        nullable: true
                       ukprn:
                         type: string
                       ethnicity:
@@ -6963,6 +7008,7 @@ paths:
                     - slug_sent_to_dqt_at
                     - placement_detail
                     - provider_trainee_id
+                    - defer_reason
                     - ukprn
                     - ethnicity
                     - course_qualification
@@ -7002,20 +7048,20 @@ paths:
                 data:
                   commencement_status:
                   withdraw_date: '2024-09-15T12:34:56.000Z'
-                  first_names: Troy
-                  middle_names: Leffler
-                  last_name: Toy
-                  email: Troy.Toy@example.com
+                  first_names: Efrain
+                  middle_names: Wyman
+                  last_name: O'Hara
+                  email: Efrain.O'Hara@example.com
                   ethnic_background:
                   additional_ethnic_background:
-                  trn: '3936132'
+                  trn: '9621410'
                   region:
-                  hesa_id: '7241438004119'
+                  hesa_id: '9715682062388'
                   course_subject_one: '100403'
                   course_subject_two:
                   course_subject_three:
                   record_source: manual
-                  date_of_birth: '1983-05-26'
+                  date_of_birth: '1971-02-14'
                   created_at: '2024-09-15T12:34:56.000Z'
                   updated_at: '2024-09-15T12:34:56.000Z'
                   training_route:
@@ -7023,13 +7069,13 @@ paths:
                   diversity_disclosure: diversity_not_disclosed
                   ethnic_group:
                   disability_disclosure:
-                  itt_start_date: '2024-08-21'
+                  itt_start_date: '2024-08-17'
                   outcome_date:
-                  itt_end_date: '2025-07-25'
+                  itt_end_date: '2025-07-09'
                   submitted_for_trn_at: '2024-09-15T12:34:56.000Z'
                   defer_date:
                   recommended_for_award_at:
-                  trainee_start_date: '2024-08-21'
+                  trainee_start_date: '2024-08-24'
                   reinstate_date:
                   course_min_age: 11
                   course_max_age: 18
@@ -7051,21 +7097,22 @@ paths:
                   hesa_editable: false
                   slug_sent_to_dqt_at:
                   placement_detail:
-                  provider_trainee_id: 24/25-589
-                  ukprn: '37432111'
+                  provider_trainee_id: 24/25-590
+                  defer_reason:
+                  ukprn: '93397463'
                   ethnicity:
                   course_qualification: QTS
                   course_title:
                   course_level: postgrad
-                  course_itt_start_date: '2024-08-21'
+                  course_itt_start_date: '2024-08-17'
                   course_age_range: '13917'
-                  expected_end_date: '2025-07-25'
+                  expected_end_date: '2025-07-09'
                   employing_school_urn:
                   lead_partner_ukprn:
                   lead_partner_urn:
                   fund_code: '2'
                   bursary_level: '4'
-                  previous_last_name: Schuster
+                  previous_last_name: Kuhlman
                   itt_aim: '202'
                   course_study_mode: '01'
                   course_year: 2024
@@ -7096,9 +7143,9 @@ paths:
                     uk_degree_uuid: ed695652-c197-e711-80d8-005056ac45bb
                     subject_uuid: e78170f0-5dce-e911-a985-000d3ab79618
                     grade_uuid: 8741765a-13d8-4550-a413-c5a860a59d25
-                    degree_id: p31ybwbhb4qqly6kv0xm1z96
+                    degree_id: wqqgn2bpo62pr6tlfvcwwb2g
                   state: withdrawn
-                  trainee_id: rmfecfecsq2bbrfiz7q340of
+                  trainee_id: 5qubdz2bwo7w5yr22ywy7ayh
                   application_id:
         '401':
           description: did not change the trainee

--- a/spec/requests/api/v0_1/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_placement_spec.rb
@@ -158,7 +158,7 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
               trainee.placements.count
             }.from(1).to(2)
 
-            placement = trainee.reload.placements.last
+            placement = trainee.reload.placements.order(:id).last
 
             expect(response).to have_http_status(:created)
             expect(response.parsed_body["data"]).to include(

--- a/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_placement_spec.rb
@@ -163,9 +163,10 @@ describe "`POST /trainees/:trainee_slug/placements/` endpoint" do
             trainee.placements.count
           }.from(1).to(2)
 
-          placement = trainee.reload.placements.last
+          placement = trainee.reload.placements.order(:id).last
 
           expect(response).to have_http_status(:created)
+
           expect(response.parsed_body["data"]).to include(
             urn: data[:urn],
             name: data[:name],

--- a/spec/serializers/api/v0_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/trainee_serializer_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Api::V01::TraineeSerializer do
         withdrawal_future_interest
         withdrawal_another_reason
         defer_date
+        defer_reason
         recommended_for_award_at
         trainee_start_date
         reinstate_date


### PR DESCRIPTION
### Context

[8310-add-deferral-reason-to-api-endpoint-post-trainees-traineeid-defer](https://trello.com/c/hd9TAkJM/8310-add-deferral-reason-to-api-endpoint-post-trainees-traineeid-defer)

Add support for `defer_reason` optional string attribute limited to 500 characters to the deferral endpoint.

### Changes proposed in this pull request

* Add `defer_reason` to 'trainees'
* Refactor `DeferralService`
* Refactor `TraineeSerializer`
* Update docs

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
