### PR TITLE
[8590] Add correct HESA code for subject for TRS

### DIFF
--- a/app/lib/hesa/code_sets/course_subjects.rb
+++ b/app/lib/hesa/code_sets/course_subjects.rb
@@ -28,6 +28,7 @@ module Hesa
         "100069" => ::CourseSubjects::DRAMA,
         "100510" => ::CourseSubjects::EARLY_YEARS_TEACHING,
         "100450" => ::CourseSubjects::ECONOMICS,
+        "101109" => ::CourseSubjects::ENGLISH_AS_SECOND_LANGUAGE,
         "100320" => ::CourseSubjects::ENGLISH_STUDIES,
         "100381" => ::CourseSubjects::ENVIRONMENTAL_SCIENCES,
         "101017" => ::CourseSubjects::FOOD_AND_BEVERAGE_STUDIES,

--- a/app/lib/trs/params/professional_status.rb
+++ b/app/lib/trs/params/professional_status.rb
@@ -102,7 +102,7 @@ module Trs
       end
 
       def subject_reference(subject_name)
-        # these three subjects are not coded by HESA so we've agreed these encodings with the DQT team
+        # These three subjects are not coded by HESA so we've agreed these encodings with the DQT team
         return "999001" if subject_name == ::CourseSubjects::CITIZENSHIP
         return "999002" if subject_name == ::CourseSubjects::PHYSICAL_EDUCATION
         return "999003" if subject_name == ::CourseSubjects::DESIGN_AND_TECHNOLOGY

--- a/spec/lib/trs/params/professional_status_spec.rb
+++ b/spec/lib/trs/params/professional_status_spec.rb
@@ -16,14 +16,15 @@ module Trs
             create(:trainee, :completed, :trn_received,
                    course_subject_one: "Primary",
                    course_subject_two: "Mathematics",
-                   course_subject_three: nil)
+                   course_subject_three: "English as a second or other language")
           end
 
           it "returns the correct subject references" do
             primary_code = Hesa::CodeSets::CourseSubjects::MAPPING.invert["Primary"]
             maths_code = Hesa::CodeSets::CourseSubjects::MAPPING.invert["Mathematics"]
+            english_as_a_second_language_code = Hesa::CodeSets::CourseSubjects::MAPPING.invert["English as a second or other language"]
 
-            expect(subject["trainingSubjectReferences"]).to contain_exactly(primary_code, maths_code)
+            expect(subject["trainingSubjectReferences"]).to contain_exactly(primary_code, maths_code, english_as_a_second_language_code)
           end
         end
 


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/wmXqCwLh/8590-record-stuck-in-trs-update-professional-status-queue)

### Changes proposed in this pull request

* Add HESA code for English as a second language subject specialism for sending to TRS

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
