### PR TITLE
[8629] Allow HEI lead partners access to CSV create trainee on CSV Sandbox

### DIFF
--- a/app/lib/user_with_organisation_context.rb
+++ b/app/lib/user_with_organisation_context.rb
@@ -75,6 +75,12 @@ class UserWithOrganisationContext < SimpleDelegator
     accredited_provider? && organisation.hei?
   end
 
+  # HEI Lead Partners are all previously-accredited Providers. They should be signed in as
+  # their previously-accredited Provider in order to use bulk update trainee uploads.
+  def accredited_hei_provider_or_hei_lead_partner?
+    accredited_hei_provider? || LeadPartner.hei.find_by(provider: organisation).present?
+  end
+
 private
 
   attr_reader :session

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -109,7 +109,7 @@ class Provider < ApplicationRecord
   end
 
   def hei?
-    accreditation_id.starts_with?("1")
+    accreditation_id&.starts_with?("1")
   end
 
   def performance_profile_sign_offs

--- a/app/policies/bulk_update/imports/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/imports/trainee_upload_policy.rb
@@ -4,6 +4,8 @@ module BulkUpdate
   module Imports
     class TraineeUploadPolicy < TraineeUploads::BasePolicy
       def create?
+        return user.accredited_hei_provider_or_hei_lead_partner? && trainee_upload.uploaded? if Rails.env.in?(%w[csv-sandbox])
+
         user.accredited_hei_provider? && trainee_upload.uploaded?
       end
     end

--- a/app/policies/bulk_update/trainee_upload_policy.rb
+++ b/app/policies/bulk_update/trainee_upload_policy.rb
@@ -3,6 +3,8 @@
 module BulkUpdate
   class TraineeUploadPolicy < TraineeUploads::BasePolicy
     def new?
+      return user.accredited_hei_provider_or_hei_lead_partner? if Rails.env.in?(%w[csv-sandbox])
+
       user.accredited_hei_provider?
     end
 

--- a/spec/lib/user_with_organisation_context_spec.rb
+++ b/spec/lib/user_with_organisation_context_spec.rb
@@ -6,7 +6,8 @@ describe UserWithOrganisationContext do
   let(:user) { create(:user, id: 1, first_name: "Dave", providers: [provider]) }
   let(:session) { {} }
   let(:provider) { create(:provider) }
-  let(:lead_partner) { create(:lead_partner, :hei) }
+  let(:school_lead_partner) { create(:lead_partner, :school) }
+  let(:hei_lead_partner) { create(:lead_partner, :hei) }
 
   subject do
     described_class.new(user:, session:)
@@ -32,13 +33,13 @@ describe UserWithOrganisationContext do
       it { is_expected.to eq(user.providers.first) }
 
       context "user has a lead partner and a provider" do
-        let(:user) { create(:user, id: 1, first_name: "Dave", providers: [provider], lead_partners: [lead_partner]) }
+        let(:user) { create(:user, id: 1, first_name: "Dave", providers: [provider], lead_partners: [school_lead_partner]) }
 
         it { is_expected.to eq(user.providers.first) }
       end
 
       context "user has only a lead partner" do
-        let(:user) { create(:user, id: 1, first_name: "Dave", providers: [], lead_partners: [lead_partner]) }
+        let(:user) { create(:user, id: 1, first_name: "Dave", providers: [], lead_partners: [school_lead_partner]) }
 
         it "raises not authorised" do
           expect { subject }.to raise_error(Pundit::NotAuthorizedError)
@@ -52,7 +53,7 @@ describe UserWithOrganisationContext do
       end
 
       context "user has multiple organisations" do
-        let(:user) { create(:user, id: 1, providers: [provider], lead_partners: [lead_partner]) }
+        let(:user) { create(:user, id: 1, providers: [provider], lead_partners: [school_lead_partner]) }
 
         context "provider is set in the session" do
           let(:session) { { current_organisation: { id: provider.id, type: "Provider" } } }
@@ -61,9 +62,9 @@ describe UserWithOrganisationContext do
         end
 
         context "lead partner is set in the session" do
