### PR TITLE
Change timing of db backup workflow

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -24,8 +24,8 @@ on:
       db-server:
         description: |
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
-  schedule: # 03:30 UTC
-    - cron: '30 3 * * *'
+  schedule: # 03:15 UTC
+    - cron: '15 3 * * *'
 
 permissions:
   id-token: write
@@ -85,7 +85,7 @@ jobs:
 
   restore_and_sanitise:
     needs: [backup]
-    name: restore and sanitise
+    name: Restore and sanitise
     if: ${{ github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     environment:
@@ -228,7 +228,7 @@ jobs:
 
   restore_staging:
     needs: [restore_and_sanitise]
-    name: restore Database (staging)
+    name: Restore database (staging)
     if: ${{ github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     environment:
@@ -268,7 +268,7 @@ jobs:
         make ci staging get-cluster-credentials
         make install-konduit
 
-    - name: Restore backup to aks env database
+    - name: Restore backup to staging database
       shell: bash
       run: |
         bin/konduit.sh -n bat-staging -i ${SANITISED_FILE_NAME}.sql.gz -c -t 7200 register-staging -- psql


### PR DESCRIPTION
### Context

DB backup workflow runs have been failing. The recommendation is to tweak the timing to see if that helps.

### Changes proposed in this pull request

* Run the db backup workflow 15 mins earlier

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
