### PR TITLE
Send api_request events to BigQuery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem "mechanize" # interact with HESA
 gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v3.7.1"
 
 # for sending analytics data to the analytics platform
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.5"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.6"
 
 gem "ruby-progressbar" # useful for tracking long running rake tasks
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 53a373781df8ed73dbc8d42ffe31d40da8e284af
-  tag: v1.15.5
+  revision: 14be35cf91c1ca86a18bd87243444cb3e2d9fae2
+  tag: v1.15.6
   specs:
-    dfe-analytics (1.15.5)
+    dfe-analytics (1.15.6)
       google-cloud-bigquery (~> 1.38)
       httparty (~> 0.21)
       multi_xml (~> 0.6.0)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,6 +4,7 @@ module Api
   class BaseController < ActionController::API
     include Api::ErrorResponse
     include ApiMonitorable
+    include DfE::Analytics::ApiRequests
 
     before_action :check_feature_flag!, :authenticate!, :update_last_used_at_on_token!
 
@@ -49,6 +50,10 @@ module Api
     end
 
     def audit_user
+      current_provider
+    end
+
+    def current_user
       current_provider
     end
 

--- a/spec/requests/dfe_analytics_api_request_events_spec.rb
+++ b/spec/requests/dfe_analytics_api_request_events_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class ApiRequestTestController < Api::BaseController
+  skip_before_action :update_last_used_at_on_token!
+  def test
+    render plain: "Booyah"
+  end
+
+  def authenticate!
+    @current_provider = UserWithOrganisationContext.new(user: User.last, session: {})
+  end
+
+  attr_reader :current_provider
+end
+
+describe "sending request events" do
+  let!(:user) { create(:user) }
+  let(:headers) do
+    {
+      "HTTP_USER_AGENT" => "Toaster/1.23",
+      "HTTP_REFERER" => "https://example.com/",
+      "X-Request-Id" => "iamauuid",
+    }
+  end
+
+  before do
+    enable_features("register_api")
+
+    Rails.application.routes.draw do
+      get "/test", to: "api_request_test#test"
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  context "feature is enabled" do
+    before { enable_features("google.send_data_to_big_query") }
+
+    it "does send to big query" do
+      expect {
+        get "/test?foo=bar", headers:
+      }.to(have_sent_analytics_event_types(:api_request))
+    end
+  end
+
+  context "feature is disabled" do
+    before {
+      disable_features("google.send_data_to_big_query")
+    }
+
+    it "doesn't send to big query" do
+      expect {
+        get "/test?foo=bar", headers:
+      }.not_to(have_sent_analytics_event_types(:api_request))
+    end
+  end
+end

--- a/spec/requests/dfe_analytics_api_request_events_spec.rb
+++ b/spec/requests/dfe_analytics_api_request_events_spec.rb
@@ -9,14 +9,14 @@ class ApiRequestTestController < Api::BaseController
   end
 
   def authenticate!
-    @current_provider = UserWithOrganisationContext.new(user: User.last, session: {})
+    @current_provider = Provider.last
   end
 
   attr_reader :current_provider
 end
 
 describe "sending request events" do
-  let!(:user) { create(:user) }
+  let!(:provider) { create(:provider) }
   let(:headers) do
     {
       "HTTP_USER_AGENT" => "Toaster/1.23",


### PR DESCRIPTION
### Context

Send api request events to BigQuery

Trello ticket [here](https://trello.com/c/bbU5kOXr/2625-dfeanalytics-add-native-support-for-api-requests)

### Changes proposed in this pull request

Update DfE::Analytcsi GEM.

Include DfE::Analytics module to API Base controller to send api_request events.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
