### PR TITLE
add census sign off

### DIFF
--- a/app/components/census_banner/view.html.erb
+++ b/app/components/census_banner/view.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_notification_banner(title_text: "Important") do |banner| %>
+  <% banner.with_heading(text: banner_heading_text) %>
+
+  <%= govuk_link_to("Sign off your census trainee data", reports_censuses_path) %> by the <%= deadline_date %> deadline.
+<% end %>

--- a/app/components/census_banner/view.rb
+++ b/app/components/census_banner/view.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CensusBanner
+  class View < ViewComponent::Base
+    DEFAULT_ACADEMIC_CYCLE_START_DATE = "1 August"
+
+    def initialize(current_academic_cycle: AcademicCycle.current, sign_off_period: DetermineSignOffPeriod.call, provider:)
+      @current_academic_cycle = current_academic_cycle
+      @provider = provider
+      @sign_off_period = sign_off_period
+    end
+
+    def render?
+      census_period? && provider.census_awaiting_sign_off?
+    end
+
+    def banner_heading_text
+      "The #{current_academic_cycle_label} ITT census sign off is due"
+    end
+
+    delegate :label, :itt_census_end_date, to: :current_academic_cycle, prefix: true
+
+    def deadline_date
+      current_academic_cycle.itt_census_end_date.strftime(Date::DATE_FORMATS[:govuk])
+    end
+
+  private
+
+    attr_reader :current_academic_cycle, :provider, :sign_off_period
+
+    def census_period?
+      sign_off_period == :census_period
+    end
+  end
+end

--- a/app/components/export_with_count_link/view.html.erb
+++ b/app/components/export_with_count_link/view.html.erb
@@ -1,0 +1,10 @@
+
+<% if count.zero? %>
+  <%= govuk_inset_text do %>
+    <%= no_record_text %>
+  <% end %>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to("#{link_text} (#{count} #{count_label.pluralize(count)})", href, method: :get) %>
+</p>

--- a/app/components/export_with_count_link/view.rb
+++ b/app/components/export_with_count_link/view.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ExportWithCountLink
+  class View < ViewComponent::Base
+    renders_one :no_record_text
+
+    def initialize(link_text:, count:, count_label:, href:)
+      @link_text = link_text
+      @count = count
+      @count_label = count_label
+      @href = href
+    end
+
+  private
+
+    attr_reader :link_text, :count, :count_label, :href
+  end
+end

