### PR TITLE
[8499] Clear disabilities if values change in a HESA/API update

### DIFF
--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -119,11 +119,6 @@ module Api
           ))
 
         build_nested_models(new_attributes)
-
-        self.trainee_disabilities_attributes = []
-        new_attributes[:disabilities]&.each do |disability|
-          trainee_disabilities_attributes << { disability_id: disability.id }
-        end
       end
 
       def build_nested_models(new_attributes)
@@ -140,6 +135,7 @@ module Api
         end
 
         new_hesa_trainee_detail_attributes = new_attributes.slice(*HesaTraineeDetailAttributes::ATTRIBUTES)
+
         if new_hesa_trainee_detail_attributes.present?
           self.hesa_trainee_detail_attributes = self.class.module_parent::HesaTraineeDetailAttributes.new(
             new_hesa_trainee_detail_attributes.merge(

--- a/app/models/api/v2025_0_rc/trainee_attributes.rb
+++ b/app/models/api/v2025_0_rc/trainee_attributes.rb
@@ -23,11 +23,18 @@ module Api
         end
 
         new_hesa_trainee_detail_attributes = new_attributes.slice(*HesaTraineeDetailAttributes::ATTRIBUTES)
+
         if new_hesa_trainee_detail_attributes.present?
           self.hesa_trainee_detail_attributes = V20250Rc::HesaTraineeDetailAttributes.new(
             new_hesa_trainee_detail_attributes.merge(trainee_attributes: self),
             record_source:,
           )
+        end
+
+        self.trainee_disabilities_attributes = []
+
+        new_attributes[:disabilities]&.each do |disability|
+          trainee_disabilities_attributes << { disability_id: disability.id }
         end
       end
 

--- a/app/services/api/v0_1/update_trainee_service.rb
+++ b/app/services/api/v0_1/update_trainee_service.rb
@@ -15,12 +15,13 @@ module Api
 
         attributes_to_save = attributes.deep_attributes.with_indifferent_access
         trainee.nationalities.destroy_all if attributes_to_save[:nationalisations_attributes].present?
-        trainee.trainee_disabilities.destroy_all if attributes_to_save[:trainee_disabilities_attributes].present?
+        trainee.clear_disabilities if attributes_to_save[:trainee_disabilities_attributes].present?
 
         if trainee_attributes_validation.invalid?
           [false, trainee_attributes_validation]
         else
           trainee.assign_attributes(attributes_to_save)
+          trainee.disabilities = [] if !trainee.disabled? && trainee.disability_disclosure_changed?
 
           if validation.all_errors.any?
             [false, validation]

--- a/app/services/concerns/has_diversity_attributes.rb
+++ b/app/services/concerns/has_diversity_attributes.rb
@@ -23,7 +23,7 @@ module HasDiversityAttributes
   end
 
   def disability_attributes
-    if disabilities.empty? || disabilities == [Diversities::NOT_PROVIDED]
+    if !disability_disclosed?
       return {
         disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided],
       }
@@ -50,7 +50,7 @@ module HasDiversityAttributes
   end
 
   def disability_disclosed?
-    disabilities.present? && (disabilities & [Diversities::NOT_PROVIDED, Diversities::NO_KNOWN_DISABILITY]).empty?
+    disabilities.any? && disabilities != [Diversities::NOT_PROVIDED]
   end
 
   def ethnicity_disclosed?

--- a/app/services/concerns/has_diversity_attributes.rb
+++ b/app/services/concerns/has_diversity_attributes.rb
@@ -23,7 +23,7 @@ module HasDiversityAttributes
   end
 
   def disability_attributes
-    if !disability_disclosed?
+    if disabilities.empty? || disabilities == [Diversities::NOT_PROVIDED]
       return {
         disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided],
       }
@@ -50,7 +50,7 @@ module HasDiversityAttributes
   end
 
   def disability_disclosed?
