### PR TITLE
[xxxx] Change database backup time to avoid scheduled jobs

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -24,8 +24,8 @@ on:
       db-server:
         description: |
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
-  schedule: # 03:00 UTC
-    - cron: '0 3 * * *'
+  schedule: # 03:30 UTC
+    - cron: '30 3 * * *'
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Context

Database backups [have been failing](https://github.com/DFE-Digital/register-trainee-teachers/actions/workflows/database-backup.yml). They currently run at the same time as a scheduled job.

### Changes proposed in this pull request

* Change database backup time to avoid scheduled jobs

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
