### PR TITLE
Fix delete-review-app for dependencies

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -21,7 +21,7 @@ jobs:
     if: >
       github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy') ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'deploy') || (github.event_name ==
-      'workflow_dispatch')
+      'workflow_dispatch') || contains(github.event.pull_request.labels.*.name, 'dependencies')
 
     environment: review
     permissions:


### PR DESCRIPTION
### Context

Delete review app is not running for dependabot PR's raised for dependencies

### Changes proposed in this pull request

Add back if statement from previous update

### Guidance to review

Check delete-review-app runs on dependencies after merge

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