-    disabilities.any? && disabilities != [Diversities::NOT_PROVIDED]
+    disabilities.present? && (disabilities & [Diversities::NOT_PROVIDED, Diversities::NO_KNOWN_DISABILITY]).empty?
   end
 
   def ethnicity_disclosed?

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -43,6 +43,7 @@ module Trainees
 
       Audited.audit_class.as_user(USERNAME) do
         trainee.assign_attributes(mapped_attributes)
+        trainee.disabilities = [] if !trainee.disabled? && trainee.disability_disclosure_changed?
 
         if trainee.save!
           create_degrees!

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -940,6 +940,38 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           )
         end
       end
+
+      %w[95 98 99].each do |code|
+        let(:disability_disclosures) {
+          {
+            "95" => "no_disability",
+            "98" => "disability_not_provided",
+            "99" => "disability_not_provided",
+          }
+        }
+
+        context "when disability1 has code #{code}" do
+          let(:params) do
+            {
+              data: {
+                disability1: code,
+              }
+            }
+          end
+
+          it do
+            expect(response).to have_http_status(:success)
+
+            expect(response.parsed_body[:data][:disability_disclosure]).to eq(disability_disclosures[code])
+            expect(response.parsed_body[:data][:disability1]).to eq(code)
+
+            trainee.reload
+
+            expect(trainee.disability_disclosure).to eq(disability_disclosures[code])
+            expect(trainee.disabilities).to be_empty
+          end
+        end
+      end
     end
 
     context "with course subjects" do

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -955,7 +955,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
             {
               data: {
                 disability1: code,
-              }
+              },
             }
           end
 

--- a/spec/requests/api/v2025_0_rc/put_trainee_spec.rb
+++ b/spec/requests/api/v2025_0_rc/put_trainee_spec.rb
@@ -986,7 +986,7 @@ describe "`PUT /api/v2025.0-rc/trainees/:id` endpoint" do
             {
               data: {
                 disability1: code,
-              }
+              },
             }
           end
 

--- a/spec/requests/api/v2025_0_rc/put_trainee_spec.rb
+++ b/spec/requests/api/v2025_0_rc/put_trainee_spec.rb
@@ -971,6 +971,38 @@ describe "`PUT /api/v2025.0-rc/trainees/:id` endpoint" do
           )
         end
       end
+
+      %w[95 98 99].each do |code|
+        let(:disability_disclosures) {
+          {
+            "95" => "no_disability",
+            "98" => "disability_not_provided",
+            "99" => "disability_not_provided",
+          }
+        }
+
+        context "when disability1 has code #{code}" do
+          let(:params) do
+            {
+              data: {
+                disability1: code,
+              }
+            }
+          end
+
+          it do
+            expect(response).to have_http_status(:success)
+
+            expect(response.parsed_body[:data][:disability_disclosure]).to eq(disability_disclosures[code])
+            expect(response.parsed_body[:data][:disability1]).to eq(code)
+
+            trainee.reload
+
+            expect(trainee.disability_disclosure).to eq(disability_disclosures[code])
+            expect(trainee.disabilities).to be_empty
+          end
+        end
+      end
     end
 
     context "with course subjects" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -437,6 +437,8 @@ module Trainees
           end
 
           it "sets no disabilities on the trainee" do
+            trainee.reload
+
             expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed])
             expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
             expect(trainee.disabilities).to be_empty

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -46,10 +46,6 @@ module Trainees
       create(:lead_partner, :school, school:)
       create(:withdrawal_reason, :with_all_reasons)
       create_custom_state
-      described_class.call(
-        hesa_trainee: student_attributes,
-        record_source: record_source,
-      )
     end
 
     after do
@@ -57,6 +53,13 @@ module Trainees
     end
 
     describe "HESA information imported from XML" do
+      before do
+        described_class.call(
+          hesa_trainee: student_attributes,
+          record_source: record_source,
+        )
+      end
+
       it "updates the Trainee ID, HESA ID and record_source" do
         expect(trainee.provider_trainee_id).to eq(student_attributes[:provider_trainee_id])
         expect(trainee.hesa_id).to eq(student_attributes[:hesa_id])
