### PR TITLE
[8372] - Add 274 missing institutions for previous degrees

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ gem "govuk_markdown"
 
 gem "mechanize" # interact with HESA
 
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", branch: "add-274-missing-institutions-for-previous-degrees"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v3.7.1"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.5"

--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ gem "govuk_markdown"
 
 gem "mechanize" # interact with HESA
 
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v3.7.0"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", branch: "add-274-missing-institutions-for-previous-degrees"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: 6660e634ac24a00d8afa3b9f60686cb7ae45e59a
-  tag: v3.7.0
+  revision: 6a9762ca826b38d1d09256228ba15092ca08790c
+  branch: add-274-missing-institutions-for-previous-degrees
   specs:
     dfe-reference-data (3.7.0)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: 6a9762ca826b38d1d09256228ba15092ca08790c
-  branch: add-274-missing-institutions-for-previous-degrees
+  revision: 392090cc0448bf5f6555c0b180ff924bf2c6c5a0
+  tag: v3.7.1
   specs:
-    dfe-reference-data (3.7.0)
+    dfe-reference-data (3.7.1)
       activesupport
       tzinfo
 

--- a/spec/requests/api/v0_1/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_degrees_spec.rb
@@ -17,7 +17,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
       {
         grade: "02",
         subject: "100425",
-        institution: "0084",
+        institution: "1166",
         uk_degree: "014",
         graduation_year: "2015-01-01",
         country: "XF",
@@ -40,7 +40,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
 
         expect(degree_attributes["grade"]).to eq("02")
         expect(degree_attributes["subject"]).to eq("100425")
-        expect(degree_attributes["institution"]).to eq("0084")
+        expect(degree_attributes["institution"]).to eq("1166")
         expect(degree_attributes["uk_degree"]).to eq("014")
         expect(degree_attributes["graduation_year"]).to eq(2015)
         expect(degree_attributes["country"]).to be_nil
@@ -56,8 +56,8 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree.grade_uuid).to eq("e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f")
         expect(degree.subject).to eq("Physics")
         expect(degree.subject_uuid).to eq("918170f0-5dce-e911-a985-000d3ab79618")
-        expect(degree.institution).to eq("Wimbledon School of Art")
-        expect(degree.institution_uuid).to eq("c6501667-3718-43e3-9390-71bc20ccb6c7")
+        expect(degree.institution).to eq("Blackburn College")
+        expect(degree.institution_uuid).to eq("c63d87ce-7c3d-4e5a-93e2-337b71426d8f")
         expect(degree.uk_degree).to eq("Bachelor of Science")
         expect(degree.uk_degree_uuid).to eq("1b6a5652-c197-e711-80d8-005056ac45bb")
         expect(degree.non_uk_degree).to be_nil

--- a/spec/requests/api/v0_1/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_degrees_spec.rb
@@ -58,8 +58,8 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree.subject_uuid).to eq("918170f0-5dce-e911-a985-000d3ab79618")
         expect(degree.institution).to eq("Blackburn College")
         expect(degree.institution_uuid).to eq("c63d87ce-7c3d-4e5a-93e2-337b71426d8f")
-        expect(degree.uk_degree).to eq("Bachelor of Science")
-        expect(degree.uk_degree_uuid).to eq("1b6a5652-c197-e711-80d8-005056ac45bb")
+        expect(degree.uk_degree).to eq("Bachelor of Arts (Hons) with intercalated PGCE")
+        expect(degree.uk_degree_uuid).to eq("0caa1ea5-868a-47a4-9b26-4b7470528b67")
         expect(degree.non_uk_degree).to be_nil
 
         expect(degree.graduation_year).to eq(2015)

--- a/spec/requests/api/v0_1/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_degrees_spec.rb
@@ -17,7 +17,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
       {
         grade: "02",
         subject: "100425",
-        institution: "0117",
+        institution: "0084",
         uk_degree: "014",
         graduation_year: "2015-01-01",
         country: "XF",
@@ -40,7 +40,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
 
         expect(degree_attributes["grade"]).to eq("02")
         expect(degree_attributes["subject"]).to eq("100425")
-        expect(degree_attributes["institution"]).to eq("0117")
+        expect(degree_attributes["institution"]).to eq("0084")
         expect(degree_attributes["uk_degree"]).to eq("014")
         expect(degree_attributes["graduation_year"]).to eq(2015)
         expect(degree_attributes["country"]).to be_nil
@@ -56,10 +56,10 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree.grade_uuid).to eq("e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f")
         expect(degree.subject).to eq("Physics")
         expect(degree.subject_uuid).to eq("918170f0-5dce-e911-a985-000d3ab79618")
-        expect(degree.institution).to eq("University of East Anglia")
-        expect(degree.institution_uuid).to eq("1271f34a-2887-e711-80d8-005056ac45bb")
-        expect(degree.uk_degree).to eq("Bachelor of Arts (Hons) with intercalated PGCE")
-        expect(degree.uk_degree_uuid).to eq("0caa1ea5-868a-47a4-9b26-4b7470528b67")
+        expect(degree.institution).to eq("Wimbledon School of Art")
+        expect(degree.institution_uuid).to eq("c6501667-3718-43e3-9390-71bc20ccb6c7")
+        expect(degree.uk_degree).to eq("Bachelor of Science")
+        expect(degree.uk_degree_uuid).to eq("1b6a5652-c197-e711-80d8-005056ac45bb")
         expect(degree.non_uk_degree).to be_nil
 
         expect(degree.graduation_year).to eq(2015)

--- a/spec/requests/api/v1_0_pre/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_degrees_spec.rb
@@ -40,7 +40,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
 
         expect(degree_attributes["grade"]).to eq("02")
         expect(degree_attributes["subject"]).to eq("100425")
