### PR TITLE
[8371] Add missing degree type mapping for 4 specific degrees

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ gem "govuk_markdown"
 
 gem "mechanize" # interact with HESA
 
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v3.6.10"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v3.7.0"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: 2837469518d193aa819cc9fdedc40854dafa8284
-  tag: v3.6.10
+  revision: 6660e634ac24a00d8afa3b9f60686cb7ae45e59a
+  tag: v3.7.0
   specs:
-    dfe-reference-data (3.6.10)
+    dfe-reference-data (3.7.0)
       activesupport
       tzinfo
 

--- a/spec/requests/api/v0_1/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_degrees_spec.rb
@@ -18,7 +18,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         grade: "02",
         subject: "100425",
         institution: "0117",
-        uk_degree: "083",
+        uk_degree: "014",
         graduation_year: "2015-01-01",
         country: "XF",
       }
@@ -41,7 +41,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree_attributes["grade"]).to eq("02")
         expect(degree_attributes["subject"]).to eq("100425")
         expect(degree_attributes["institution"]).to eq("0117")
-        expect(degree_attributes["uk_degree"]).to eq("083")
+        expect(degree_attributes["uk_degree"]).to eq("014")
         expect(degree_attributes["graduation_year"]).to eq(2015)
         expect(degree_attributes["country"]).to be_nil
         expect(degree_attributes["locale_code"]).to be_nil
@@ -58,8 +58,8 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree.subject_uuid).to eq("918170f0-5dce-e911-a985-000d3ab79618")
         expect(degree.institution).to eq("University of East Anglia")
         expect(degree.institution_uuid).to eq("1271f34a-2887-e711-80d8-005056ac45bb")
-        expect(degree.uk_degree).to eq("Bachelor of Science")
-        expect(degree.uk_degree_uuid).to eq("1b6a5652-c197-e711-80d8-005056ac45bb")
+        expect(degree.uk_degree).to eq("Bachelor of Arts (Hons) with intercalated PGCE")
+        expect(degree.uk_degree_uuid).to eq("0caa1ea5-868a-47a4-9b26-4b7470528b67")
         expect(degree.non_uk_degree).to be_nil
 
         expect(degree.graduation_year).to eq(2015)

--- a/spec/requests/api/v1_0_pre/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_degrees_spec.rb
@@ -18,7 +18,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         grade: "02",
         subject: "100425",
         institution: "0117",
-        uk_degree: "083",
+        uk_degree: "014",
         graduation_year: "2015-01-01",
         country: "XF",
       }
@@ -41,7 +41,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree_attributes["grade"]).to eq("02")
         expect(degree_attributes["subject"]).to eq("100425")
         expect(degree_attributes["institution"]).to eq("0117")
-        expect(degree_attributes["uk_degree"]).to eq("083")
+        expect(degree_attributes["uk_degree"]).to eq("014")
         expect(degree_attributes["graduation_year"]).to eq(2015)
         expect(degree_attributes["country"]).to be_nil
         expect(degree_attributes["locale_code"]).to be_nil
@@ -57,8 +57,8 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree.subject_uuid).to eq("918170f0-5dce-e911-a985-000d3ab79618")
         expect(degree.institution).to eq("University of East Anglia")
         expect(degree.institution_uuid).to eq("1271f34a-2887-e711-80d8-005056ac45bb")
-        expect(degree.uk_degree).to eq("Bachelor of Science")
-        expect(degree.uk_degree_uuid).to eq("1b6a5652-c197-e711-80d8-005056ac45bb")
+        expect(degree.uk_degree).to eq("Bachelor of Arts (Hons) with intercalated PGCE")
+        expect(degree.uk_degree_uuid).to eq("0caa1ea5-868a-47a4-9b26-4b7470528b67")
 
         expect(degree.graduation_year).to eq(2015)
         expect(degree.country).to be_nil


### PR DESCRIPTION
### Context

[8371-add-missing-degree-type-mapping-for-4-specific-degrees](https://trello.com/c/1MBUPAiU/8371-add-missing-degree-type-mapping-for-4-specific-degrees)

Bump DfE data reference gem to `v3.7.0`

https://github.com/DFE-Digital/dfe-reference-data/pull/141

### Changes proposed in this pull request

* Refactor specs to test DfE reference gem new degree type

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
