### PR TITLE
[8515] Update complex error messages used by API only

### DIFF
--- a/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
+++ b/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
@@ -40,7 +40,7 @@ module Api
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
 
-      validates(:itt_qualification_aim, presence: true, if: -> { itt_aim == ITT_AIM_REQUIRED_CODE || itt_aim.blank? })
+      validates(:itt_qualification_aim, presence: true, if: -> { itt_aim.to_i == ITT_AIM_REQUIRED_CODE || itt_aim.blank? })
 
       validates(:itt_aim, inclusion: { in: Hesa::CodeSets::IttAims::MAPPING.keys }, allow_blank: true)
       validates(:itt_qualification_aim, inclusion: { in: Hesa::CodeSets::IttQualificationAims::MAPPING.keys }, allow_blank: true)

--- a/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
+++ b/app/models/api/v0_1/hesa_trainee_detail_attributes.rb
@@ -40,7 +40,7 @@ module Api
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
 
-      validates(:itt_qualification_aim, presence: true, if: -> { itt_aim.to_i == ITT_AIM_REQUIRED_CODE || itt_aim.blank? })
+      validates(:itt_qualification_aim, presence: true, if: -> { itt_aim == ITT_AIM_REQUIRED_CODE || itt_aim.blank? })
 
       validates(:itt_aim, inclusion: { in: Hesa::CodeSets::IttAims::MAPPING.keys }, allow_blank: true)
       validates(:itt_qualification_aim, inclusion: { in: Hesa::CodeSets::IttQualificationAims::MAPPING.keys }, allow_blank: true)

--- a/app/models/api/v0_1/withdrawal_attributes.rb
+++ b/app/models/api/v0_1/withdrawal_attributes.rb
@@ -32,11 +32,15 @@ module Api
 
       def initialize(trainee:)
         @trainee = trainee
+
         super
       end
 
       def attributes_to_save
-        attributes.symbolize_keys.except(:reasons).merge(withdrawal_reasons:)
+        attributes
+          .symbolize_keys
+          .except(:record_source, :reasons)
+          .merge(withdrawal_reasons:)
       end
 
     private

--- a/app/models/api/v2025_0_rc/withdrawal_attributes.rb
+++ b/app/models/api/v2025_0_rc/withdrawal_attributes.rb
@@ -3,6 +3,9 @@
 module Api
   module V20250Rc
     class WithdrawalAttributes < Api::V01::WithdrawalAttributes
+      include Api::ErrorAttributeAdapter
+
+      attribute :record_source, default: -> { Trainee::API_SOURCE }
     end
   end
 end

--- a/app/services/api/trainees/award_recommendation_service.rb
+++ b/app/services/api/trainees/award_recommendation_service.rb
@@ -7,7 +7,10 @@ module Api
       include ActiveModel::Attributes
       include ServicePattern
 
+      include Api::ErrorAttributeAdapter
+
       attribute :qts_standards_met_date
+      attribute :record_source, default: -> { Trainee::API_SOURCE }
 
       attr_reader :trainee
 
@@ -39,10 +42,14 @@ module Api
       end
 
       def trainee_degree_missing?
-        trainee.degrees.blank?
+        degrees.blank?
       end
 
     private
