### PR TITLE
[8523] Restrict API token management to HEI providers

### DIFF
--- a/app/controllers/authentication_tokens/revokes_controller.rb
+++ b/app/controllers/authentication_tokens/revokes_controller.rb
@@ -17,7 +17,7 @@ module AuthenticationTokens
   private
 
     def token
-      @token ||= policy_scope(AuthenticationToken).find(params[:authentication_token_id])
+      @token ||= AuthenticationToken.find(params[:authentication_token_id])
     end
   end
 end

--- a/app/controllers/authentication_tokens_controller.rb
+++ b/app/controllers/authentication_tokens_controller.rb
@@ -13,6 +13,10 @@ class AuthenticationTokensController < ApplicationController
     authorize(tokens)
   end
 
+  def show
+    authorize(AuthenticationToken.find(params[:id]))
+  end
+
   def new
     authorize(AuthenticationToken)
 

--- a/app/lib/user_with_organisation_context.rb
+++ b/app/lib/user_with_organisation_context.rb
@@ -71,6 +71,10 @@ class UserWithOrganisationContext < SimpleDelegator
     provider? && organisation.hei?
   end
 
+  def accredited_hei_provider?
+    accredited_provider? && organisation.hei?
+  end
+
 private
 
   attr_reader :session

--- a/app/policies/authentication_token_policy.rb
+++ b/app/policies/authentication_token_policy.rb
@@ -11,7 +11,7 @@ class AuthenticationTokenPolicy
     end
 
     def resolve
-      return scope.none unless user.hei_provider?
+      return scope.none unless user.accredited_hei_provider?
 
       scope.where(provider_id: user.organisation.id)
     end
@@ -26,22 +26,22 @@ class AuthenticationTokenPolicy
   end
 
   def index?
-    user.hei_provider?
+    user.accredited_hei_provider?
   end
 
   def new?
-    user.hei_provider?
+    user.accredited_hei_provider?
   end
 
   def create?
-    user.hei_provider?
+    user.accredited_hei_provider?
   end
 
   def show?
-    user.hei_provider? && token.can_revoke?
+    user.accredited_hei_provider? && token.can_revoke?
   end
 
   def update?
-    user.hei_provider? && token.can_revoke?
+    user.accredited_hei_provider? && token.can_revoke?
   end
 end

--- a/app/policies/authentication_token_policy.rb
+++ b/app/policies/authentication_token_policy.rb
@@ -11,7 +11,7 @@ class AuthenticationTokenPolicy
     end
 
     def resolve
-      return scope.none unless user.provider?
+      return scope.none unless user.hei_provider?
 
       scope.where(provider_id: user.organisation.id)
     end
@@ -26,22 +26,22 @@ class AuthenticationTokenPolicy
   end
 
   def index?
-    user.provider?
+    user.hei_provider?
   end
 
   def new?
-    user.provider?
+    user.hei_provider?
   end
 
   def create?
-    user.provider?
+    user.hei_provider?
   end
 
   def show?
-    user.provider? && token.can_revoke?
+    user.hei_provider? && token.can_revoke?
   end
 
   def update?
-    user.provider? && token.can_revoke?
+    user.hei_provider? && token.can_revoke?
   end
 end

--- a/app/policies/bulk_update/imports/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/imports/trainee_upload_policy.rb
@@ -4,7 +4,7 @@ module BulkUpdate
   module Imports
     class TraineeUploadPolicy < TraineeUploads::BasePolicy
       def create?
-        user.hei_provider? && trainee_upload.uploaded?
+        user.accredited_hei_provider? && trainee_upload.uploaded?
       end
     end
   end

--- a/app/policies/bulk_update/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/trainee_upload_policy.rb
@@ -3,7 +3,7 @@
 module BulkUpdate
   class TraineeUploadPolicy < TraineeUploads::BasePolicy
     def new?
-      user.hei_provider?
+      user.accredited_hei_provider?
     end
 
     def create?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
       providers { [build(:provider, :hei)] }
     end
 
+    trait :scitt do
+      providers { [build(:provider, :scitt)] }
+    end
+
     trait :system_admin do
       providers { [] }
       system_admin { true }

--- a/spec/features/authentication_tokens/create_new_authentication_token_spec.rb
+++ b/spec/features/authentication_tokens/create_new_authentication_token_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 feature "create a new authentication token" do
   background do
-    given_i_am_authenticated
+    given_i_am_authenticated_as_an_hei_provider_user
     and_i_can_generate_an_authentication_token
   end
 
@@ -12,7 +12,7 @@ feature "create a new authentication token" do
   let(:expires_at) { Date.new(Date.current.year + 1, 12, 31) }
 
   scenario "when the feature flag is off I cannot access the create token form", feature_token_management: false do
-    given_i_am_authenticated
+    given_i_am_authenticated_as_an_hei_provider_user
     and_i_can_generate_an_authentication_token
 
     when_i_navigate_to_the_create_authentication_token_page
