### PR TITLE
[8289] Active HEI provider users only

### DIFF
--- a/.github/workflows/reset-csv-sandbox-database.yml
+++ b/.github/workflows/reset-csv-sandbox-database.yml
@@ -63,6 +63,11 @@ jobs:
       run: |
         bin/konduit.sh -n bat-production -i ${SANITISED_FILE_NAME}.sql.gz -c -t 7200 register-csv-sandbox -- psql
 
+    - name: Retains HEI and system admin users only
+      shell: bash
+      run: |
+        (kubectl -n bat-production exec -ti deployment/register-csv-sandbox -- bundle exec rake user:retain_hei_and_system_admin_users_only)
+
     - name: Check for Failure
       uses: ./.github/actions/send-slack-notification/
       if: ${{ failure() }}

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -79,7 +79,7 @@ class Provider < ApplicationRecord
                     },
                   }
 
-  scope :with_active_hei, -> { kept.where(accredited: true).where("accreditation_id ~ ?", "^[1][0-9]{3}") }
+  scope :active_hei, -> { kept.where(accredited: true).where("accreditation_id ~ ?", "^1[0-9]{3}$") }
 
   TEACH_FIRST_PROVIDER_CODE = "1TF"
   AMBITION_PROVIDER_CODE = "2A2"

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -79,6 +79,8 @@ class Provider < ApplicationRecord
                     },
                   }
 
+  scope :with_active_hei, -> { kept.where(accredited: true).where("accreditation_id ~ ?", "^[1][0-9]{3}") }
+
   TEACH_FIRST_PROVIDER_CODE = "1TF"
   AMBITION_PROVIDER_CODE = "2A2"
   START_MANDATING_PLACEMENT_DATA_CYCLE = 2022

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -29,5 +29,5 @@ class ProviderUser < ApplicationRecord
 
   audited associated_with: :provider
 
-  scope :with_active_hei_providers, -> { where(provider: Provider.with_active_hei) }
+  scope :with_active_hei_providers, -> { where(provider: Provider.active_hei) }
 end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -28,4 +28,6 @@ class ProviderUser < ApplicationRecord
   validates :user, uniqueness: { scope: :provider_id }
 
   audited associated_with: :provider
+
+  scope :with_active_hei_providers, -> { where(provider: Provider.with_active_hei) }
 end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :user do
+  desc "Retain HEI and system admin users only"
+  task retain_hei_and_system_admin_users_only: :environment do
+    raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
+
+    provider_user_with_active_hei_providers = ProviderUser.with_active_hei_providers
+    ProviderUser.where.not(id: provider_user_with_active_hei_providers.ids).delete_all
+
+    user_ids = ProviderUser.with_active_hei_providers.pluck(:user_id) + User.where(system_admin: true).ids
+    User.where.not(id: user_ids).update(dfe_sign_in_uid: nil)
+
+    LeadPartnerUser.delete_all
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -46,11 +46,11 @@ FactoryBot.define do
     end
 
     trait :hei do
-      accreditation_id { "1234" }
+      accreditation_id { Faker::Number.within(range: 1000..1999)    }
     end
 
     trait :scitt do
-      accreditation_id { "5432" }
+      accreditation_id { Faker::Number.within(range: 5000..5999)    }
     end
 
     trait :performance_profile_sign_off do