+
+      delegate :state, :degrees, to: :trainee
+
+      alias_method :degree_id, :degrees
 
       def trainee_attributes
         {

--- a/app/services/api/trainees/deferral_service.rb
+++ b/app/services/api/trainees/deferral_service.rb
@@ -7,6 +7,10 @@ module Api
       include ActiveModel::Attributes
       include ServicePattern
 
+      include ErrorAttributeAdapter
+
+      attribute :record_source, default: -> { Trainee::API_SOURCE }
+
       attribute :defer_date
       attribute :defer_reason
 
@@ -39,6 +43,8 @@ module Api
       end
 
     private
+
+      delegate :state, to: :trainee
 
       def trainee_attributes
         {}.tap do |hash|

--- a/app/validators/api/trainees/award_recommendation_validator.rb
+++ b/app/validators/api/trainees/award_recommendation_validator.rb
@@ -4,8 +4,6 @@ module Api
   module Trainees
     class AwardRecommendationValidator < ActiveModel::Validator
       def validate(record)
-        return unless record.errors.empty?
-
         record.errors.add(:degree_id) if record.trainee_requires_degree? && record.trainee_degree_missing?
         record.errors.add(:state) unless record.trainee_can_recommend_for_award?
       end

--- a/app/validators/api/trainees/award_recommendation_validator.rb
+++ b/app/validators/api/trainees/award_recommendation_validator.rb
@@ -6,8 +6,8 @@ module Api
       def validate(record)
         return unless record.errors.empty?
 
-        record.errors.add(:trainee, :degrees) if record.trainee_requires_degree? && record.trainee_degree_missing?
-        record.errors.add(:trainee, :state) unless record.trainee_can_recommend_for_award?
+        record.errors.add(:degree_id) if record.trainee_requires_degree? && record.trainee_degree_missing?
+        record.errors.add(:state) unless record.trainee_can_recommend_for_award?
       end
     end
   end

--- a/app/validators/api/trainees/deferral_validator.rb
+++ b/app/validators/api/trainees/deferral_validator.rb
@@ -6,7 +6,7 @@ module Api
       def validate(record)
         return unless record.errors.empty?
 
-        record.errors.add(:trainee, :state) unless record.trainee_can_defer?
+        record.errors.add(:state) unless record.trainee_can_defer?
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2175,8 +2175,6 @@ en:
               invalid: must be completed before qts_standards_met_date
             state:
               invalid: must be selected as trn_received
-            trainee:
-              submission_ready: submission ready is invalid must be true
             qts_standards_met_date:
               itt_start_date: &qts_itt_start_date must be after itt_start_date
         api/trainees/deferral_service:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2105,6 +2105,12 @@ en:
                 blank: uk_degree or non_uk_degree must be entered if specifying a postgraduate training_route
               csv:
                 blank: UK degree type or Non-UK degree type must be entered if specifying a postgraduate Training Route
+        api/v20250_rc/withdrawal_attributes:
+          attributes:
+            withdraw_date:
+              not_before_itt_start_date: must be after itt_start_date
+            reasons:
+              invalid: entered not valid for selected trigger eg unacceptable_behaviour for a trainee trigger
         api/v20250_rc/hesa_trainee_detail_attributes:
           attributes:
             itt_qualification_aim:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2171,12 +2171,14 @@ en:
           duplicate: This trainee is already in Register
         api/trainees/award_recommendation_service:
           attributes:
+            degree_id:
+              invalid: must be completed before qts_standards_met_date
+            state:
+              invalid: must be selected as trn_received
             trainee:
-              state: state is invalid must be [trn_received]
               submission_ready: submission ready is invalid must be true
-              degrees: degree information must be completed before QTS recommendation
             qts_standards_met_date:
-              itt_start_date: &qts_itt_start_date must not be before the ITT start date
+              itt_start_date: &qts_itt_start_date must be after itt_start_date
         api/trainees/deferral_service:
           attributes:
             trainee:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2181,8 +2181,8 @@ en:
               itt_start_date: &qts_itt_start_date must be after itt_start_date
         api/trainees/deferral_service:
           attributes:
-            trainee:
-              state: state is invalid must be one of [submitted_for_trn, trn_received]
+            state:
+              invalid: is invalid must be one of [submitted_for_trn, trn_received]
             defer_date:
               itt_start_date: *qts_itt_start_date
   page_headings:

--- a/spec/requests/api/v0_1/trainees/post_deferral_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_deferral_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe "POST /trainees/{trainee_id}/defer" do
       expect(response.parsed_body[:errors]).to contain_exactly(
         {
           "error" => "UnprocessableEntity",
-          "message" => "Defer date can't be blank",
+          "message" => "defer_date can't be blank",
         },
         {
           "error" => "UnprocessableEntity",
-          "message" => "Defer reason is too long (maximum is 500 characters)",
+          "message" => "defer_reason is too long (maximum is 500 characters)",
         },
       )
 

--- a/spec/requests/api/v0_1/trainees/post_recommend_for_qts_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_recommend_for_qts_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "POST /api/v0.1/trainees/:trainee_id/recommend-for-qts" do
 
         expect(response.parsed_body[:errors]).to contain_exactly(
           "error" => "UnprocessableEntity",
-          "message" => "Trainee degree information must be completed before QTS recommendation",
+          "message" => "degree_id must be completed before qts_standards_met_date",
         )
       end
     end
@@ -88,7 +88,7 @@ RSpec.describe "POST /api/v0.1/trainees/:trainee_id/recommend-for-qts" do
 
       expect(response.parsed_body[:errors]).to contain_exactly(
         "error" => "UnprocessableEntity",
-        "message" => "QTS standards met date can't be blank",
+        "message" => "qts_standards_met_date can't be blank",
       )
     end
   end

--- a/spec/requests/api/v2025_0_rc/trainees/post_deferral_spec.rb
+++ b/spec/requests/api/v2025_0_rc/trainees/post_deferral_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "POST /trainees/{trainee_id}/defer" do
       expect(response.parsed_body[:errors]).to contain_exactly(
         {
           "error" => "UnprocessableEntity",
-          "message" => "Defer date can't be blank",
+          "message" => "defer_date can't be blank",
         },
       )
 

--- a/spec/requests/api/v2025_0_rc/trainees/post_recommend_for_qts_spec.rb
+++ b/spec/requests/api/v2025_0_rc/trainees/post_recommend_for_qts_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "POST /api/v2025.0-rc/trainees/:trainee_id/recommend-for-qts" do
 
         expect(response.parsed_body[:errors]).to contain_exactly(
           "error" => "UnprocessableEntity",
-          "message" => "Trainee degree information must be completed before QTS recommendation",
+          "message" => "degree_id must be completed before qts_standards_met_date",
         )
       end
     end
@@ -87,7 +87,7 @@ RSpec.describe "POST /api/v2025.0-rc/trainees/:trainee_id/recommend-for-qts" do
 
       expect(response.parsed_body[:errors]).to contain_exactly(
         "error" => "UnprocessableEntity",
-        "message" => "QTS standards met date can't be blank",
+        "message" => "qts_standards_met_date can't be blank",
       )
     end
   end

--- a/spec/requests/api/v2025_0_rc/trainees/post_withdraw_spec.rb
+++ b/spec/requests/api/v2025_0_rc/trainees/post_withdraw_spec.rb
@@ -91,7 +91,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
             super().deep_merge(
               data: {
                 withdraw_date: nil,
-              }
+              },
             )
           end
 
