### PR TITLE
[8275] - Add new 'revoke a token' page

### DIFF
--- a/app/components/authentication_tokens/details/view.html.erb
+++ b/app/components/authentication_tokens/details/view.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_summary_card(title: name, html_attributes: { id: "token-#{id}" }) do |card|
-  card.with_action { govuk_link_to("Revoke", authentication_token_revoke_path(authentication_token_id: id)) } if token.active? && revokable?
+  card.with_action { govuk_link_to("Revoke", authentication_token_revoke_path(authentication_token_id: id)) } if policy(token).update?
   card.with_summary_list(rows: rows)
 end %>

--- a/app/components/authentication_tokens/details/view.html.erb
+++ b/app/components/authentication_tokens/details/view.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_summary_card(title: name, html_attributes: { id: "token-#{id}" }) do |card|
-  card.with_action { govuk_link_to("Revoke", organisation_authentication_token_revoke_path(organisation_id: provider_id, authentication_token_id: id)) } if token.active?
+  card.with_action { govuk_link_to("Revoke", authentication_token_revoke_path(authentication_token_id: id)) } if token.active? && revokable?
   card.with_summary_list(rows: rows)
 end %>

--- a/app/components/authentication_tokens/details/view.html.erb
+++ b/app/components/authentication_tokens/details/view.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_summary_card(title: name, html_attributes: { id: "token-#{id}" }) do |card|
+  card.with_action { govuk_link_to("Revoke", organisation_authentication_token_revoke_path(organisation_id: provider_id, authentication_token_id: id)) } if token.active?
   card.with_summary_list(rows: rows)
 end %>
-

--- a/app/components/authentication_tokens/details/view.rb
+++ b/app/components/authentication_tokens/details/view.rb
@@ -16,6 +16,7 @@ module AuthenticationTokens
                :revoked_at,
                :revoked?,
                :expired?,
+               :provider_id,
                to: :token
 
       def initialize(token)

--- a/app/components/authentication_tokens/details/view.rb
+++ b/app/components/authentication_tokens/details/view.rb
@@ -3,7 +3,10 @@
 module AuthenticationTokens
   module Details
     class View < ViewComponent::Base
-      attr_reader :token
+      include Pundit::Authorization
+      include UsersHelper
+
+      attr_reader :token, :current_user
 
       delegate :id,
                :name,
@@ -16,7 +19,6 @@ module AuthenticationTokens
                :revoked_at,
                :revoked?,
                :expired?,
-               :provider_id,
                to: :token
 
       def initialize(token)
@@ -53,6 +55,10 @@ module AuthenticationTokens
         end
 
         row
+      end
+
+      def revokable?
+        @revokable ||= AuthenticationTokenPolicy.new(current_user, token)
       end
     end
   end

--- a/app/components/authentication_tokens/details/view.rb
+++ b/app/components/authentication_tokens/details/view.rb
@@ -4,7 +4,6 @@ module AuthenticationTokens
   module Details
     class View < ViewComponent::Base
       include Pundit::Authorization
-      include UsersHelper
 
       attr_reader :token, :current_user
 
@@ -21,8 +20,9 @@ module AuthenticationTokens
                :expired?,
                to: :token
 
-      def initialize(token)
+      def initialize(token, current_user = Current.user)
         @token = token
+        @current_user = current_user
       end
 
       def rows
@@ -55,10 +55,6 @@ module AuthenticationTokens
         end
 
         row
-      end
-
-      def revokable?
-        @revokable ||= AuthenticationTokenPolicy.new(current_user, token)
       end
     end
   end

--- a/app/controllers/authentication_tokens/revokes_controller.rb
+++ b/app/controllers/authentication_tokens/revokes_controller.rb
@@ -17,7 +17,7 @@ module AuthenticationTokens
   private
 
     def token
