### PR TITLE
[8565] - Allow any case for email via api

### DIFF
--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -9,7 +9,7 @@
 class EmailFormatValidator
   EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~\-]+@([^.@][^@\s]+)$/
   PART_REGEX = /^(xn-|[a-z0-9]+)(-[a-z0-9]+)*$/i
-  TLD_REGEX = /^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$/
+  TLD_REGEX = /^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$/i
 
   MAX_LENGTH = 320
   MAX_HOSTNAME_LENGTH = 253

--- a/spec/models/api/v0_1/trainee_attributes_spec.rb
+++ b/spec/models/api/v0_1/trainee_attributes_spec.rb
@@ -26,6 +26,19 @@ RSpec.describe Api::V01::TraineeAttributes do
         )
     }
 
+    describe "email" do
+      context "with uppercase TLD" do
+        before do
+          subject.email = "valid@example.COM"
+        end
+
+        it "is valid" do
+          subject.validate
+          expect(subject.errors[:email]).to be_empty
+        end
+      end
+    end
+
     describe "sex" do
       context "when empty" do
         subject { described_class.new(sex: "") }

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -17,6 +17,14 @@ describe EmailFormatValidator do
     end
   end
 
+  context "with uppercase TLD" do
+    let(:email) { "valid@example.COM" }
+
+    it "does not add errors" do
+      expect(subject).to be_valid
+    end
+  end
+
   context "with an invalid email" do
     error_test = "error test"
 


### PR DESCRIPTION
### Context

A provider using the CSV sandbox reported email addresses with containing capital letters were failing validation. Further exploration revealed that this happens when an email address has capital letters in the top level domain (.com, .co.uk etc).  We don’t know if the same happens with the API, but likely it does

[Trello Ticket](https://trello.com/c/E0tJ3dTg/8565-stop-email-addresses-with-capital-letters-in-top-level-domain-from-failing-validation)

### Changes proposed in this pull request

Removes case case cehcking from the email regex

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