--- a/app/controllers/reports/censuses_controller.rb
+++ b/app/controllers/reports/censuses_controller.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Reports
+  class CensusesController < ApplicationController
+    before_action :redirect_if_not_applicable, only: %i[index create new]
+
+    helper_method :itt_new_starter_trainees
+
+    def index
+      authorize(current_user, :reports?)
+
+      @current_academic_cycle = AcademicCycle.current
+      @current_academic_cycle_label = @current_academic_cycle.label
+
+      respond_to do |format|
+        format.html do
+          @sign_off_url = Settings.sign_off_trainee_data_url
+          @census_date = @current_academic_cycle.second_wednesday_of_october
+        end
+
+        format.csv do
+          authorize(:trainee, :export?)
+          headers["X-Accel-Buffering"] = "no"
+          headers["Cache-Control"] = "no-cache"
+          headers["Content-Type"] = "text/csv; charset=utf-8"
+          headers["Content-Disposition"] =
+            %(attachment; filename="#{itt_new_starter_filename}")
+          headers["Last-Modified"] = Time.zone.now.ctime.to_s
+
+          response.status = 200
+
+          self.response_body = Exports::ReportCsvEnumeratorService.call(itt_new_starter_trainees)
+        end
+      end
+
+      authorize(current_user, :reports?)
+    end
+
+    def new
+      authorize(current_user, :reports?)
+
+      @current_academic_cycle = AcademicCycle.current
+      @current_academic_cycle_label = @current_academic_cycle.label
+
+      @census_sign_off_form = CensusSignOffForm.new
+    end
+
+    def create
+      authorize(current_user, :reports?)
+
+      @census_sign_off_form = CensusSignOffForm.new(sign_off: sign_off, provider: current_user.organisation, user: current_user)
+
+      if @census_sign_off_form.save!
+        email_provider_users
+        redirect_to(confirmation_reports_censuses_path)
+      else
+        @current_academic_cycle = AcademicCycle.current
+        @current_academic_cycle_label = @current_academic_cycle.label
+        render(:new)
+      end
+    end
+
+    def confirmation
+      authorize(current_user, :reports?)
+
+      redirect_to(reports_path) unless current_user.provider? && current_user.organisation.census_signed_off? && DetermineSignOffPeriod.call == :census_period
+    end
+
+  private
+
+    def redirect_if_not_applicable
+      redirect_to(reports_path) unless applicable_to_user?
+    end
+
+    def applicable_to_user?
+      current_user.provider? && current_user.organisation.census_awaiting_sign_off? && DetermineSignOffPeriod.call == :census_period
+    end
+
+    def time_now
+      Time.now.in_time_zone("London").strftime("%F_%H-%M-%S")
+    end
+
+    def censuses_filename
+      "#{time_now}_#{@current_academic_cycle.label('-')}_trainees_censuses-sign-off_register-trainee-teachers.csv"
+    end
+
+    def censuses_trainees
+      Trainees::Filter.call(trainees: base_trainee_scope, filters: { academic_year: [@current_academic_cycle.start_year] })
+    end
+
+    def base_trainee_scope
+      policy_scope(Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :end_academic_cycle).not_draft)
+    end
+
+    def email_provider_users
+      SendCensusSubmittedEmailService.call(provider: current_user.organisation, submitted_at: Time.zone.now)
+    end
+
+    def itt_new_starter_trainees
+      @itt_new_starter_trainees ||= policy_scope(FindNewStarterTrainees.new(@current_academic_cycle.first_day_of_september).call)
+    end
+
+    def itt_new_starter_filename
+      "#{time_now}_New-trainees-#{@current_academic_cycle.label('-')}-sign-off-Register-trainee-teachers_exported_records.csv"
+    end
+
+    def sign_off
+      params.require(:census_sign_off_form).permit(:sign_off)[:sign_off]
+    end
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -19,6 +19,14 @@ class ReportsController < BaseTraineeController
         @partial_page = :outside_period
       end
     end
+
+    if @partial_page == :census_period
+      if current_user.organisation.nil? && current_user.system_admin?
+        @partial_page = :system_admin_with_no_associated_provider
+      elsif current_user.organisation.census_signed_off?
+        @partial_page = :outside_period
+      end
+    end
   end
 
   def itt_new_starter_data_sign_off

--- a/app/forms/census_sign_off_form.rb
+++ b/app/forms/census_sign_off_form.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CensusSignOffForm
+  include ActiveModel::Model
+
+  validates :sign_off, presence: true, inclusion: { in: ["confirmed"] }
+
+  def initialize(sign_off: "not_confirmed", provider: nil, user: nil)
+    @sign_off = sign_off
+    @provider = provider
+    @user = user
+  end
+
+  def save!
+    return false unless valid?
+
+    census_sign_off = provider.sign_offs.find_or_initialize_by(academic_cycle: AcademicCycle.current, sign_off_type: :census)
+    census_sign_off.user = user
+
+    census_sign_off.save!
+  end
+
+private
+
+  attr_reader :sign_off, :provider, :user
+end

--- a/app/mailers/census_submitted_email_mailer.rb
+++ b/app/mailers/census_submitted_email_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CensusSubmittedEmailMailer < GovukNotifyRails::Mailer
+  def generate(user:, submitted_at:)
+    set_template(Settings.govuk_notify.census_submitted_email_template_id)
+
+    set_personalisation(
+      first_name: user.first_name,
+      submitted_at: submitted_at.to_fs(:govuk_date_and_time),
+    )
+
+    mail(to: user.email)
+  end
+end

--- a/app/models/academic_cycle.rb
+++ b/app/models/academic_cycle.rb
@@ -90,10 +90,30 @@ class AcademicCycle < ApplicationRecord
     Date.new(end_year + 1, 2, -1)
   end
 
+  def second_wednesday_of_october
+    Date.new(start_year, 10, 1).next_week(:wednesday)
+  end
+
+  def first_day_of_september
+    Date.new(start_year, 9, 1)
+  end
+
+  def last_day_of_october
+    Date.new(start_year, 10, -1)
+  end
+
   alias_method :end_date_of_performance_profile, :last_day_of_february
