### PR TITLE
[xxxx] - Update survey sending requirement

### DIFF
--- a/app/jobs/dqt/recommend_for_award_job.rb
+++ b/app/jobs/dqt/recommend_for_award_job.rb
@@ -30,7 +30,7 @@ module Dqt
 
     def survey_should_be_scheduled?
       # Don't send survey for Assessment Only routes or EYTS awards
-      !trainee.assessment_only? && trainee.training_route_manager.award_type != EYTS_AWARD_TYPE
+      !(trainee.assessment_only? || trainee.training_route_manager.award_type == EYTS_AWARD_TYPE)
     end
   end
 end

--- a/app/jobs/dqt/recommend_for_award_job.rb
+++ b/app/jobs/dqt/recommend_for_award_job.rb
@@ -30,7 +30,7 @@ module Dqt
 
     def survey_should_be_scheduled?
       # Don't send survey for Assessment Only routes or EYTS awards
-      !(trainee.assessment_only? || trainee.training_route_manager.award_type == EYTS_AWARD_TYPE)
+      !(trainee.assessment_only? || trainee.award_type == EYTS_AWARD_TYPE)
     end
   end
 end

--- a/spec/jobs/dqt/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dqt/recommend_for_award_job_spec.rb
@@ -50,7 +50,7 @@ module Dqt
           let(:award_type) { QTS_AWARD_TYPE }
 
           it "schedules a survey with the configured delay" do
-            expect(Survey::SendJob).to receive(:set).with(wait: days_delayed.days).and_return(delayed_job)
+            allow(Survey::SendJob).to receive(:set).with(wait: days_delayed.days).and_return(delayed_job)
             described_class.perform_now(trainee)
             expect(delayed_job).to have_received(:perform_later).with(trainee: trainee, event_type: :award)
           end

--- a/spec/jobs/dqt/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dqt/recommend_for_award_job_spec.rb
@@ -45,21 +45,20 @@ module Dqt
           allow(trainee.training_route_manager).to receive(:award_type).and_return(award_type)
         end
 
-        context "when trainee is on a non-Assessment Only route and has a QTS award" do
+        context "when trainee has QTS award and is not on Assessment Only route" do
           let(:training_route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
-          let(:award_type) { "QTS" }
+          let(:award_type) { QTS_AWARD_TYPE }
 
           it "schedules a survey with the configured delay" do
-            allow(Survey::SendJob).to receive(:set).with(wait: days_delayed.days).and_return(delayed_job)
+            expect(Survey::SendJob).to receive(:set).with(wait: days_delayed.days).and_return(delayed_job)
             described_class.perform_now(trainee)
-            expect(Survey::SendJob).to have_received(:set).with(wait: days_delayed.days)
             expect(delayed_job).to have_received(:perform_later).with(trainee: trainee, event_type: :award)
           end
         end
 
         context "when trainee is on an Assessment Only route" do
           let(:training_route) { TRAINING_ROUTE_ENUMS[:assessment_only] }
-          let(:award_type) { "QTS" }
+          let(:award_type) { QTS_AWARD_TYPE }
 
           it "does not schedule a survey" do
             expect(Survey::SendJob).not_to receive(:set)
@@ -69,7 +68,7 @@ module Dqt
 
         context "when trainee has an EYTS award" do
           let(:training_route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
-          let(:award_type) { "EYTS" }
+          let(:award_type) { EYTS_AWARD_TYPE }
 
           it "does not schedule a survey" do
             expect(Survey::SendJob).not_to receive(:set)


### PR DESCRIPTION
### Context

Updates the Survey sending rule to "Don't send survey for Assessment Only routes **or** EYTS awards"

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