@@ -106,7 +106,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
 
             expect(response.parsed_body[:errors]).to contain_exactly(
               { error: "UnprocessableEntity", message: "withdraw_date Choose a withdrawal date" },
-           )
+            )
           end
 
           it "did not change the trainee" do

--- a/spec/services/api/trainees/award_recommendation_service_spec.rb
+++ b/spec/services/api/trainees/award_recommendation_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("QTS standards met date can't be blank")
+          expect(errors.full_messages).to contain_exactly("qts_standards_met_date can't be blank")
           expect(trainee.recommended_for_award?).to be(false)
         end
       end
@@ -71,7 +71,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("QTS standards met date can't be blank")
+          expect(errors.full_messages).to contain_exactly("qts_standards_met_date can't be blank")
           expect(trainee.recommended_for_award?).to be(false)
         end
       end
@@ -88,7 +88,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("QTS standards met date is invalid")
+          expect(errors.full_messages).to contain_exactly("qts_standards_met_date is invalid")
           expect(trainee.recommended_for_award?).to be(false)
         end
       end
@@ -105,7 +105,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("QTS standards met date must not be in the future")
+          expect(errors.full_messages).to contain_exactly("qts_standards_met_date must not be in the future")
           expect(trainee.recommended_for_award?).to be(false)
         end
       end
@@ -122,7 +122,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("QTS standards met date must not be before the ITT start date")
+          expect(errors.full_messages).to contain_exactly("qts_standards_met_date must be after itt_start_date")
           expect(trainee.recommended_for_award?).to be(false)
         end
       end
@@ -139,7 +139,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("Trainee state is invalid must be [trn_received]")
+          expect(errors.full_messages).to contain_exactly("state must be selected as trn_received")
           expect(trainee.recommended_for_award?).to be(false)
         end
       end