+
+  alias_method :itt_census_date, :second_wednesday_of_october
+
+  alias_method :itt_census_end_date, :last_day_of_october
 
   def performance_profile_date_range
     @performance_profile_date_range ||= second_monday_of_january..end_date_of_performance_profile
+  end
+
+  def census_date_range
+    @census_date_range ||= first_day_of_september..last_day_of_october
   end
 
 private

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -124,6 +124,18 @@ class Provider < ApplicationRecord
     !performance_profile_signed_off?
   end
 
+  def census_sign_offs
+    sign_offs.census
+  end
+
+  def census_signed_off?
+    sign_offs.census.current_academic_cycle.exists?
+  end
+
+  def census_awaiting_sign_off?
+    !census_signed_off?
+  end
+
 private
 
   def update_courses

--- a/app/models/sign_off.rb
+++ b/app/models/sign_off.rb
@@ -38,4 +38,10 @@ class SignOff < ApplicationRecord
 
     joins(:academic_cycle).where(academic_cycles: { id: AcademicCycle.previous.id })
   }
+
+  scope :current_academic_cycle, lambda {
+    return none if AcademicCycle.previous.blank?
+
+    joins(:academic_cycle).where(academic_cycles: { id: AcademicCycle.current.id })
+  }
 end

--- a/app/services/send_census_submitted_email_service.rb
+++ b/app/services/send_census_submitted_email_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SendCensusSubmittedEmailService
+  include ServicePattern
+
+  def initialize(provider:, submitted_at:)
+    @provider = provider
+    @submitted_at = submitted_at
+  end
+
+  def call
+    provider.users.kept.each do |user|
+      CensusSubmittedEmailMailer.generate(
+        user:,
+        submitted_at:,
+      ).deliver_later
+    end
+  end
+
+private
+
+  attr_reader :provider, :submitted_at
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -118,6 +118,7 @@
           <%= render(YearChangeBanner::View.new) %>
           <%= render(CsvSandboxBanner::View.new) if @current_user&.present? && request.path == root_path %>
           <%= render(PerformanceProfileBanner::View.new(previous_academic_cycle: AcademicCycle.previous, sign_off_period: DetermineSignOffPeriod.call, provider: @current_user.organisation)) if @current_user&.provider? && request.path == root_path %>
+          <%= render(CensusBanner::View.new(current_academic_cycle: AcademicCycle.current, sign_off_period: DetermineSignOffPeriod.call, provider: @current_user.organisation)) if @current_user&.provider? && request.path == root_path %>
         <% end %>
 
         <%= render(FlashBanner::View.new(flash: flash, trainee: @trainee)) %>

--- a/app/views/reports/_census_period.html.erb
+++ b/app/views/reports/_census_period.html.erb
@@ -4,13 +4,8 @@
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
-      <%= govuk_link_to "New trainees for the #{@current_academic_cycle_label} academic year", itt_new_starter_data_sign_off_reports_path, class: "new-trainee-data" %>
+      <%= govuk_link_to "Trainees with their academic start year in #{@current_academic_cycle_label} report", reports_censuses_path, class: "new-trainee-data" %>
       - for census sign off.
-    </p>
-  </li>
-  <li>
-    <p>
-       Trainees who studied in the <%= @previous_academic_cycle_label %> academic year - will be available for performance profiles sign off.
     </p>
   </li>
 </ul>

--- a/app/views/reports/censuses/confirmation.html.erb
+++ b/app/views/reports/censuses/confirmation.html.erb
@@ -1,0 +1,29 @@
+<% page_title = "Census sign off submitted" %>
+<%= render PageTitle::View.new(text: page_title) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Reports",
+    href: reports_path,
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= govuk_panel(title_text: page_title, classes: "trn-submission-success-panel govuk-!-margin-bottom-6") %>
+
+    <h1 class="govuk-body">
+      Census sign off completed.
+    </h1>
+
+    <p class="govuk-body">
+      We have sent you and the other Register account users a confirmation email.
+    </p>
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+
+    <p class="govuk-body">
+      If you have any questions email <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
+    </p>
+  </div>
+</div>