@@ -99,7 +102,7 @@ module Trainees
 
       context "when lead_partner_not_applicable was previously set to true" do
         before do
-          trainee.update(lead_partner_not_applicable: true, lead_partner_id: nil)
+          trainee.update!(lead_partner_not_applicable: true, lead_partner_id: nil)
           described_class.call(hesa_trainee: student_attributes, record_source: record_source)
           trainee.reload
         end
@@ -197,6 +200,13 @@ module Trainees
         create(:trainee, hesa_id: student_attributes[:hesa_id], trn: existing_trn, record_source: Trainee::HESA_TRN_DATA_SOURCE)
       end
 
+      before do
+        described_class.call(
+          hesa_trainee: student_attributes,
+          record_source: record_source,
+        )
+      end
+
       it "updates the trainee record source to be HESA collection" do
         expect(trainee.hesa_collection_record?).to be(true)
       end
@@ -204,6 +214,13 @@ module Trainees
 
     context "when the trainee is submitted via TRN data" do
       let(:record_source) { Trainee::HESA_TRN_DATA_SOURCE }
+
+      before do
+        described_class.call(
+          hesa_trainee: student_attributes,
+          record_source: record_source,
+        )
+      end
 
       it "sets record source to HESA_TRN_DATA" do
         expect(trainee.hesa_trn_data_record?).to be(true)
@@ -226,6 +243,14 @@ module Trainees
       feature_duplicate_checking: true,
       feature_integrate_with_dqt: true,
     ) do
+
+      before do
+        described_class.call(
+          hesa_trainee: student_attributes,
+          record_source: record_source,
+        )
+      end
+
       context "when there is a potential duplicate" do
         let(:duplicate_trainee) { create(:trainee) }
         let(:duplicate_trainees) { [duplicate_trainee] }
@@ -247,6 +272,14 @@ module Trainees
       feature_duplicate_checking: false,
       feature_integrate_with_dqt: true,
     ) do
+
+      before do
+        described_class.call(
+          hesa_trainee: student_attributes,
+          record_source: record_source,
+        )
+      end
+
       context "when there is a potential duplicate" do
         let(:duplicate_trainee) { create(:trainee) }
         let(:duplicate_trainees) { [duplicate_trainee] }
@@ -266,6 +299,13 @@ module Trainees
       context "when ethnicity is missing" do
         let(:hesa_stub_attributes) { { ethnic_background: nil } }
 
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
+        end
+
         it "sets the ethnic_group and background to 'Not provided'" do
           expect(trainee.ethnic_group).to eq(Diversities::ETHNIC_GROUP_ENUMS[:not_provided])
           expect(trainee.ethnic_background).to eq(Diversities::NOT_PROVIDED)
@@ -275,6 +315,13 @@ module Trainees
       context "when ethnicity is explicitly 'not provided'" do
         let(:hesa_stub_attributes) do
           { ethnic_background: hesa_ethnicity_codes[Diversities::NOT_PROVIDED] }
+        end
+
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
         end
 
         it "sets the ethnic_group and background to 'Not provided'" do
@@ -291,6 +338,13 @@ module Trainees
           }
         end
 
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
+        end
+
         it "sets the diversity disclosure to 'diversity_not_disclosed'" do
           expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
           expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided])
@@ -305,9 +359,21 @@ module Trainees
           }
         end
 
-        it "sets the disclosures to 'not_disclosed'" do
+        before do
+          trainee.disabilities << first_disability
+
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
+        end
+
+        it "sets the disclosures to 'not_disclosed' and removes the disabilities" do
+          trainee.reload
+
           expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
           expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided])
+          expect(trainee.disabilities).to be_empty
         end
       end
 
@@ -317,6 +383,13 @@ module Trainees
             ethnic_background: hesa_ethnicity_codes[Diversities::NOT_PROVIDED],
             disability1: hesa_disability_codes[first_disability_name],
           }
+        end
+
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
         end
 
         it "correctly sets the disclosures and the disability on the trainee" do