-      @token ||= policy_scope(AuthenticationToken).where(id: token_params).first
+      @token ||= policy_scope(AuthenticationToken).find(params[:authentication_token_id)
     end
 
     def token_params

--- a/app/controllers/authentication_tokens/revokes_controller.rb
+++ b/app/controllers/authentication_tokens/revokes_controller.rb
@@ -17,11 +17,7 @@ module AuthenticationTokens
   private
 
     def token
-      @token ||= policy_scope(AuthenticationToken).find(token_params)
-    end
-
-    def token_params
-      params.require(:authentication_token_id)
+      @token ||= policy_scope(AuthenticationToken).find(params[:authentication_token_id])
     end
   end
 end

--- a/app/controllers/authentication_tokens/revokes_controller.rb
+++ b/app/controllers/authentication_tokens/revokes_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AuthenticationTokens
+  class RevokesController < ApplicationController
+    def show
+      authorize(token)
+    end
+
+    def update
+      authorize(token)
+
+      token.revoke!
+
+      redirect_to(authentication_tokens_path)
+    end
+
+  private
+
+    def token
+      @token ||= policy_scope(AuthenticationToken).where(id: token_params).first
+    end
+
+    def token_params
+      params.require(:authentication_token_id)
+    end
+  end
+end

--- a/app/controllers/authentication_tokens/revokes_controller.rb
+++ b/app/controllers/authentication_tokens/revokes_controller.rb
@@ -17,7 +17,7 @@ module AuthenticationTokens
   private
 
     def token
-      @token ||= policy_scope(AuthenticationToken).find(params[:authentication_token_id)
+      @token ||= policy_scope(AuthenticationToken).find(token_params)
     end
 
     def token_params

--- a/app/policies/authentication_token_policy.rb
+++ b/app/policies/authentication_token_policy.rb
@@ -42,6 +42,6 @@ class AuthenticationTokenPolicy
   end
 
   def update?
-    user.provider? && !token.revoked?
+    user.provider? && token.can_revoke?
   end
 end

--- a/app/policies/authentication_token_policy.rb
+++ b/app/policies/authentication_token_policy.rb
@@ -34,4 +34,12 @@ class AuthenticationTokenPolicy
   def create?
     user.provider?
   end
+
+  def show?
+    user.organisation?
+  end
+
+  def update?
+    user.organisation?
+  end
 end

--- a/app/policies/authentication_token_policy.rb
+++ b/app/policies/authentication_token_policy.rb
@@ -18,9 +18,11 @@ class AuthenticationTokenPolicy
   end
 
   attr_reader :user
+  attr_reader :token
 
-  def initialize(user, _record)
+  def initialize(user, token)
     @user = user
+    @token = token
   end
 
   def index?
@@ -36,10 +38,10 @@ class AuthenticationTokenPolicy
   end
 
   def show?
-    user.organisation?
+    user.provider? && !token.revoked?
   end
 
   def update?
-    user.organisation?
+    user.provider? && !token.revoked?
   end
 end

--- a/app/policies/authentication_token_policy.rb
+++ b/app/policies/authentication_token_policy.rb
@@ -38,7 +38,7 @@ class AuthenticationTokenPolicy
   end
 
   def show?
-    user.provider? && !token.revoked?
+    user.provider? && token.can_revoke?
   end
 
   def update?

--- a/app/views/authentication_tokens/revokes/show.html.erb
+++ b/app/views/authentication_tokens/revokes/show.html.erb
@@ -1,0 +1,25 @@
+<%= render PageTitle::View.new(text: current_user.organisation.name) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: authentication_tokens_path
+  ) %>
+<% end %>
+<h1 class="govuk-heading-l">
+  Are you sure you want to revoke this token?
+</h1>
+<p class="govuk-body">Revoking a token removes access to the Register API.</p>
+
+<p class="govuk-body">Before revoking a current token, you should generate a new token if you want to continue transferring your trainee data to Register via the API.</p>
+
+<p class="govuk-body">
+  <%= register_form_with(url: organisation_authentication_token_revoke_path(organisation: current_user.organisation, authentication_token: @token),method: :put) do |f| %>
+    <%= f.submit"Yes I’m sure — revoke this token", class: "govuk-button govuk-button--warning" %>
+  <% end %>
+</p>
+<div class="govuk-body">
+  <%= govuk_link_to(
+    "Cancel revoking this API token",
+    authentication_tokens_path) %>
+</div>

--- a/app/views/authentication_tokens/revokes/show.html.erb
+++ b/app/views/authentication_tokens/revokes/show.html.erb
@@ -14,7 +14,7 @@
 <p class="govuk-body">Before revoking a current token, you should generate a new token if you want to continue transferring your trainee data to Register via the API.</p>
 
 <p class="govuk-body">
-  <%= register_form_with(url: organisation_authentication_token_revoke_path(organisation: current_user.organisation, authentication_token: @token),method: :put) do |f| %>
+  <%= register_form_with(url: authentication_token_revoke_path(authentication_token: @token),method: :put) do |f| %>
     <%= f.submit"Yes I’m sure — revoke this token", class: "govuk-button govuk-button--warning" %>
   <% end %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,14 +245,14 @@ Rails.application.routes.draw do
   resource :cookie_preferences, only: %i[show update], path: "/cookies"
 
   resources :service_updates, only: %i[index], path: "service-updates"
-  resources :organisations, only: %i[index show], path: "organisations" do
-    resources :authentication_tokens, only: %i[] do
-      resource :revoke, only: %i[show update], controller: "authentication_tokens/revokes"
-    end
-  end
+
+  resources :organisations, only: %i[index show], path: "organisations"
+
   resource :organisation_settings, only: :show, path: "organisation-settings"
 
-  resources :authentication_tokens, only: %i[index new create show], path: "token-manage"
+  resources :authentication_tokens, only: %i[index new create show], path: "token-manage" do
+    resource :revoke, only: %i[show update], controller: "authentication_tokens/revokes"
+  end
 
   resource :guidance, only: %i[show], controller: "guidance" do
     get "/about-register-trainee-teachers", to: "guidance#about_register_trainee_teachers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,7 +245,11 @@ Rails.application.routes.draw do
   resource :cookie_preferences, only: %i[show update], path: "/cookies"
 
   resources :service_updates, only: %i[index], path: "service-updates"
-  resources :organisations, only: %i[index show], path: "organisations"
+  resources :organisations, only: %i[index show], path: "organisations" do
+    resources :authentication_tokens, only: %i[] do
+      resource :revoke, only: %i[show update], controller: "authentication_tokens/revokes"
+    end
+  end
   resource :organisation_settings, only: :show, path: "organisation-settings"
 
   resources :authentication_tokens, only: %i[index new create show], path: "token-manage"

--- a/spec/features/authentication_tokens/revoke_authentication_token_spec.rb
+++ b/spec/features/authentication_tokens/revoke_authentication_token_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "revoke an authentication token" do
+  scenario "when the feature flag is on I can revoke a token", feature_token_management: true do
+    given_i_am_authenticated
+    and_i_have_generated_a_token
+
+    given_i_navigate_to_the_authentication_token_index_page
+    and_i_click_the_revoke_token_action
+    then_i_should_see_the_revoke_token_page
+
+    and_i_click_the_revoke_token_confirmation_button
+    then_the_token_should_have_a_revoked_status
+    and_i_should_no_longer_see_the_revoke_action
+    and_i_should_see_when_the_token_was_revoked
+  end
+
+private
+
+  def and_i_have_generated_a_token
+    visit authentication_tokens_path
+    click_on "Generate a new token"
+    fill_in "Token name", with: "My new token"
+    fill_in "Day", with: 1.year.from_now.day.to_s
+    fill_in "Month", with: 1.year.from_now.month.to_s
+    fill_in "Year", with: 1.year.from_now.year.to_s
+    click_on "Generate token"
+    click_on "Continue to manage tokens"
+  end
+
+  def when_i_navigate_to_the_create_authentication_token_page
+    visit new_authentication_token_path
+  end
+
+  def given_i_navigate_to_the_authentication_token_index_page
+    visit authentication_tokens_path
+  end
+
+  def and_i_click_the_revoke_token_action
+    click_on "Revoke"
+  end
+
+  def and_i_click_the_revoke_token_confirmation_button
+    click_on "Yes I’m sure — revoke this token"
+  end
+
+  def then_i_should_see_the_revoke_token_page
+    expect(page).to have_content("Are you sure you want to revoke this token?")
+  end
+
+  def then_the_token_should_have_a_revoked_status
+    expect(page).to have_content("Revoked")
+  end
+
+  def and_i_should_no_longer_see_the_revoke_action
+    expect(page).not_to have_link("Revoke")
+  end
+
+  def and_i_should_see_when_the_token_was_revoked
+    expect(page).to have_content("Revoked by")
+    expect(page).to have_content("on #{Date.today.to_fs(:govuk)}")
+  end
+end

--- a/spec/features/authentication_tokens/revoke_authentication_token_spec.rb
+++ b/spec/features/authentication_tokens/revoke_authentication_token_spec.rb
@@ -60,6 +60,6 @@ private
 
   def and_i_should_see_when_the_token_was_revoked
     expect(page).to have_content("Revoked by")
-    expect(page).to have_content("on #{Date.today.to_fs(:govuk)}")
+    expect(page).to have_content("on #{Time.zone.today.to_fs(:govuk)}")
   end
 end

--- a/spec/features/authentication_tokens/revoke_authentication_token_spec.rb
+++ b/spec/features/authentication_tokens/revoke_authentication_token_spec.rb
@@ -17,6 +17,21 @@ feature "revoke an authentication token" do
     and_i_should_see_when_the_token_was_revoked
   end
 
+  scenario "when the feature flag is on I cannot revoke a token twice", feature_token_management: true do
+    given_i_am_authenticated
+    and_i_have_generated_a_token
+
+    given_i_navigate_to_the_authentication_token_index_page
+    and_i_click_the_revoke_token_action
+    then_i_should_see_the_revoke_token_page
+
+    and_i_click_the_revoke_token_confirmation_button
+    then_the_token_should_have_a_revoked_status
+
+    and_i_navigate_to_the_revoke_token_page
+    then_i_see_an_unauthorised_message
+  end
+
 private
 
   def and_i_have_generated_a_token
@@ -61,5 +76,23 @@ private
   def and_i_should_see_when_the_token_was_revoked
     expect(page).to have_content("Revoked by")
     expect(page).to have_content("on #{Time.zone.today.to_fs(:govuk)}")
+  end
+
+  def then_i_see_an_unauthorised_message
+    expect(page).to have_content("You do not have permission to perform this action")
+  end
+
+  def and_i_cannot_see_the_revoke_action
+    expect(page).not_to have_link("Revoke")
+  end
+
+  def and_i_navigate_to_the_revoke_token_page
+    token = AuthenticationToken.last
+
+    visit authentication_token_revoke_path(token)
+  end
+
+  def then_i_see_an_unauthorised_message
+    expect(page).to have_content("You do not have permission to perform this action")
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/47mHovqF/8275-add-new-revoke-a-token-page

### Changes proposed in this pull request

Add process for revoking authentication token

![Screenshot 2025-04-09 at 09-55-58 Londinium Teacher Training - Register trainee teachers - GOV UK](https://github.com/user-attachments/assets/3f1a4877-a894-4e51-ac05-38f5723ccd65)

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