--- a/app/views/reports/censuses/index.html.erb
+++ b/app/views/reports/censuses/index.html.erb
@@ -1,0 +1,52 @@
+<%= render PageTitle::View.new(text: "Export new trainee data for sign off for the #{@current_academic_cycle_label} academic year") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Reports",
+    href: reports_path,
+    ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">Export new trainee data for sign off for the <%= @current_academic_cycle_label %> academic year</h1>
+    <p class="govuk-body">This export will show the new trainee data you’ve provided to the DfE for trainees who’ve started their initial teacher training (ITT) in the <%= @current_academic_cycle_label %> academic year, and have a trainee start date on or before the second Wednesday of October (sometimes called the ITT census date).</p>
+    <p class="govuk-body">For the <%= @current_academic_cycle_label %> academic year, the ITT census date is Wednesday <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>.
+    </p>
+    <h2 class="govuk-heading-m">What you must do to sign off your new trainee data</h2>
+    <p class="govuk-body">Use this export to check you’ve provided accurate data for all your new trainees. You should check for any errors or missing trainees.</p>
+    <p class="govuk-body">You must sign off your data by <%= @current_academic_cycle.itt_census_end_date.strftime(Date::DATE_FORMATS[:govuk]) %>. Not submitting and signing off new trainee data by this date will mean that we (the DfE) do not have accurate data on your trainees and they may be excluded from the ITT census publication</p>
+    <h2 class="govuk-heading-m">How new trainee data relates to the ITT census publication</h2>
+    <p class="govuk-body">After signing off your new trainee data, it gets analysed and filtered for the ITT census publication.</p>
+    <p class="govuk-body">Not all your new trainees in this export will be included in the ITT census publication. To understand what data will be used, read the The ITT census is put together using the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">Initial Teacher Training Census methodology (opens in a new tab)</a>.</p>
+    <h2 class="govuk-heading-m">New trainees without a start date</h2>
+    <p class="govuk-body">Any new trainee who has a course start date on or before <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>, but does not have a trainee start date, will be included in this export.</p>
+    <p class="govuk-body">If a new trainee starts their course on or before <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>, you should add their trainee start date as soon as possible (if you’re registering trainees manually in the Register service). Not adding this means we will not know if the trainee has started their course, which could affect funding payments, if the trainee is eligible for funding.</p>
+    <h2 class="govuk-heading-m">About this export</h2>
+    <p class="govuk-body">This export includes all trainees:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        with their academic start year in <%= @current_academic_cycle_label %>
+      </li>
+      <li>
+        with an ITT course start date on or before the ITT census date
+      </li>
+      <li>
+        with a trainee start date on or before the ITT census date
+      </li>
+    </ul>
+    <p class="govuk-body">If a trainee does not have a trainee start date, they will also be included in this export.</p>
+    <p class="govuk-body">This export will not include trainees on the Assessment Only (AO) route or trainees who started training but then withdrew before the ITT census date.</p>
+
+    <%= render ExportWithCountLink::View.new(link_text: "Export new trainee data", count: itt_new_starter_trainees_count, count_label: "trainee", href: itt_new_starter_data_sign_off_reports_path(:csv)) do |component| %>
+      <% component.no_record_text do %>
+        <p>You have no trainees available to export. Check you have registered new trainees for the <%= @current_academic_cycle_label %> academic year.</p>
+      <% end %>
+    <% end %>
+
+    <h2 class="govuk-heading-m">Sign off your new trainee data</h2>
+    <p class="govuk-body">If you have checked your data.</p>
+
+    <%= govuk_button_link_to("Continue to census sign off", new_reports_censuse_path)%>
+  </div>
+</div>

