### PR TITLE
[8592] Fix nil object reference in TRS interface

### DIFF
--- a/app/lib/trs/params/professional_status.rb
+++ b/app/lib/trs/params/professional_status.rb
@@ -58,7 +58,7 @@ module Trs
           "routeTypeId" => route_type_id,
           "status" => status,
           "awardedDate" => trainee.outcome_date&.to_date&.iso8601,
-          "trainingStartDate" => trainee.itt_start_date.iso8601,
+          "trainingStartDate" => trainee.itt_start_date&.iso8601 || trainee.trainee_start_date&.iso8601,
           "trainingEndDate" => trainee.itt_end_date&.iso8601 || trainee.estimated_end_date&.iso8601,
           "trainingSubjectReferences" => training_subject_references,
           "trainingAgeSpecialism" => training_age_specialism,

--- a/spec/lib/trs/params/professional_status_spec.rb
+++ b/spec/lib/trs/params/professional_status_spec.rb
@@ -160,6 +160,37 @@ module Trs
           end
         end
 
+        context "when trainee has no itt_start_date or trainee_start_date" do
+          let(:itt_end_date) { Time.zone.today }
+          let(:trainee) do
+            create(:trainee, :trn_received,
+                   itt_end_date: itt_end_date,
+                   trainee_start_date: nil,
+                   itt_start_date: nil)
+          end
+          let(:expected_end_date) { trainee.estimated_end_date }
+
+          it "falls back to `nil` trainingStartDate" do
+            expect(subject["trainingStartDate"]).to be_nil
+          end
+        end
+
+        context "when trainee has no itt_start_date" do
+          let(:itt_end_date) { Date.current }
+          let(:trainee_start_date) { 1.year.ago.to_date }
+          let(:trainee) do
+            create(:trainee, :trn_received,
+                   itt_end_date: itt_end_date,
+                   trainee_start_date: trainee_start_date,
+                   itt_start_date: nil)
+          end
+          let(:expected_end_date) { trainee.estimated_end_date }
+
+          it "falls back to `trainee_start_date` for trainingStartDate" do
+            expect(subject["trainingStartDate"]).to eq(trainee_start_date.iso8601)
+          end
+        end
+
         context "when trainee course subject is non-HESA" do
           let(:trainee) do
             create(:trainee, :trn_received, :with_secondary_education).tap do |t|


### PR DESCRIPTION
### Context
We need to handle cases where `Trainee#itt_start_date` is `nil` because it's currently causing crashes.

See https://dfe-teacher-services.sentry.io/issues/6661231287/events/5ea008158b674107bf9843588142e147/?project=5552118

### Changes proposed in this pull request

When `Trainee#itt_start_date` is `nil` fall back to `Trainee#trainee_start_date` or failing that just send a `nil` value to TRS.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