-        expect(degree_attributes["institution"]).to eq("0084")
+        expect(degree_attributes["institution"]).to eq("1166")
         expect(degree_attributes["uk_degree"]).to eq("083")
         expect(degree_attributes["graduation_year"]).to eq(2015)
         expect(degree_attributes["country"]).to be_nil
@@ -55,8 +55,8 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree.grade_uuid).to eq("e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f")
         expect(degree.subject).to eq("Physics")
         expect(degree.subject_uuid).to eq("918170f0-5dce-e911-a985-000d3ab79618")
-        expect(degree.institution).to eq("Wimbledon School of Art")
-        expect(degree.institution_uuid).to eq("c6501667-3718-43e3-9390-71bc20ccb6c7")
+        expect(degree.institution).to eq("Blackburn College")
+        expect(degree.institution_uuid).to eq("c63d87ce-7c3d-4e5a-93e2-337b71426d8f")
         expect(degree.uk_degree).to eq("Bachelor of Science")
         expect(degree.uk_degree_uuid).to eq("1b6a5652-c197-e711-80d8-005056ac45bb")
 

--- a/spec/requests/api/v1_0_pre/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_degrees_spec.rb
@@ -17,7 +17,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
       {
         grade: "02",
         subject: "100425",
-        institution: "0117",
+        institution: "0084",
         uk_degree: "014",
         graduation_year: "2015-01-01",
         country: "XF",
@@ -40,8 +40,8 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
 
         expect(degree_attributes["grade"]).to eq("02")
         expect(degree_attributes["subject"]).to eq("100425")
-        expect(degree_attributes["institution"]).to eq("0117")
-        expect(degree_attributes["uk_degree"]).to eq("014")
+        expect(degree_attributes["institution"]).to eq("0084")
+        expect(degree_attributes["uk_degree"]).to eq("083")
         expect(degree_attributes["graduation_year"]).to eq(2015)
         expect(degree_attributes["country"]).to be_nil
         expect(degree_attributes["locale_code"]).to be_nil
@@ -55,10 +55,10 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree.grade_uuid).to eq("e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f")
         expect(degree.subject).to eq("Physics")
         expect(degree.subject_uuid).to eq("918170f0-5dce-e911-a985-000d3ab79618")
-        expect(degree.institution).to eq("University of East Anglia")
-        expect(degree.institution_uuid).to eq("1271f34a-2887-e711-80d8-005056ac45bb")
-        expect(degree.uk_degree).to eq("Bachelor of Arts (Hons) with intercalated PGCE")
-        expect(degree.uk_degree_uuid).to eq("0caa1ea5-868a-47a4-9b26-4b7470528b67")
+        expect(degree.institution).to eq("Wimbledon School of Art")
+        expect(degree.institution_uuid).to eq("c6501667-3718-43e3-9390-71bc20ccb6c7")
+        expect(degree.uk_degree).to eq("Bachelor of Science")
+        expect(degree.uk_degree_uuid).to eq("1b6a5652-c197-e711-80d8-005056ac45bb")
 
         expect(degree.graduation_year).to eq(2015)
         expect(degree.country).to be_nil

--- a/spec/requests/api/v1_0_pre/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v1_0_pre/trainees/post_degrees_spec.rb
@@ -17,7 +17,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
       {
         grade: "02",
         subject: "100425",
-        institution: "0084",
+        institution: "1166",
         uk_degree: "014",
         graduation_year: "2015-01-01",
         country: "XF",
@@ -41,7 +41,7 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree_attributes["grade"]).to eq("02")
         expect(degree_attributes["subject"]).to eq("100425")
         expect(degree_attributes["institution"]).to eq("1166")
-        expect(degree_attributes["uk_degree"]).to eq("083")
+        expect(degree_attributes["uk_degree"]).to eq("014")
         expect(degree_attributes["graduation_year"]).to eq(2015)
         expect(degree_attributes["country"]).to be_nil
         expect(degree_attributes["locale_code"]).to be_nil
@@ -57,8 +57,8 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
         expect(degree.subject_uuid).to eq("918170f0-5dce-e911-a985-000d3ab79618")
         expect(degree.institution).to eq("Blackburn College")
         expect(degree.institution_uuid).to eq("c63d87ce-7c3d-4e5a-93e2-337b71426d8f")
-        expect(degree.uk_degree).to eq("Bachelor of Science")
-        expect(degree.uk_degree_uuid).to eq("1b6a5652-c197-e711-80d8-005056ac45bb")
+        expect(degree.uk_degree).to eq("Bachelor of Arts (Hons) with intercalated PGCE")
+        expect(degree.uk_degree_uuid).to eq("0caa1ea5-868a-47a4-9b26-4b7470528b67")
 
         expect(degree.graduation_year).to eq(2015)
         expect(degree.country).to be_nil

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -119,7 +119,7 @@ module Degrees
                 graduation_date: "2003-06-01",
                 degree_type: "400",
                 subject_one: "100485",
-                institution: "0045",
+                institution: "1250",
                 grade: "02",
                 country: nil,
               },

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -119,7 +119,7 @@ module Degrees
                 graduation_date: "2003-06-01",
                 degree_type: "400",
                 subject_one: "100485",
-                institution: "1250",
+                institution: "1000",
                 grade: "02",
                 country: nil,
               },


### PR DESCRIPTION
### Context

[8372-add-274-missing-institutions-for-previous-degrees](https://trello.com/c/7Xn8GyQo/8372-add-274-missing-institutions-for-previous-degrees)

Refactor specs to test DfE reference gem new degree type

https://github.com/DFE-Digital/dfe-reference-data/pull/143

### Changes proposed in this pull request

* Test for new institutions

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