-          let(:session) { { current_organisation: { id: lead_partner.id, type: "LeadPartner" } } }
+          let(:session) { { current_organisation: { id: school_lead_partner.id, type: "LeadPartner" } } }
 
-          it { is_expected.to eq(lead_partner) }
+          it { is_expected.to eq(school_lead_partner) }
         end
 
         context "no organisation is set in the session" do
@@ -78,9 +79,9 @@ describe UserWithOrganisationContext do
       end
 
       context "user has only one lead partner" do
-        let(:user) { create(:user, id: 1, providers: [], lead_partners: [lead_partner]) }
+        let(:user) { create(:user, id: 1, providers: [], lead_partners: [school_lead_partner]) }
 
-        it { is_expected.to eq(lead_partner) }
+        it { is_expected.to eq(school_lead_partner) }
       end
     end
   end
@@ -102,7 +103,7 @@ describe UserWithOrganisationContext do
       end
 
       context "user has multiple organisations" do
-        let(:user) { create(:user, id: 1, providers: [provider], lead_partners: [lead_partner]) }
+        let(:user) { create(:user, id: 1, providers: [provider], lead_partners: [school_lead_partner]) }
 
         context "provider is set in the session" do
           let(:session) { { current_organisation: { id: provider.id, type: "Provider" } } }
@@ -140,16 +141,16 @@ describe UserWithOrganisationContext do
       end
 
       context "user has multiple organisations" do
-        let(:user) { create(:user, id: 1, lead_partners: [lead_partner], providers: [provider]) }
+        let(:user) { create(:user, id: 1, lead_partners: [school_lead_partner], providers: [provider]) }
 
         context "provider is set in the session" do
-          let(:session) { { current_organisation: { id: lead_partner.id, type: "Provider" } } }
+          let(:session) { { current_organisation: { id: school_lead_partner.id, type: "Provider" } } }
 
           it { is_expected.to be(false) }
         end
 
         context "lead partner is set in the session" do
-          let(:session) { { current_organisation: { id: lead_partner.id, type: "LeadPartner" } } }
+          let(:session) { { current_organisation: { id: school_lead_partner.id, type: "LeadPartner" } } }
 
           it { is_expected.to be(true) }
         end
@@ -170,7 +171,7 @@ describe UserWithOrganisationContext do
       end
 
       context "user has multiple organisations" do
-        let(:user) { create(:user, id: 1, lead_partners: [lead_partner], providers: [provider]) }
+        let(:user) { create(:user, id: 1, lead_partners: [school_lead_partner], providers: [provider]) }
 
         it { is_expected.to be(true) }
       end
@@ -188,7 +189,7 @@ describe UserWithOrganisationContext do
       end
 
       context "user has multiple organisations" do
-        let(:user) { create(:user, id: 1, lead_partners: [lead_partner], providers: [provider]) }
+        let(:user) { create(:user, id: 1, lead_partners: [school_lead_partner], providers: [provider]) }
 
         it { is_expected.to be(false) }
       end
@@ -281,7 +282,7 @@ describe UserWithOrganisationContext do
     subject { described_class.new(user:, session:).hei_provider? }
 
     context "when the organisation is a provider" do
-      context "and the provider is a HEI" do
+      context "and the provider is an HEI" do
         let(:provider) { create(:provider, :hei) }
 
         it { is_expected.to be true }
@@ -295,7 +296,7 @@ describe UserWithOrganisationContext do
     end
 
     context "when the organisation is a lead partner" do
-      let(:user) { create(:user, id: 1, first_name: "Dave", lead_partners: [lead_partner]) }
+      let(:user) { create(:user, id: 1, first_name: "Dave", lead_partners: [hei_lead_partner]) }
 
       it { is_expected.to be false }
     end
@@ -333,9 +334,67 @@ describe UserWithOrganisationContext do
     end
 
     context "when the organisation is a lead partner" do
-      let(:user) { create(:user, id: 1, first_name: "Dave", lead_partners: [lead_partner]) }
+      let(:user) { create(:user, id: 1, first_name: "Dave", lead_partners: [hei_lead_partner]) }
 
       it { is_expected.to be false }