--- a/app/views/reports/censuses/new.html.erb
+++ b/app/views/reports/censuses/new.html.erb
@@ -1,0 +1,38 @@
+<% page_title = "Census sign off your organisation’s new trainee data for the #{@current_academic_cycle_label} academic year" %>
+<%= render PageTitle::View.new(text: page_title, has_errors: @census_sign_off_form.errors.any?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Reports",
+    href: reports_path,
+    ) %>
+<% end %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @census_sign_off_form, url: reports_censuses_path) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <%= page_title %>
+      </h1>
+      <p class="govuk-body">
+        Once you’ve checked your data is correct, you can sign off on behalf of your organisation.
+      </p>
+
+      <%= govuk_summary_card(title: "Census sign off information") do |card|
+            card.with_summary_list(rows: [
+            { key: { text: "Provider name" }, value: { text: current_user.organisation.name } },
+            { key: { text: "UKPRN" }, value: { text: @current_user.organisation.ukprn } },
+            { key: { text: "Approver name" }, value: { text: @current_user.name } },
+          ],)
+          end %>
+
+      <%= f.govuk_check_boxes_fieldset(:sign_off, multiple: false, legend: { text: "Confirm your organisation’s new trainee data is in Register, you’ve checked it’s correct and you’re signing it off", size: "s" }) do %>
+        <%= f.govuk_check_box(:sign_off, "confirmed", "not_confirmed", multiple: false, link_errors: true, label: { text: "Yes, the trainee data is correct to the best of my knowledge" }) %>
+      <% end %>
+
+      <%= f.govuk_submit("Sign off census") %>
+    <%- end -%>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,12 @@ Rails.application.routes.draw do
             get "confirmation", to: "performance_profiles#confirmation"
           end
         end
+
+        resources :censuses, path: "censuses", only: %i[index new create] do
+          collection do
+            get "confirmation", to: "censuses#confirmation"
+          end
+        end
       end
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -168,6 +168,7 @@ govuk_notify:
     succeeded_template_id: 8ff06d35-8960-462e-aa6e-9942a7fd713d
     failed_template_id: 3344fd46-7f33-4762-a350-d02a88f863b0
   performance_profile_submitted_email_template_id: 21879652-3975-4a0a-b0b4-9fe6a5353090
+  census_submitted_email_template_id: 5a610b43-a36e-4e4c-8ab0-e7e9d158f440
 
 google_tag_manager:
   tracking_id: GTM-PD8MFNL

--- a/spec/components/export_with_count_link/view_preview.rb
+++ b/spec/components/export_with_count_link/view_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ExportWithCountLink
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(
+        View.new(
+          link_text: "Export",
+          count: 1,
+          count_label: "trainee",
+          href: "/export",
+        ),
+      )
+    end
+
+    def with_no_record_text
+      render(
+        View.new(
+          link_text: "Export",
+          count: 0,
+          count_label: "trainee",
+          href: "/export",
+        ),
+      ) do |component|
+        component.no_record_text { "No trainees found." }
+      end
+    end
+  end
+end

--- a/spec/components/export_with_count_link/view_spec.rb
+++ b/spec/components/export_with_count_link/view_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ExportWithCountLink
+  describe View do
+    let(:link_text) { "Export" }
+    let(:count_label) { "trainee" }
+    let(:href) { "/export" }
+
+    describe "rendered output" do
+      before do
+        render_inline(described_class.new(link_text:, count:, count_label:, href:))
+      end
+
+      context "with 0 records" do
+        let(:count) { 0 }
+
+        it "renders the count" do
+          expect(page).to have_link("Export (0 trainees)")
+        end
+      end
+
+      context "with 1 record" do
+        let(:count) { 1 }
+
+        it "renders the count" do
+          expect(page).to have_link("Export (1 trainee)")
+        end
+      end
+
+      context "with 2 or more records" do
+        let(:count) { 2 }
+
+        it "renders the count" do
+          expect(page).to have_link("Export (2 trainees)")
+        end
+      end
+    end
+
+    describe "no record text" do
+      before do
+        render_inline(described_class.new(link_text: link_text, count: 0, count_label: count_label, href: href)) do |component|
+          component.with_no_record_text { "No trainees found" }
+        end
+      end
+
+      it "renders the no record text" do
+        expect(page).to have_content("No trainees found")
+      end
+    end
+  end
+end

--- a/spec/controllers/reports/censuses_controller_spec.rb
+++ b/spec/controllers/reports/censuses_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Reports::CensusesController do
+  let(:user) { build_current_user }
+
+  before do
+    create(:academic_cycle, previous_cycle: false)
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(DetermineSignOffPeriod).to receive(:call).and_return(:census_period)
+  end
+
+  describe "#index" do
+    it "returns a 200 status code" do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the application template" do
+      get :index
+      expect(response).to render_template("application")
+    end
+
+    it "renders a csv" do
+      get :index, params: { format: :csv }
+      expect(response.content_type).to eq("text/csv; charset=utf-8")
+    end
+  end
+end

