### PR TITLE
Skip smoke tests for prod DSI envs

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -153,6 +153,7 @@ runs:
         bin/konduit.sh -n ${{ env.namespace }} -r REDIS_QUEUE_URL register-${{ env.app_environment }} -- redis-cli del queues
 
     - name: Run Smoke Tests for ${{ inputs.environment }}
+      if: ${{ !contains(fromJSON('["sandbox", "csv-sandbox", "productiondata", "production"]'), inputs.environment) }}
       uses: ./.github/actions/smoke-test/
       with:
         environment: ${{ inputs.environment }}


### PR DESCRIPTION
### Context

Our smoke testing account has had MFA set as a requirement for production DSI. Our smoke tests are now failing for Register envs which use production DSI.

Whilst pre-prod DSI accounts are exempted from MFA, there’s no such exemption for the production DSI.

### Changes proposed in this pull request

* Temporarily skip smoke tests for envs which use production DSI until [this ticket is done](https://trello.com/c/Ywq6MxGQ/2278-spike-migrating-to-mailosaur-for-production-smoke-tests)

### Guidance to review

* Are all the right envs covered?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
