### PR TITLE
[8492] - adds logging to some TRS services

### DIFF
--- a/app/lib/trs/client.rb
+++ b/app/lib/trs/client.rb
@@ -26,6 +26,7 @@ module Trs
 
     def self.put(...)
       response = Request.put(...)
+      Rails.logger.info("TRS PUT response:\nstatus: #{response.code}\nbody: #{response.body}\nheaders: #{response.headers}")
 
       handle_response(response: response, statuses: PUT_SUCCESSES)
     end

--- a/app/services/trs/update_professional_status.rb
+++ b/app/services/trs/update_professional_status.rb
@@ -14,6 +14,8 @@ module Trs
     def call
       return unless FeatureService.enabled?(:integrate_with_trs)
 
+      Rails.logger.info("Updating professional status for trainee #{trainee.id} with TRN #{trainee.trn}\nPayload:\n#{payload.to_json}")
+
       if trainee.trn.blank?
         raise_professional_status_update_missing_trn_message
       end


### PR DESCRIPTION
### Context

owing to an update to a trainee withdrawal not showing up, but changing when manually calling `UpdateProfessionalStatus`, some extra logging around this service has been added to help with debugging any further issues

### Changes proposed in this pull request
Adds logging to `UpdateProfessionalStatus` and the `put` TRS client

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