@@ -182,7 +182,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("Trainee degree information must be completed before QTS recommendation")
+          expect(errors.full_messages).to contain_exactly("degree_id must be completed before qts_standards_met_date")
           expect(trainee.recommended_for_award?).to be(false)
         end
       end

--- a/spec/services/api/trainees/deferral_service_spec.rb
+++ b/spec/services/api/trainees/deferral_service_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Api::Trainees::DeferralService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("Defer date can't be blank")
+          expect(errors.full_messages).to contain_exactly("defer_date can't be blank")
           expect(trainee.deferred?).to be(false)
         end
       end
@@ -82,7 +82,7 @@ RSpec.describe Api::Trainees::DeferralService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("Defer date can't be blank")
+          expect(errors.full_messages).to contain_exactly("defer_date can't be blank")
           expect(trainee.deferred?).to be(false)
         end
       end
@@ -98,7 +98,7 @@ RSpec.describe Api::Trainees::DeferralService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("Defer date is invalid")
+          expect(errors.full_messages).to contain_exactly("defer_date is invalid")
           expect(trainee.deferred?).to be(false)
         end
       end
@@ -115,7 +115,7 @@ RSpec.describe Api::Trainees::DeferralService do
           success, errors = subject.call(params, trainee)
 
           expect(success).to be(false)
-          expect(errors.full_messages).to contain_exactly("Defer reason is too long (maximum is 500 characters)")
+          expect(errors.full_messages).to contain_exactly("defer_reason is too long (maximum is 500 characters)")
           expect(trainee.deferred?).to be(false)
         end
       end
@@ -139,7 +139,7 @@ RSpec.describe Api::Trainees::DeferralService do
         success, errors = subject.call(params, trainee)
 
         expect(success).to be(false)
-        expect(errors.full_messages).to contain_exactly("Trainee state is invalid must be one of [submitted_for_trn, trn_received]")
+        expect(errors.full_messages).to contain_exactly("state is invalid must be one of [submitted_for_trn, trn_received]")
         expect(trainee.deferred?).to be(false)
       end
     end

--- a/spec/services/api/trainees/withdraw_response_spec.rb
+++ b/spec/services/api/trainees/withdraw_response_spec.rb
@@ -54,11 +54,12 @@ describe Api::Trainees::WithdrawResponse do
 
       it "returns status unprocessable entity with error response" do
         expect(subject[:status]).to be(:unprocessable_entity)
+
         expect(subject[:json][:errors]).to contain_exactly(
-          { error: "UnprocessableEntity", message: "Withdraw date Choose a withdrawal date" },
-          { error: "UnprocessableEntity", message: "Reasons Reason(s) selected are not valid for this trigger" },
-          { error: "UnprocessableEntity", message: "Future interest is not included in the list" },
-          { error: "UnprocessableEntity", message: "Trigger is not included in the list" },
+          { error: "UnprocessableEntity", message: "withdraw_date Choose a withdrawal date" },
+          { error: "UnprocessableEntity", message: "reasons entered not valid for selected trigger eg unacceptable_behaviour for a trainee trigger" },
+          { error: "UnprocessableEntity", message: "trigger is not included in the list" },
+          { error: "UnprocessableEntity", message: "future_interest is not included in the list" },
         )
       end
 
@@ -74,7 +75,7 @@ describe Api::Trainees::WithdrawResponse do
         it "returns status unprocessable entity with error response" do
           expect(subject[:status]).to be(:unprocessable_entity)
           expect(subject[:json][:errors]).to include(
-            { error: "UnprocessableEntity", message: "Another reason Enter another reason" },
+            { error: "UnprocessableEntity", message: "another_reason Enter another reason" },
           )
         end
       end


### PR DESCRIPTION
### Context

[8515-update-complex-error-messages-used-by-api-only](https://trello.com/c/JcGCFAp1/8515-update-complex-error-messages-used-by-api-only)

### Changes proposed in this pull request

* Add custom error messages for withdrawals
* Add custom error messages for award recommendations
* Add custom error messages for deferrals
* Remove `trainee.submission_ready` translation key

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