--- a/spec/features/reports/census_spec.rb
+++ b/spec/features/reports/census_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "census sign off" do
+  context "outside period" do
+    background do
+      allow(DetermineSignOffPeriod).to receive(:call).and_return(:outside_period)
+    end
+
+    scenario "navigate to the sign off your census page" do
+      given_i_am_authenticated
+      when_i_visit_the_sign_off_your_census_page
+      then_i_am_redirected_to_the_reports_page
+    end
+
+    scenario "navigate to the itt census sign off for the page" do
+      given_i_am_authenticated
+      when_i_visit_the_itt_census_sign_off_for_the_academic_year_page
+      then_i_am_redirected_to_the_reports_page
+    end
+  end
+
+  context "census period" do
+    background do
+      allow(DetermineSignOffPeriod).to receive(:call).and_return(:census_period)
+    end
+
+    context "accredited provider user" do
+      scenario "navigate to the census confirmation page" do
+        given_i_am_authenticated
+        when_i_visit_the_census_confirmation_page
+        then_i_am_redirected_to_the_reports_page
+      end
+
+      scenario "user signing off the census from banner" do
+        given_i_am_authenticated
+        and_i_am_on_the_root_page
+        and_i_can_see_the_census_banner
+        and_i_click_on("Sign off your census")
+        and_i_am_on_the_sign_off_your_census_page
+
+        when_i_click_on("Continue to census sign off")
+        and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
+        and_i_can_see_the_census_information
+        and_i_click_on("Sign off census")
+        and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
+        and_i_click_on("Sign off census")
+
+        then_i_am_on_the_census_confirmation_page
+        and_the_provider_has_census_signed_off
+      end
+
+      scenario "user signing off the census from reports page" do
+        given_i_am_authenticated
+        and_i_am_on_the_reports_page
+        and_i_click_on("Trainees with their academic start year in #{current_academic_cycle_label} report")
+        and_i_am_on_the_sign_off_your_census_page
+
+        when_i_click_on("Continue to census sign off")
+        and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
+        and_i_can_see_the_census_information
+        and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
+        and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
+        and_i_click_on("Sign off census")
+
+        then_i_am_on_the_census_confirmation_page
+        and_the_provider_has_census_signed_off
+      end
+
+      scenario "a previously accredited provider signing off the census from reports page" do
+        given_i_am_authenticated(user: create(:user, providers: [build(:provider, :unaccredited)]))
+        and_i_am_on_the_reports_page
+
+        and_i_click_on("Trainees with their academic start year in #{current_academic_cycle_label} report")
+        and_i_am_on_the_sign_off_your_census_page
+
+        when_i_click_on("Continue to census sign off")
+        and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
+        and_i_can_see_the_census_information
+        and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
+        and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
+        and_i_click_on("Sign off census")
+
+        then_i_am_on_the_census_confirmation_page
+        and_the_provider_has_census_signed_off
+      end
+
+      context "census signed off" do
+        scenario "sign off your census page" do
+          given_i_am_authenticated
+          and_provider_has_census_signed_off
+
+          when_i_visit_the_sign_off_your_census_page
+          then_i_am_redirected_to_the_reports_page
+        end
+
+        scenario "itt census sign off for the page" do
+          given_i_am_authenticated
+          and_provider_has_census_signed_off
+
+          when_i_visit_the_itt_census_sign_off_for_the_academic_year_page
+          then_i_am_redirected_to_the_reports_page
+        end
+      end
+    end
+
+    context "lead provider user" do
+      scenario "unauthorized message is shown" do
+        given_i_am_authenticated_as_a_lead_partner_user
+        when_i_visit_the_sign_off_your_census_page
+        then_i_see_the_unauthorized_message
+      end
+    end
+
+    context "system admin with no associated provider" do
+      scenario "system administrator account banner message is shown" do
+        given_i_am_authenticated_as_system_admin
+        when_i_visit_the_sign_off_your_census_page
+        then_i_see_the_system_administrator_account_banner
+      end
+    end
+  end
+
+private
+
+  def current_academic_cycle_label
+    AcademicCycle.current.label
+  end
+
+  def and_the_provider_has_census_signed_off
+    expect(SignOff.exists?(academic_cycle: AcademicCycle.current, sign_off_type: :census, user: current_user, provider: current_user.providers.first)).to be_truthy
+  end
+
+  def and_provider_has_census_signed_off
+    SignOff.new(academic_cycle: AcademicCycle.current, sign_off_type: :census, user: current_user, provider: current_user.providers.first).save!
+  end
+
+  def and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
+    expect(page).to have_current_path("/reports/censuses/new")
+  end
+
+  def then_i_am_on_the_census_confirmation_page
+    expect(page).to have_current_path("/reports/censuses/confirmation")
+  end
+
+  def and_i_can_see_the_census_information
+    expect(page).to have_css(".govuk-heading-l", text: "Census sign off your organisation’s new trainee data for the #{current_academic_cycle_label} academic year")
+
+    expect(page).to have_css(".govuk-summary-card__title", text: "Census sign off information")
+
+    expect(page).to have_css(".govuk-summary-list__key", text: "Provider name")
+    expect(page).to have_css(".govuk-summary-list__value", text: current_user.providers.first.name)
+
+    expect(page).to have_css(".govuk-summary-list__key", text: "UKPRN")
+    expect(page).to have_css(".govuk-summary-list__value", text: current_user.providers.first.ukprn)
+
+    expect(page).to have_css(".govuk-summary-list__key", text: "Approver name")
+    expect(page).to have_css(".govuk-summary-list__value", text: current_user.name)
+  end
+
+  def and_i_am_on_the_root_page
+    visit "/"
+  end
+
+  def and_i_am_on_the_reports_page
+    visit "/reports"
+  end
+
+  def and_i_can_see_the_census_banner
+    expect(page).to have_css("#govuk-notification-banner-title", text: "Important")
+    expect(page).to have_css(".govuk-notification-banner__heading", text: "The #{current_academic_cycle_label} ITT census sign off is due")
+  end
+
+  def current_academic_cycle_label
+    AcademicCycle.current.label
+  end
+
+  def and_i_am_on_the_sign_off_your_census_page
+    expect(page).to have_current_path("/reports/censuses")
+  end
+
+  def when_i_visit_the_itt_census_sign_off_for_the_academic_year_page
+    visit("/reports/censuses/new")
+  end
+
+  def when_i_visit_the_sign_off_your_census_page
+    visit "/reports/censuses"
+  end
+
+  def when_i_visit_the_census_confirmation_page
+    visit "/reports/censuses/confirmation"
+  end
+
+  def then_i_am_redirected_to_the_reports_page
+    expect(page).to have_current_path("/reports")
+  end
+
+  def then_i_see_the_unauthorized_message
+    expect(page).to have_content("You do not have permission to perform this action")
+  end
+
+  def then_i_see_the_system_administrator_account_banner
+    expect(page).to have_css("#govuk-notification-banner-title", text: "Important")
+    expect(page).to have_css(".govuk-notification-banner__heading", text: "Your system administrator account must be associated with an accredited provider")
+    expect(page).to have_css(".govuk-notification-banner__content", text: "You can edit your user details")
+
+    expect(page).to have_link("user details", href: "/system-admin/users/#{@current_user.id}")
+  end
+
+  def and_i_see_there_is_a_problem
+    expect(page).to have_css(".govuk-error-summary__title", text: "There is a problem")
+  end
+
+  alias_method :and_i_check_on, :check
+  alias_method :and_i_click_on, :click_on
+  alias_method :when_i_click_on, :click_on
+end

--- a/spec/mailers/census_submitted_email_mailer_spec.rb
+++ b/spec/mailers/census_submitted_email_mailer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CensusSubmittedEmailMailer do
+  context "sending an email to a user" do
+    let(:user) { create(:user) }
+    let(:submitted_at) { Time.zone.local(2025, 1, 12, 12, 30) }
+    let(:mail) { described_class.generate(user:, submitted_at:) }
+
+    before { mail }
+
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.census_submitted_email_template_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "includes the first name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:first_name]).to eq(user.first_name)
+    end
+
+    it "includes the submitted at time in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:submitted_at]).to eq("12 January 2025 at 12:30pm")
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/ICoK0OL5/8610-integrate-the-census-sign-off-in-register

### Changes proposed in this pull request

Add pages for Census sign off in the vein of the performance profile sign off

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
