### PR TITLE
[8558] - adds TRS jobs to dead jobs retrieval list

### DIFF
--- a/app/services/dead_jobs/dqt_recommend_for_award.rb
+++ b/app/services/dead_jobs/dqt_recommend_for_award.rb
@@ -4,7 +4,7 @@ module DeadJobs
   class DqtRecommendForAward < Base
   private
 
-    # full class name to look for in Sidekiq dead jobs
+    # Full class name to look for in Sidekiq dead jobs
     def klass
       "Dqt::RecommendForAwardJob"
     end

--- a/app/services/dead_jobs/dqt_update_trainee.rb
+++ b/app/services/dead_jobs/dqt_update_trainee.rb
@@ -12,7 +12,7 @@ module DeadJobs
       flatten_hash(Dqt::Params::Update.new(trainee:).params.compact)
     end
 
-    # full class name to look for in Sidekiq dead jobs
+    # Full class name to look for in Sidekiq dead jobs
     def klass
       "Dqt::UpdateTraineeJob"
     end

--- a/app/services/dead_jobs/dqt_withdraw_trainee.rb
+++ b/app/services/dead_jobs/dqt_withdraw_trainee.rb
@@ -4,7 +4,7 @@ module DeadJobs
   class DqtWithdrawTrainee < Base
   private
 
-    # full class name to look for in Sidekiq dead jobs
+    # Full class name to look for in Sidekiq dead jobs
     def klass
       "Dqt::WithdrawTraineeJob"
     end

--- a/app/services/dead_jobs/trs_register_for_trn.rb
+++ b/app/services/dead_jobs/trs_register_for_trn.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DeadJobs
+  class TrsRegisterForTrn < Base
+  private
+
+    # full class name to look for in Sidekiq dead jobs
+    def klass
+      "Trs::RegisterForTrnJob"
+    end
+  end
+end

--- a/app/services/dead_jobs/trs_register_for_trn.rb
+++ b/app/services/dead_jobs/trs_register_for_trn.rb
@@ -4,7 +4,7 @@ module DeadJobs
   class TrsRegisterForTrn < Base
   private
 
-    # full class name to look for in Sidekiq dead jobs
+    # Full class name to look for in Sidekiq dead jobs
     def klass
       "Trs::RegisterForTrnJob"
     end

--- a/app/services/dead_jobs/trs_retrieve_trn.rb
+++ b/app/services/dead_jobs/trs_retrieve_trn.rb
@@ -4,7 +4,7 @@ module DeadJobs
   class TrsRetrieveTrn < Base
   private
 
-    # full class name to look for in Sidekiq dead jobs
+    # Full class name to look for in Sidekiq dead jobs
     def klass
       "Trs::RetrieveTrnJob"
     end

--- a/app/services/dead_jobs/trs_retrieve_trn.rb
+++ b/app/services/dead_jobs/trs_retrieve_trn.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DeadJobs
+  class TrsRetrieveTrn < Base
+  private
+
+    # full class name to look for in Sidekiq dead jobs
+    def klass
+      "Trs::RetrieveTrnJob"
+    end
+  end
+end

--- a/app/services/dead_jobs/trs_update_professional_status.rb
+++ b/app/services/dead_jobs/trs_update_professional_status.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DeadJobs
+  class TrsUpdateProfessionalStatus < Base
+  private
+
+    # full class name to look for in Sidekiq dead jobs
+    def klass
+      "Trs::UpdateProfessionalStatusJob"
+    end
+  end
+end

--- a/app/services/dead_jobs/trs_update_professional_status.rb
+++ b/app/services/dead_jobs/trs_update_professional_status.rb
@@ -4,7 +4,7 @@ module DeadJobs
   class TrsUpdateProfessionalStatus < Base
   private
 
-    # full class name to look for in Sidekiq dead jobs
+    # Full class name to look for in Sidekiq dead jobs
     def klass
       "Trs::UpdateProfessionalStatusJob"
     end

--- a/app/services/dead_jobs/trs_update_trainee.rb
+++ b/app/services/dead_jobs/trs_update_trainee.rb
@@ -4,7 +4,7 @@ module DeadJobs
   class TrsUpdateTrainee < Base
   private
 
-    # full class name to look for in Sidekiq dead jobs
+    # Full class name to look for in Sidekiq dead jobs
     def klass
       "Trs::UpdateTraineeJob"
     end

--- a/spec/services/dead_jobs/trs_register_for_trn_spec.rb
+++ b/spec/services/dead_jobs/trs_register_for_trn_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeadJobs::TrsRegisterForTrn do
+  it_behaves_like "Dead jobs", Trs::RegisterForTrnJob, "TRS Register For Trn"
+end

--- a/spec/services/dead_jobs/trs_retrieve_trn_spec.rb
+++ b/spec/services/dead_jobs/trs_retrieve_trn_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeadJobs::TrsRetrieveTrn do
+  it_behaves_like "Dead jobs", Trs::RetrieveTrnJob, "TRS Retrieve Trn"
+end

--- a/spec/services/dead_jobs/trs_update_professional_status_spec.rb
+++ b/spec/services/dead_jobs/trs_update_professional_status_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeadJobs::TrsUpdateProfessionalStatus do
+  it_behaves_like "Dead jobs", Trs::UpdateProfessionalStatusJob, "TRS Update Professional Status"
+end


### PR DESCRIPTION
### Context

Dead Jobs currently only expose DQT failures. We need to list any dead jobs resulting from failed TRS.

[Trello Ticket](https://trello.com/c/FBajrj7R/8558-trs-dead-jobs)

### Changes proposed in this pull request

Adds definitions for the TRS jobs to dead jobs
Excludes `UpdateTraineeJob` failures as these weren't useful for the TRS team.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
