### PR TITLE
[8492] - Update professional status retrieving TRN via admin console

### DIFF
--- a/app/controllers/system_admin/pending_trns/retrieve_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns/retrieve_trns_controller.rb
@@ -11,6 +11,7 @@ module SystemAdmin
         if trn
           trainee.trn_received!(trn)
           trn_request.received!
+          Trs::UpdateProfessionalStatusJob.set(wait: 30.seconds).perform_later(trainee) if FeatureService.enabled?(:integrate_with_trs)
           redirect_to(pending_trns_path, flash: { success: "TRN successfully retrieved for #{trainee_name(trainee)}" })
         else
           redirect_to(pending_trns_path, flash: { warning: "TRN still not available for #{trainee_name(trainee)}" })

--- a/spec/controllers/system_admin/pending_trns/retrieve_trns_controller_spec.rb
+++ b/spec/controllers/system_admin/pending_trns/retrieve_trns_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SystemAdmin::PendingTrns::RetrieveTrnsController do
         allow(Trs::RetrieveTrn).to receive(:call).with(trn_request:).and_return(trn)
         expect(trainee).to receive(:trn_received!).with(trn)
         expect(trn_request).to receive(:received!)
-        
+
         Timecop.freeze do
           expect {
             patch :update, params: { id: trainee.slug }


### PR DESCRIPTION
### Context

Currently calling "Retrieve TRN" via the admin only writes the trn to the trainee. We need to then make a call to TRS with the new training status

### Changes proposed in this pull request

Queues up `Trs::UpdateProfessionalStatusJob` when a successful TRN retrieval has occurred.
