### PR TITLE
[8511] Switch on CSV bulk add trainees in sandbox for vendors

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -41,6 +41,7 @@ features:
   register_api: true
   google:
     send_data_to_big_query: false
+  bulk_add_trainees: true
 
 environment:
   name: sandbox


### PR DESCRIPTION
### Context

We want to allow vendors in the `sandbox` env to use CSV bulk add trainees now that it's available for providers in `csv-sandbox`.

### Changes proposed in this pull request

* Turn on feature in `sandbox`

### Guidance to review


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