@@ -335,6 +408,13 @@ module Trainees
           }
         end
 
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
+        end
+
         it "correctly sets the disclosures and all the disabilities on the trainee" do
           expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed])
           expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled])
@@ -350,10 +430,38 @@ module Trainees
           }
         end
 
-        it "sets no disabilities on the trainee" do
-          expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed])
-          expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
-          expect(trainee.disabilities).to be_empty
+        context "when the trainee does not have existing disabilities" do
+          before do
+            described_class.call(
+              hesa_trainee: student_attributes,
+              record_source: record_source,
+            )
+          end
+
+          it "sets no disabilities on the trainee" do
+            expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
+            expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
+            expect(trainee.disabilities).to be_empty
+          end
+        end
+
+        context "when the trainee has existing disabilities" do
+          before do
+            trainee.disabilities << first_disability
+
+            described_class.call(
+              hesa_trainee: student_attributes,
+              record_source: record_source,
+            )
+          end
+
+          it "removes the disabilities" do
+            trainee.reload
+
+            expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
+            expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
+            expect(trainee.disabilities).to be_empty
+          end
         end
       end
 
@@ -362,6 +470,13 @@ module Trainees
           {
             course_subject_one: "invalid course subject one codeset",
           }
+        end
+
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
         end
 
         it "raises an error" do
@@ -374,6 +489,13 @@ module Trainees
           {
             disability1: "disability not in codeset",
           }
+        end
+
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
         end
 
         it "raises an error" do
@@ -389,6 +511,13 @@ module Trainees
           }
         end
 
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
+        end
+
         it "sets the diversity disclosure to 'diversity_disclosed' and the correct ethnic group and background" do
           expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed])
           expect(trainee.ethnic_group).to eq(Diversities::ETHNIC_GROUP_ENUMS[:black])
@@ -402,6 +531,13 @@ module Trainees
           { bursary_level: hesa_bursary_level_codes[CodeSets::BursaryDetails::UNDERGRADUATE_BURSARY] }
         end
 
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
+        end
+
         it "uses the MapFundingFromDttpEntityId service to determine bursary information" do
           expect(trainee.applying_for_bursary).to be(true)
         end
@@ -409,9 +545,15 @@ module Trainees
 
       context "when training initiative is available and mappable" do
         let(:hesa_training_initiative_codes) { ::Hesa::CodeSets::TrainingInitiatives::MAPPING.invert }
-
         let(:hesa_stub_attributes) do
           { training_initiative: hesa_training_initiative_codes[ROUTE_INITIATIVES_ENUMS[:now_teach]] }
+        end
+
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
         end
 
         it "maps the the HESA code to the register enum" do
@@ -426,6 +568,13 @@ module Trainees
           }
         end
 
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
+        end
+
         it "maps the `application_choice_id` to `Trainee#application_choice_id`" do
           expect(trainee.application_choice_id).to eq(123456)
         end
@@ -434,6 +583,13 @@ module Trainees
       context "when bursary level indicates veteran teaching undergraduate bursary" do
         let(:hesa_stub_attributes) do
           { bursary_level: described_class::VETERAN_TEACHING_UNDERGRADUATE_BURSARY_LEVEL }
+        end
+
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
         end
 
         it "maps the trainee to the veteran teaching undergraduate bursary" do
@@ -447,6 +603,13 @@ module Trainees
             course_age_range: hesa_age_range_codes[DfE::ReferenceData::AgeRanges::SEVEN_TO_ELEVEN],
             course_subject_one: hesa_course_subject_codes[CourseSubjects::DESIGN],
           }
+        end
+
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
         end
 
         it "adds 'primary teaching' and places it in the course_subject_one column" do
@@ -464,6 +627,13 @@ module Trainees
           }
         end
 
+        before do
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source,
+          )
+        end
+
         it "moves 'primary teaching' to be the first subject" do
           expect(trainee.course_subject_one).to eq(CourseSubjects::PRIMARY_TEACHING)
           expect(trainee.course_subject_two).to eq(CourseSubjects::DESIGN)
