### PR TITLE
[xxxx] Fix failing specs on Faker unique numbers limit

### DIFF
--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     ukprn { Faker::Number.number(digits: 8) }
 
     after(:build) do |provider|
-      provider.accreditation_id ||= "#{provider.name.include?('University') ? 1 : 5}#{Faker::Number.unique.number(digits: 4)}"
+      provider.accreditation_id ||= "#{provider.name.include?('University') ? 1 : 5}#{Faker::Number.unique.number(digits: 3)}"
     end
 
     after(:create) do |provider|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec::Matchers.define_negated_matcher :not_change, :change
 RSpec.configure do |config|
   config.before do
     RedisClient.current.flushdb
+    Faker::Number.unique.clear
   end
 
   config.include RSpec::Benchmark::Matchers


### PR DESCRIPTION
### Context

Code coverage test runs are failing on `Faker::UniqueGenerator::RetryLimitExceeded` due to the numbers generated by the Provider factory.

### Changes proposed in this pull request

* Reset the `Faker::Number.unique` before each test (https://github.com/faker-ruby/faker?tab=readme-ov-file#ensuring-unique-values)
* Also tweak the `accreditation_id` to be 4 digits to match the real ones

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
