### PR TITLE
[8380] Sending the same disability code in 2 fields to the API causes a 500 error

### DIFF
--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -102,6 +102,8 @@ module Api
                 inclusion: { in: RecruitsApi::CodeSets::Nationalities::MAPPING.values }, allow_blank: true
       validates :training_initiative,
                 inclusion: { in: ROUTE_INITIATIVES.keys }, allow_blank: true
+      validates :trainee_disabilities_attributes, uniqueness: true
+
 
       def initialize(new_attributes = {})
         new_attributes = new_attributes.to_h.with_indifferent_access
@@ -135,6 +137,7 @@ module Api
         end
 
         self.trainee_disabilities_attributes = []
+
         new_attributes[:disabilities]&.each do |disability|
           trainee_disabilities_attributes << { disability_id: disability.id }
         end

--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -104,7 +104,6 @@ module Api
                 inclusion: { in: ROUTE_INITIATIVES.keys }, allow_blank: true
       validates :trainee_disabilities_attributes, uniqueness: true
 
-
       def initialize(new_attributes = {})
         new_attributes = new_attributes.to_h.with_indifferent_access
 

--- a/app/validators/uniqueness_validator.rb
+++ b/app/validators/uniqueness_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UniquenessValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.tally.any? { |_k, v| v > 1 }
+      record.errors.add(attribute, I18n.t(".activemodel.errors.validators.uniqueness"))
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1547,6 +1547,7 @@ en:
           other_nationality2: *nationality
           other_nationality3: *nationality
           iqts_country: Enter the country or territory the trainee is studying in
+        uniqueness: contain duplicate values
       models:
         placements_form:
           attributes:

--- a/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
@@ -18,6 +18,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
   let(:sex) { Hesa::CodeSets::Sexes::MAPPING.keys.sample }
   let(:itt_start_date) { "2023-01-01" }
   let(:itt_end_date) { "2023-10-01" }
+  let(:disability1) { "58" }
+  let(:disability2) { "57" }
 
   let(:data) do
     {
@@ -33,8 +35,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       itt_end_date: itt_end_date,
       course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[CourseSubjects::BIOLOGY],
       study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
-      disability1: "58",
-      disability2: "57",
+      disability1:,
+      disability2:,
       degrees_attributes: [
         {
           grade: "02",
@@ -338,6 +340,22 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             end
           end
         end
+      end
+    end
+
+    context "when disabilities have the same code values" do
+      let(:disability1) { "58" }
+      let(:disability2) { "58" }
+
+      it "does not create a trainee record and returns a 422 status with meaningful error message" do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        parsed_body = response.parsed_body[:data]
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to include("Trainee disabilities attributes contain duplicate values")
       end
     end
 

--- a/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0_1/post_hesa_trainees_spec.rb
@@ -35,8 +35,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       itt_end_date: itt_end_date,
       course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[CourseSubjects::BIOLOGY],
       study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
-      disability1:,
-      disability2:,
+      disability1: disability1,
+      disability2: disability2,
       degrees_attributes: [
         {
           grade: "02",
@@ -352,7 +352,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
         expect(response).to have_http_status(:unprocessable_entity)
 
-        parsed_body = response.parsed_body[:data]
+        response.parsed_body[:data]
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to include("Trainee disabilities attributes contain duplicate values")

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -901,7 +901,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         end
       end
 
-      context "when disability1 & disability2 is set" do
+      context "when disability1 & disability2 are set" do
         let(:params) do
           {
             data: {
@@ -920,6 +920,24 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
           expect(trainee.disabilities.count).to eq(2)
           expect(trainee.disabilities.map(&:name)).to contain_exactly("Blind", "Deaf")
+        end
+      end
+
+      context "when disability1 & disability2 have the same code values" do
+        let(:params) do
+          {
+            data: {
+              disability1: "58",
+              disability2: "58",
+            },
+          }
+        end
+
+        it do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body[:errors]).to contain_exactly(
+            "Trainee disabilities attributes contain duplicate values"
+          )
         end
       end
     end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -936,7 +936,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         it do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body[:errors]).to contain_exactly(
-            "Trainee disabilities attributes contain duplicate values"
+            "Trainee disabilities attributes contain duplicate values",
           )
         end
       end

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -39,8 +39,8 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       itt_end_date: itt_end_date,
       course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[CourseSubjects::BIOLOGY],
       study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
-      disability1:,
-      disability2:,
+      disability1: disability1,
+      disability2: disability2,
       degrees_attributes: [
         {
           grade: "02",
@@ -377,7 +377,7 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
 
         expect(response).to have_http_status(:unprocessable_entity)
 
-        parsed_body = response.parsed_body[:data]
+        response.parsed_body[:data]
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to include("Trainee disabilities attributes contain duplicate values")

--- a/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v1_0_pre/post_hesa_trainees_spec.rb
@@ -20,6 +20,8 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
   let(:itt_start_date) { "2023-01-01" }
   let(:itt_end_date) { "2023-10-01" }
   let(:training_route) { Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]] }
+  let(:disability1) { "58" }
+  let(:disability2) { "57" }
 
   let(:endpoint) { "/api/v1.0-pre/trainees" }
 
@@ -37,8 +39,8 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
       itt_end_date: itt_end_date,
       course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[CourseSubjects::BIOLOGY],
       study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
-      disability1: "58",
-      disability2: "57",
+      disability1:,
+      disability2:,
       degrees_attributes: [
         {
           grade: "02",
@@ -363,6 +365,22 @@ describe "`POST /api/v1.0-pre/trainees` endpoint" do
             end
           end
         end
+      end
+    end
+
+    context "when disabilities have the same code values" do
+      let(:disability1) { "58" }
+      let(:disability2) { "58" }
+
+      it "does not create a trainee record and returns a 422 status with meaningful error message" do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        parsed_body = response.parsed_body[:data]
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to include("Trainee disabilities attributes contain duplicate values")
       end
     end
 

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -966,7 +966,7 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
         it do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body[:errors]).to contain_exactly(
-            "Trainee disabilities attributes contain duplicate values"
+            "Trainee disabilities attributes contain duplicate values",
           )
         end
       end

--- a/spec/requests/api/v1_0_pre/put_trainee_spec.rb
+++ b/spec/requests/api/v1_0_pre/put_trainee_spec.rb
@@ -931,7 +931,7 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
         end
       end
 
-      context "when disability1 & disability2 is set" do
+      context "when disability1 & disability2 are set" do
         let(:params) do
           {
             data: {
@@ -950,6 +950,24 @@ describe "`PUT /api/v1.0-pre/trainees/:id` endpoint" do
 
           expect(trainee.disabilities.count).to eq(2)
           expect(trainee.disabilities.map(&:name)).to contain_exactly("Blind", "Deaf")
+        end
+      end
+
+      context "when disability1 & disability2 have the same code values" do
+        let(:params) do
+          {
+            data: {
+              disability1: "58",
+              disability2: "58",
+            },
+          }
+        end
+
+        it do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body[:errors]).to contain_exactly(
+            "Trainee disabilities attributes contain duplicate values"
+          )
         end
       end
     end


### PR DESCRIPTION
### Context

[8380-sending-the-same-disability-code-in-2-fields-to-the-api-causes-a-500-error](https://trello.com/c/z0BDAKto/8380-sending-the-same-disability-code-in-2-fields-to-the-api-causes-a-500-error)

### Changes proposed in this pull request

* Add UniquenessValidator
* Validate for unique disabilities in `Api::V01::TraineesAttributes`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