@@ -38,7 +38,7 @@ feature "create a new authentication token" do
   end
 
   scenario "when the feature flag is on I can create a token", feature_token_management: true do
-    given_i_am_authenticated
+    given_i_am_authenticated_as_an_hei_provider_user
     and_i_can_generate_an_authentication_token
 
     given_i_navigate_to_the_authentication_token_index_page

--- a/spec/features/authentication_tokens/revoke_authentication_token_spec.rb
+++ b/spec/features/authentication_tokens/revoke_authentication_token_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 feature "revoke an authentication token" do
   scenario "when the feature flag is on I can revoke a token", feature_token_management: true do
-    given_i_am_authenticated
+    given_i_am_authenticated_as_an_hei_provider_user
     and_i_have_generated_a_token
 
     given_i_navigate_to_the_authentication_token_index_page
@@ -18,7 +18,7 @@ feature "revoke an authentication token" do
   end
 
   scenario "when the feature flag is on I cannot revoke a token twice", feature_token_management: true do
-    given_i_am_authenticated
+    given_i_am_authenticated_as_an_hei_provider_user
     and_i_have_generated_a_token
 
     given_i_navigate_to_the_authentication_token_index_page

--- a/spec/features/organisation_settings_spec.rb
+++ b/spec/features/organisation_settings_spec.rb
@@ -34,6 +34,17 @@ feature "Organisation details" do
       when_i_click_on_back_link
       then_i_see_the_root_page
     end
+  end
+
+  context "when a User belongs to an HEI Provider organisation" do
+    let(:organisation) { create(:provider, :hei) }
+    let(:user) { create(:user, providers: [organisation]) }
+    let(:provider) { organisation }
+
+    let!(:user_one) { create(:user, providers: [organisation]) }
+    let!(:user_two) { create(:user, providers: [organisation]) }
+    let!(:user_three) { create(:user) }
+    let!(:discarded_user) { create(:user, providers: [organisation], discarded_at: 1.day.ago) }
 
     scenario "a user views the token management page", feature_token_management: true, js: true do
       when_i_click_on_the_organisation_settings_link

--- a/spec/lib/user_with_organisation_context_spec.rb
+++ b/spec/lib/user_with_organisation_context_spec.rb
@@ -300,4 +300,42 @@ describe UserWithOrganisationContext do
       it { is_expected.to be false }
     end
   end
+
+  describe "#accredited_hei_provider?" do
+    subject { described_class.new(user:, session:).accredited_hei_provider? }
+
+    context "when the organisation is a provider" do
+      context "and the provider is an accredited HEI" do
+        let(:provider) { create(:provider, :hei) }
+
+        it { is_expected.to be true }
+
+        it "is accredited" do
+          expect(provider.accredited).to be true
+        end
+      end
+
+      context "and the provider is an unaccredited HEI" do
+        let(:provider) { create(:provider, :hei, :unaccredited) }
+
+        it { is_expected.to be false }
+
+        it "is accredited" do
+          expect(provider.accredited).to be false
+        end
+      end
+
+      context "and the provider is not a HEI" do
+        let(:provider) { create(:provider, :scitt) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context "when the organisation is a lead partner" do
+      let(:user) { create(:user, id: 1, first_name: "Dave", lead_partners: [lead_partner]) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/authentication_token_spec.rb
+++ b/spec/models/authentication_token_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe AuthenticationToken do
-  let(:user) { create(:user, :with_multiple_organisations) }
+  let(:user) { create(:user, :hei) }
   let(:provider) { user.providers.first }
 
   it do

--- a/spec/support/features/authentication_steps.rb
+++ b/spec/support/features/authentication_steps.rb
@@ -11,8 +11,8 @@ module Features
       visit_sign_in_page
     end
 
-    def given_i_am_authenticated_as_an_hei_provider_user(user: create(:user, :hei))
-      given_i_am_authenticated(user:)
+    def given_i_am_authenticated_as_an_hei_provider_user
+      given_i_am_authenticated(user: create(:user, :hei))
     end
 
     def given_i_am_authenticated_as_a_lead_partner_user(user: create(:user, :with_lead_partner_organisation))

--- a/spec/support/features/authentication_steps.rb
+++ b/spec/support/features/authentication_steps.rb
@@ -11,6 +11,10 @@ module Features
       visit_sign_in_page
     end
 
+    def given_i_am_authenticated_as_an_hei_provider_user(user: create(:user, :hei))
+      given_i_am_authenticated(user:)
+    end
+
     def given_i_am_authenticated_as_a_lead_partner_user(user: create(:user, :with_lead_partner_organisation))
       given_i_am_authenticated(user:)
     end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/Q0ZJAXK7/8523-restrict-api-token-management-to-hei-providers)

### Changes proposed in this pull request

* Update `AuthenticationTokenPolicy` to only allow HEI providers to use `AuthenticationToken`s
* Add and update tests
* Fix some permissions for token management pages
* Also restricted token management and CSV bulk add trainees to _accredited_ HEIs only

### Guidance to review

* Anything missing?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
