### PR TITLE
[8389] Allow users to change deferral date

### DIFF
--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -62,7 +62,7 @@ class TraineePolicy
   end
 
   def withdraw?
-    allow_actions? && (defer? || trainee.deferred? || user_is_system_admin?)
+    defer? || user_is_system_admin?
   end
 
   def undo_withdraw?
@@ -70,7 +70,7 @@ class TraineePolicy
   end
 
   def defer?
-    allow_actions? && (trainee.submitted_for_trn? || trainee.trn_received?)
+    allow_actions? && (trainee.submitted_for_trn? || trainee.trn_received? || trainee.deferred?)
   end
 
   def reinstate?

--- a/spec/features/trainee_actions/defer_trainee_spec.rb
+++ b/spec/features/trainee_actions/defer_trainee_spec.rb
@@ -144,9 +144,26 @@ feature "Deferring a trainee" do
     and_the_defer_date_i_chose_is_cleared
   end
 
+  scenario "changing the deferral date" do
+    given_a_trainee_exists_with_a_deferral_date
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_change_date_of_deferral
+    when_i_choose_today
+    and_i_continue
+    then_i_am_redirected_to_deferral_confirmation_page
+    and_i_see_my_date(Time.zone.today)
+    when_i_defer
+    then_the_defer_date_is_updated
+    then_i_am_redirected_to_the_record_page
+  end
+
   def given_i_initiate_a_deferral
     and_i_am_on_the_trainee_record_page
     and_i_click_on_defer
+  end
+
+  def and_i_click_on_change_date_of_deferral
+    record_page.change_date_of_deferral.click
   end
 
   def given_i_am_on_the_deferral_confirmation_page
@@ -256,7 +273,7 @@ feature "Deferring a trainee" do
   end
 
   def given_a_trainee_exists_with_a_deferral_date
-    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample,
+    given_a_trainee_exists(:deferred,
                            trainee_start_date: 1.month.ago,
                            itt_start_date: 1.year.ago,
                            itt_end_date: 1.year.from_now,

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -138,10 +138,10 @@ describe TraineePolicy do
         allow(provider_trainee).to receive(:deferred?).and_return(true)
       end
 
-      it { is_expected.not_to permit(provider_user, provider_trainee) }
+      it { is_expected.to permit(provider_user, provider_trainee) }
       it { is_expected.not_to permit(other_provider_user, provider_trainee) }
       it { is_expected.not_to permit(lead_partner_user, provider_trainee) }
-      it { is_expected.not_to permit(system_admin_user, provider_trainee) }
+      it { is_expected.to permit(system_admin_user, provider_trainee) }
     end
 
     context "when trainee is submitted_for_trn?" do

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -33,6 +33,7 @@ module PageObjects
       element :change_employing_school, "a", text: "Change employing school", visible: false
       element :change_course_details, "a", text: "Change course", visible: false
       element :change_trainee_status, "a", text: "Change status", visible: false
+      element :change_date_of_deferral, "a", text: "Change date of deferral", visible: false
       element :withdrawal_details_component, "h3", text: "Withdrawal details", visible: false
       element :enable_editing, ".enable-editing"
     end


### PR DESCRIPTION
### Context

Users and support agents are not able to change the deferral date of a deferred trainee. This is despite there being a 'Change' link on the trainee record.
![image](https://github.com/user-attachments/assets/cb1f09db-c96e-496a-af34-09113efa3884)

It seems like the intention was to allow this date to be changed but the permissions were not set up correctly, and there was no test for it.

### Changes proposed in this pull request

* Allow users to change the deferral date of a deferred trainee
* Prevent getting a permission denied when using the 'Change' link
* Add a feature test to cover this scenario

### Guidance to review

* Any unintended consequences?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
