### PR TITLE
[8438] Added feasibility tests for `pending_conditions`

### DIFF
--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -95,6 +95,28 @@ module Trainees
       end
     end
 
+    context "apply application status is 'pending_conditions'" do
+      let(:application_data) do
+        JSON.parse(ApiStubs::RecruitsApi.application(candidate_attributes: candidate_attributes,
+                                                     course_attributes: course_attributes.merge(recruitment_cycle_year:),
+                                                     status: "pending_conditions"))
+      end
+
+      it "creates a draft trainee" do
+        expect {
+          create_trainee_from_apply
+        }.to change(Trainee.draft, :count).by(1)
+      end
+
+      it "created trainee against the apply_application status as 'pending_conditions'" do
+        expect(trainee.apply_application.application.dig("attributes", "status")).to eq("pending_conditions")
+      end
+    end
+
+    it "created trainee against the apply_application status as 'recruited'" do
+      expect(trainee.apply_application.application.dig("attributes", "status")).to eq("recruited")
+    end
+
     it { is_expected.to have_attributes(trainee_attributes) }
 
     it "associates the created trainee against the apply_application and provider" do

--- a/spec/support/api_stubs/recruits_api.rb
+++ b/spec/support/api_stubs/recruits_api.rb
@@ -14,22 +14,23 @@ module ApiStubs
       { data: [application(id: "3774")] }.to_json
     end
 
-    def self.application(id: "3772", course_attributes: {}, candidate_attributes: {}, degree_attributes: {})
+    def self.application(id: "3772", course_attributes: {}, candidate_attributes: {}, degree_attributes: {}, status: "recruited")
       uk_application(
         id:,
         course_attributes:,
         candidate_attributes:,
         degree_attributes:,
+        status:,
       ).to_json
     end
 
-    def self.uk_application(id: "3772", course_attributes: {}, candidate_attributes: {}, degree_attributes: {})
+    def self.uk_application(id: "3772", course_attributes: {}, candidate_attributes: {}, degree_attributes: {}, status: "recruited")
       {
         id: id,
         type: "application",
         attributes: {
           support_reference: "NV6357",
-          status: "recruited",
+          status: status,
           updated_at: "2020-06-17T09:05:53+01:00",
           submitted_at: "2020-06-11T15:54:15+01:00",
           recruited_at: "2020-06-17T09:05:53.165+01:00",


### PR DESCRIPTION
### Context
Feasibility tests for `pending_conditions`
### Changes proposed in this pull request
Added a feasibility tests for `pending_conditions`
### Guidance to review
The tests just validates a trainee can be created for from apply when the status is`pending_conditions`.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