@@ -474,6 +644,13 @@ module Trainees
     context "trainee is already awarded with conflicting data to hesa" do
       let(:create_custom_state) { create(:trainee, :awarded, itt_end_date: DateTime.new(2024, 5, 11), hesa_id: student_attributes[:hesa_id]) }
 
+      before do
+        described_class.call(
+          hesa_trainee: student_attributes,
+          record_source: record_source,
+        )
+      end
+
       it "does not update the trainee" do
         expect(trainee.itt_end_date).to eq(DateTime.new(2024, 5, 11))
       end
@@ -481,12 +658,17 @@ module Trainees
 
     context "when the trainee's itt start date has changed by more than 30 days" do
       before do
-        trainee.update(itt_start_date: DateTime.new(2023, 9, 20))
+        described_class.call(
+          hesa_trainee: student_attributes,
+          record_source: record_source,
+        )
+
+        trainee.update!(itt_start_date: DateTime.new(2023, 9, 20))
       end
 
       context "when the trainee is withdrawn" do
         before do
-          trainee.update(state: :withdrawn)
+          trainee.update!(state: :withdrawn)
         end
 
         it "creates a new record" do
@@ -498,7 +680,7 @@ module Trainees
 
       context "when the trainee is awarded" do
         before do
-          trainee.update(state: :awarded)
+          trainee.update!(state: :awarded)
         end
 
         it "creates a new record" do
@@ -518,9 +700,16 @@ module Trainees
     end
 
     context "when the trainee's itt start date has not changed by more than 30 days" do
+      before do
+        described_class.call(
+          hesa_trainee: student_attributes,
+          record_source: record_source,
+        )
+      end
+
       context "when the trainee is withdrawn" do
         before do
-          trainee.update(state: :withdrawn)
+          trainee.update!(state: :withdrawn)
         end
 
         it "does not create a new record" do
@@ -538,7 +727,7 @@ module Trainees
 
       context "when the trainee is awarded" do
         before do
-          trainee.update(state: :awarded)
+          trainee.update!(state: :awarded)
         end
 
         it "does not create a new record" do
@@ -556,9 +745,12 @@ module Trainees
 
       context "when the trainee is neither awarded nor withdrawn" do
         before do
-          trainee.update(state: :draft)
+          trainee.update!(state: :draft)
 
-          described_class.call(hesa_trainee: student_attributes, record_source: record_source)
+          described_class.call(
+            hesa_trainee: student_attributes,
+            record_source: record_source
+          )
         end
 
         it "updates the existing trainee" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -243,7 +243,6 @@ module Trainees
       feature_duplicate_checking: true,
       feature_integrate_with_dqt: true,
     ) do
-
       before do
         described_class.call(
           hesa_trainee: student_attributes,
@@ -272,7 +271,6 @@ module Trainees
       feature_duplicate_checking: false,
       feature_integrate_with_dqt: true,
     ) do
-
       before do
         described_class.call(
           hesa_trainee: student_attributes,
@@ -749,7 +747,7 @@ module Trainees
 
           described_class.call(
             hesa_trainee: student_attributes,
-            record_source: record_source
+            record_source: record_source,
           )
         end
 

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -439,7 +439,7 @@ module Trainees
           end
 
           it "sets no disabilities on the trainee" do
-            expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
+            expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed])
             expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
             expect(trainee.disabilities).to be_empty
           end
@@ -458,7 +458,7 @@ module Trainees
           it "removes the disabilities" do
             trainee.reload
 
-            expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
+            expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed])
             expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
             expect(trainee.disabilities).to be_empty
           end


### PR DESCRIPTION
### Context

[8499-clear-disabilities-if-values-change-in-a-hesa-api-update](https://trello.com/c/dP5mYZGr/8499-clear-disabilities-if-values-change-in-a-hesa-api-update)

### Changes proposed in this pull request

* Refactor Api/V01/UpdateTraineeService disabilities
* Refactor Trainees::CreateFromHesa disabilities

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