+    end
+  end
+
+  describe "#accredited_hei_provider_or_hei_lead_partner?" do
+    subject { described_class.new(user:, session:).accredited_hei_provider_or_hei_lead_partner? }
+
+    context "when the organisation is a provider" do
+      context "and the provider is an accredited HEI" do
+        let(:provider) { create(:provider, :hei) }
+
+        it { is_expected.to be true }
+
+        it "is accredited" do
+          expect(provider.accredited).to be true
+        end
+      end
+
+      context "and the provider is an unaccredited HEI" do
+        let(:provider) { create(:provider, :hei, :unaccredited) }
+
+        it { is_expected.to be false }
+
+        it "is accredited" do
+          expect(provider.accredited).to be false
+        end
+      end
+
+      context "and the provider is an previously-accredited HEI that is now a Lead Partner" do
+        let!(:hei_lead_partner) { create(:lead_partner, :hei, provider:) }
+        let!(:provider) { create(:provider, :hei, :unaccredited) }
+        let(:user) { create(:user, id: 1, first_name: "Dave", providers: [provider]) }
+
+        it { is_expected.to be true }
+
+        it "is accredited" do
+          expect(provider.accredited).to be false
+        end
+      end
+
+      context "and the provider is not an HEI" do
+        let(:provider) { create(:provider, :scitt) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context "when the organisation is a lead partner" do
+      context "and the lead partner is an HEI" do
+        let(:user) { create(:user, id: 1, first_name: "Dave", providers: [], lead_partners: [hei_lead_partner]) }
+
+        it { is_expected.to be false }
+      end
+
+      context "and the lead partner is not an HEI" do
+        let(:user) { create(:user, id: 1, first_name: "Dave", providers: [], lead_partners: [school_lead_partner]) }
+
+        it { is_expected.to be false }
+      end
     end
   end
 end

--- a/spec/policies/bulk_update/imports/trainee_upload_policy_spec.rb
+++ b/spec/policies/bulk_update/imports/trainee_upload_policy_spec.rb
@@ -57,4 +57,51 @@ RSpec.describe BulkUpdate::Imports::TraineeUploadPolicy, type: :policy do
       end
     end
   end
+
+  context "when the User's organisation is a previously accredited HEI lead partner" do
+    let(:lead_partner) { create(:lead_partner, :hei) }
+    let(:user) { UserWithOrganisationContext.new(user: create(:user, providers: [lead_partner.provider]), session: {}) }
+    let(:trainee_upload) { build(:bulk_update_trainee_upload, provider: user.providers.first) }
+
+    context "and the environment is 'csv-sandbox'" do
+      context "when the upload is uploaded" do
+        let(:trainee_upload) { build(:bulk_update_trainee_upload, :uploaded) }
+
+        permissions :create? do
+          it "permits the user" do
+            allow(Rails.env).to receive(:in?).with(%w[csv-sandbox]).and_return(true)
+            expect(subject).to permit(user, trainee_upload)
+          end
+        end
+      end
+
+      %i[pending validated in_progress succeeded cancelled failed].each do |status|
+        context "when the upload is #{status}" do
+          let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+          permissions :create? do
+            it "does not permit the user" do
+              allow(Rails.env).to receive(:in?).with(%w[csv-sandbox]).and_return(true)
+              expect(subject).not_to permit(user, trainee_upload)
+            end
+          end
+        end
+      end
+    end
+
+    context "and the environment is not 'csv-sandbox'" do
+      %i[uploaded pending validated in_progress succeeded cancelled failed].each do |status|
+        context "and the upload is #{status}" do
+          let(:trainee_upload) { build(:bulk_update_trainee_upload, status) }
+
+          permissions :create? do
+            it "does not permit the user" do
+              allow(Rails.env).to receive(:in?).with(%w[csv-sandbox]).and_return(false)
+              expect(subject).not_to permit(user, trainee_upload)
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/vIxvTMS9)

### Changes proposed in this pull request

* Update policies to allow users in previously-accredited HEIs (who are now all Lead Partners) to use the CSV bulk create trainee feature in the CSV sandbox

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