--- a/spec/lib/tasks/user_retain_hei_and_system_admin_users_only_spec.rb
+++ b/spec/lib/tasks/user_retain_hei_and_system_admin_users_only_spec.rb
@@ -61,7 +61,7 @@ describe "user:retain_hei_and_system_admin_users_only" do
     expect(inactive_scitt_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
     expect(unaccredited_scitt_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
 
-    expect(Provider.with_active_hei.count).to eq(1)
+    expect(Provider.active_hei.count).to eq(1)
     expect(User.pluck(:dfe_sign_in_uid).compact.count).to eq(2)
   end
 end

--- a/spec/lib/tasks/user_retain_hei_and_system_admin_users_only_spec.rb
+++ b/spec/lib/tasks/user_retain_hei_and_system_admin_users_only_spec.rb
@@ -61,7 +61,7 @@ describe "user:retain_hei_and_system_admin_users_only" do
     expect(inactive_scitt_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
     expect(unaccredited_scitt_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
 
-    expect(Provider.all.reload.with_active_hei.count).to eq(1)
-    expect(User.all.reload.pluck(:dfe_sign_in_uid).compact.count).to eq(2)
+    expect(Provider.with_active_hei.count).to eq(1)
+    expect(User.pluck(:dfe_sign_in_uid).compact.count).to eq(2)
   end
 end

--- a/spec/lib/tasks/user_retain_hei_and_system_admin_users_only_spec.rb
+++ b/spec/lib/tasks/user_retain_hei_and_system_admin_users_only_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "user:retain_hei_and_system_admin_users_only" do
+  subject do
+    Rake::Task["user:retain_hei_and_system_admin_users_only"].execute
+  end
+
+  let(:active_hei_provider) { create(:provider, :hei) }
+  let(:system_admin_user) { create(:user, :system_admin) }
+  let(:user_with_no_provider) { create(:user, providers: []) }
+
+  let(:inactive_hei_provider) { create(:provider, :hei) }
+  let(:unaccredited_hei_provider) { create(:provider, :hei, :unaccredited) }
+  let(:active_scitt_provider) { create(:provider, :scitt) }
+  let(:inactive_scitt_provider) { create(:provider, :scitt) }
+  let(:unaccredited_scitt_provider) { create(:provider, :scitt, :unaccredited) }
+
+  let(:lead_partner_user_hei) { create(:lead_partner_user, lead_partner: build(:lead_partner, :hei)) }
+  let(:lead_partner_user_school) { create(:lead_partner_user, lead_partner: build(:lead_partner, :school)) }
+  let(:lead_partner_user_scitt) { create(:lead_partner_user, lead_partner: build(:lead_partner, :scitt)) }
+
+  before do
+    active_hei_provider
+    system_admin_user
+
+    user_with_no_provider
+
+    lead_partner_user_hei
+    lead_partner_user_school
+    lead_partner_user_scitt
+
+    inactive_hei_provider.discard
+    unaccredited_hei_provider
+
+    active_scitt_provider
+    inactive_scitt_provider.discard
+    unaccredited_scitt_provider
+  end
+
+  it "retains HEI and system admin users only" do
+    subject
+
+    expect(active_hei_provider.users.reload.pluck(:dfe_sign_in_uid).compact).not_to be_blank
+    expect(system_admin_user.reload.dfe_sign_in_uid).not_to be_blank
+
+    expect(user_with_no_provider.reload.dfe_sign_in_uid).to be_blank
+
+    expect(lead_partner_user_hei.user.reload.dfe_sign_in_uid).to be_blank
+    expect(lead_partner_user_school.user.reload.dfe_sign_in_uid).to be_blank
+    expect(lead_partner_user_scitt.user.reload.dfe_sign_in_uid).to be_blank
+
+    expect(LeadPartnerUser.all.reload.count).to be_zero
+    expect(ProviderUser.all.reload.count).to eq(1)
+
+    expect(inactive_hei_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
+    expect(unaccredited_hei_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
+
+    expect(active_scitt_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
+    expect(inactive_scitt_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
+    expect(unaccredited_scitt_provider.users.reload.pluck(:dfe_sign_in_uid).compact).to be_blank
+
+    expect(Provider.all.reload.with_active_hei.count).to eq(1)
+    expect(User.all.reload.pluck(:dfe_sign_in_uid).compact.count).to eq(2)
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -22,12 +22,7 @@ describe Provider do
       end
 
       it "returns providers that are accredited and have a valid accreditation_id" do
-        expect(described_class.with_active_hei).to include(active_hei_provider)
-        expect(described_class.with_active_hei).not_to include(inactive_hei_provider)
-        expect(described_class.with_active_hei).not_to include(unaccredited_hei_provider)
-        expect(described_class.with_active_hei).not_to include(active_scitt_provider)
-        expect(described_class.with_active_hei).not_to include(inactive_scitt_provider)
-        expect(described_class.with_active_hei).not_to include(unaccredited_scitt_provider)
+        expect(described_class.with_active_hei).to contain_exactly(active_hei_provider)
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -3,6 +3,35 @@
 require "rails_helper"
 
 describe Provider do
+  describe "scopes" do
+    describe ".with_active_hei" do
+      let(:active_hei_provider) { create(:provider, :hei) }
+      let(:inactive_hei_provider) { create(:provider, :hei) }
+      let(:unaccredited_hei_provider) { create(:provider, :hei, :unaccredited) }
+      let(:active_scitt_provider) { create(:provider, :scitt) }
+      let(:inactive_scitt_provider) { create(:provider, :scitt) }
+      let(:unaccredited_scitt_provider) { create(:provider, :scitt, :unaccredited) }
+
+      before do
+        active_hei_provider
+        inactive_hei_provider.discard
+        unaccredited_hei_provider
+        active_scitt_provider
+        inactive_scitt_provider.discard
+        unaccredited_scitt_provider
+      end
+
+      it "returns providers that are accredited and have a valid accreditation_id" do
+        expect(described_class.with_active_hei).to include(active_hei_provider)
+        expect(described_class.with_active_hei).not_to include(inactive_hei_provider)
+        expect(described_class.with_active_hei).not_to include(unaccredited_hei_provider)
+        expect(described_class.with_active_hei).not_to include(active_scitt_provider)
+        expect(described_class.with_active_hei).not_to include(inactive_scitt_provider)
+        expect(described_class.with_active_hei).not_to include(unaccredited_scitt_provider)
+      end
+    end
+  end
+
   context "fields" do
     it "validates presence" do
       expect(subject).to validate_presence_of(:name).with_message("Enter a provider name")

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe Provider do
   describe "scopes" do
-    describe ".with_active_hei" do
+    describe ".active_hei" do
       let(:active_hei_provider) { create(:provider, :hei) }
       let(:inactive_hei_provider) { create(:provider, :hei) }
       let(:unaccredited_hei_provider) { create(:provider, :hei, :unaccredited) }
@@ -22,7 +22,7 @@ describe Provider do
       end
 
       it "returns providers that are accredited and have a valid accreditation_id" do
-        expect(described_class.with_active_hei).to contain_exactly(active_hei_provider)
+        expect(described_class.active_hei).to contain_exactly(active_hei_provider)
       end
     end
   end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 describe ProviderUser do
   describe "scopes" do
     describe ".with_active_hei_providers" do
-      let(:active_hei_provider_user) { create(:provider_user, provider: create(:provider, :hei)) }
-      let(:inactive_hei_provider_user) { create(:provider_user, provider: create(:provider, :hei)) }
-      let(:unaccredited_hei_provider_user) { create(:provider_user, provider: create(:provider, :hei, :unaccredited)) }
-      let(:active_scitt_provider_user) { create(:provider_user, provider: create(:provider, :scitt)) }
-      let(:inactive_scitt_provider_user) { create(:provider_user, provider: create(:provider, :scitt)) }
-      let(:unaccredited_scitt_provider_user) { create(:provider_user, provider: create(:provider, :scitt, :unaccredited)) }
+      let(:active_hei_provider_user) { create(:provider_user, provider: build(:provider, :hei)) }
+      let(:inactive_hei_provider_user) { create(:provider_user, provider: build(:provider, :hei)) }
+      let(:unaccredited_hei_provider_user) { create(:provider_user, provider: build(:provider, :hei, :unaccredited)) }
+      let(:active_scitt_provider_user) { create(:provider_user, provider: build(:provider, :scitt)) }
+      let(:inactive_scitt_provider_user) { create(:provider_user, provider: build(:provider, :scitt)) }
+      let(:unaccredited_scitt_provider_user) { create(:provider_user, provider: build(:provider, :scitt, :unaccredited)) }
 
       before do
         inactive_hei_provider_user.provider.discard
@@ -25,12 +25,7 @@ describe ProviderUser do
       end
 
       it "returns provider user that have providers that are accredited and have a valid accreditation_id" do
-        expect(described_class.with_active_hei_providers).to include(active_hei_provider_user)
-        expect(described_class.with_active_hei_providers).not_to include(inactive_hei_provider_user)
-        expect(described_class.with_active_hei_providers).not_to include(unaccredited_hei_provider_user)
-        expect(described_class.with_active_hei_providers).not_to include(active_scitt_provider_user)
-        expect(described_class.with_active_hei_providers).not_to include(inactive_scitt_provider_user)
-        expect(described_class.with_active_hei_providers).not_to include(unaccredited_scitt_provider_user)
+        expect(described_class.with_active_hei_providers).to contain_exactly(active_hei_provider_user)
       end
     end
   end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -3,6 +3,38 @@
 require "rails_helper"
 
 describe ProviderUser do
+  describe "scopes" do
+    describe ".with_active_hei_providers" do
+      let(:active_hei_provider_user) { create(:provider_user, provider: create(:provider, :hei)) }
+      let(:inactive_hei_provider_user) { create(:provider_user, provider: create(:provider, :hei)) }
+      let(:unaccredited_hei_provider_user) { create(:provider_user, provider: create(:provider, :hei, :unaccredited)) }
+      let(:active_scitt_provider_user) { create(:provider_user, provider: create(:provider, :scitt)) }
+      let(:inactive_scitt_provider_user) { create(:provider_user, provider: create(:provider, :scitt)) }
+      let(:unaccredited_scitt_provider_user) { create(:provider_user, provider: create(:provider, :scitt, :unaccredited)) }
+
+      before do
+        inactive_hei_provider_user.provider.discard
+        inactive_scitt_provider_user.provider.discard
+
+        active_hei_provider_user
+        inactive_hei_provider_user
+        unaccredited_hei_provider_user
+        active_scitt_provider_user
+        inactive_scitt_provider_user
+        unaccredited_scitt_provider_user
+      end
+
+      it "returns provider user that have providers that are accredited and have a valid accreditation_id" do
+        expect(described_class.with_active_hei_providers).to include(active_hei_provider_user)
+        expect(described_class.with_active_hei_providers).not_to include(inactive_hei_provider_user)
+        expect(described_class.with_active_hei_providers).not_to include(unaccredited_hei_provider_user)
+        expect(described_class.with_active_hei_providers).not_to include(active_scitt_provider_user)
+        expect(described_class.with_active_hei_providers).not_to include(inactive_scitt_provider_user)
+        expect(described_class.with_active_hei_providers).not_to include(unaccredited_scitt_provider_user)
+      end
+    end
+  end
+
   subject { create(:provider_user) }
 
   describe "validations" do


### PR DESCRIPTION
### Context
Active HEI provider users

### Changes proposed in this pull request
Retain active hei provider users only

### Guidance to review
To test pull down and restore a sanitised database back up and run the rake task
```
bundle exec rake user:retain_hei_and_system_admin_users_only
```

Only the user relationship of a HEI is retained

`LeadPartnerUser` will be destroyed, this is to prevent a user that has both `HEI` and `LeadPartner` provider to interactive as a `LeadPartner`

`ProviderUser` may be destroyed (only `HEI` related will be retained) this is to prevent a user that has both `HEI` and `SCITT` provider to interactive as a `SCITT`

`User`'s `dfe_sign_in_uid` will either be retained if `HEI` related or a `system admin` otherwise it will all be nil out, this is to prevent any other users to interactive during our selective testing

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
