### PR TITLE
[8485] Switch off CSV bulk add trainees in sandbox

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -99,7 +99,7 @@ features:
   register_api: true
   itt_reform: true
   duplicate_checking: true
-  bulk_add_trainees: true
+  bulk_add_trainees: false
   token_management: false
   show_csv_sandbox_banner: false
 

--- a/config/settings/csv-sandbox.yml
+++ b/config/settings/csv-sandbox.yml
@@ -46,6 +46,7 @@ features:
     test_mode: true
     sync_trn_data: false
   register_api: false
+  bulk_add_trainees: true
   show_csv_sandbox_banner: true
 
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -9,7 +9,6 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
-  token_management: true
   routes:
     provider_led_postgrad: true
     assessment_only: true
@@ -25,6 +24,8 @@ features:
     iqts: true
     teacher_degree_apprenticeship: true
   funding: true
+  token_management: true
+  bulk_add_trainees: true
   show_csv_sandbox_banner: true
 
 pagination:

--- a/config/settings/pen.yml
+++ b/config/settings/pen.yml
@@ -42,6 +42,7 @@ features:
   google:
     send_data_to_big_query: false
   token_management: true
+  bulk_add_trainees: true
 
 environment:
   name: pen

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -50,7 +50,6 @@ features:
   dqt_import:
     sync_teachers: true
   register_api: false
-  bulk_add_trainees: false
   duplicate_checking: true
 
 environment:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -34,6 +34,7 @@ features:
     teacher_degree_apprenticeship: true
   google:
     send_data_to_big_query: true
+  bulk_add_trainees: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -9,7 +9,6 @@ features:
   sign_in_method: persona
   enable_feedback_link: true
   publish_course_details: true
-  token_management: true
   routes:
     provider_led_postgrad: true
     assessment_only: true
@@ -28,8 +27,9 @@ features:
   funding: true
   google:
     send_data_to_big_query: true
+  token_management: true
+  bulk_add_trainees: true
   show_csv_sandbox_banner: true
-
 
 pagination:
   records_per_page: 30


### PR DESCRIPTION
### Context

We want to prevent users on the `sandbox` env from using CSV bulk add trainees at the moment.

Provider testing for this feature will be happening on the `csv-sandbox`.

### Changes proposed in this pull request

* Turn off feature on `sandbox`
* Refactor to make feature 'off' by default

### Guidance to review

* The the envs settings look right?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
