### PR TITLE
[xxxx] - Disable productiondata deploys and restores

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -220,7 +220,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [sandbox, csv-sandbox, productiondata]
+        environment: [sandbox, csv-sandbox] # productiondata temporarily disabled
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -152,10 +152,11 @@ jobs:
     - name: Setup postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
 
-    - name: Restore backup to aks productiondata database
-      shell: bash
-      run: |
-        bin/konduit.sh -n bat-production -i ${{ env.BACKUP_FILE }} -c -t 7200 register-productiondata -- psql
+    # Temporarily disabled productiondata restore - will be restored later
+    # - name: Restore backup to aks productiondata database
+    #   shell: bash
+    #   run: |
+    #     bin/konduit.sh -n bat-production -i ${{ env.BACKUP_FILE }} -c -t 7200 register-productiondata -- psql
 
     - name: Restore backup to aks analysis database
       shell: bash


### PR DESCRIPTION
### Context

To keep data static in `productiondata`, we must disable the automatic deploys and nightly restore GitHub aciton

### Changes proposed in this pull request

Disables the aforementioned processes