### PR TITLE
[8630] - service updates new design

### DIFF
--- a/app/components/service_update/view.rb
+++ b/app/components/service_update/view.rb
@@ -6,11 +6,11 @@ class ServiceUpdate::View < ViewComponent::Base
   delegate :title, :content, :date, to: :service_update
 
   TITLE_TAGS = %w[h1 h2 h3 h4 h5 h6].freeze
-  TITLE_CLASS = "govuk-heading-m govuk-!-margin-bottom-2"
 
-  def initialize(service_update:, title_tag: "h2")
+  def initialize(service_update:, title_tag: "h2", title_size: "l")
     @service_update = service_update
     @title_tag = title_tag
+    @title_size = title_size
   end
 
   def render?
@@ -18,9 +18,9 @@ class ServiceUpdate::View < ViewComponent::Base
   end
 
   def title_element
-    return tag.public_send(title_tag, title, class: TITLE_CLASS) if TITLE_TAGS.include?(title_tag)
+    return tag.public_send(title_tag, title, class: title_class) if TITLE_TAGS.include?(title_tag)
 
-    tag.h2(title, class: TITLE_CLASS)
+    tag.h2(title, class: title_class)
   end
 
   def date_pretty
@@ -34,5 +34,9 @@ class ServiceUpdate::View < ViewComponent::Base
 
 private
 
-  attr_reader :title_tag
+  attr_reader :title_tag, :title_size
+
+  def title_class
+    "govuk-heading-#{title_size} govuk-!-margin-bottom-2"
+  end
 end

--- a/app/controllers/service_updates_controller.rb
+++ b/app/controllers/service_updates_controller.rb
@@ -6,4 +6,9 @@ class ServiceUpdatesController < ApplicationController
   def index
     @service_updates = ServiceUpdate.all
   end
+
+  def show
+    @service_update = ServiceUpdate.find_by_id(params[:id])
+    raise(ActionController::RoutingError, "Not Found") if @service_update.nil?
+  end
 end

--- a/app/models/service_update.rb
+++ b/app/models/service_update.rb
@@ -5,16 +5,40 @@ class ServiceUpdate
 
   include ActiveModel::Model
 
-  attr_accessor :date, :title, :content
+  attr_accessor :date, :title, :content, :summary
 
   def id
     title.parameterize
   end
 
   def self.all
-    YAML.load_file(SERVICE_UPDATES_YAML_FILE).map do |params|
+    updates = YAML.load_file(SERVICE_UPDATES_YAML_FILE).map do |params|
       new(params)
     end
+
+    updates.sort_by { |update| Date.parse(update.date) }.reverse
+  end
+
+  def self.find_by_id(id)
+    all.find { |update| update.id == id }
+  end
+
+  def summary_text
+    return summary if summary.present?
+
+    content_lines = content.split("\n").compact_blank
+    first_paragraph = content_lines.first&.strip
+
+    if first_paragraph && first_paragraph.length > 200
+      "#{first_paragraph[0, 200]}..."
+    else
+      first_paragraph || ""
+    end
+  end
+
+  def summary_html
+    custom_render = Redcarpet::Render::HTML.new(link_attributes: { class: "govuk-link" })
+    Redcarpet::Markdown.new(custom_render).render(summary_text).html_safe
   end
 
   def self.recent_updates

--- a/app/views/landing_page/start.html.erb
+++ b/app/views/landing_page/start.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h2 class="govuk-heading-l"><%= t(".service_updates_title") %></h2>
     <% ServiceUpdate.recent_updates.each do |service_update| %>
-      <%= render ServiceUpdate::View.new(service_update: service_update, title_tag: "h3") %>
+      <%= render ServiceUpdate::View.new(service_update: service_update, title_tag: "h3", title_size: "m") %>
     <% end %>
 
     <%= govuk_link_to(t(".service_updates_link"), service_updates_path, class: "govuk-body" ) %>

--- a/app/views/service_updates/index.html.erb
+++ b/app/views/service_updates/index.html.erb
@@ -17,7 +17,7 @@
           <%= link_to service_update.title, service_update_path(service_update.id), class: "govuk-link" %>
         </h2>
         <div class="govuk-body govuk-!-margin-bottom-2"><%= service_update.summary_html %></div>
-        <p class="govuk-hint govuk-!-margin-bottom-0"><%= service_update.date.to_date.strftime("%e %B %Y") %></p>
+        <p class="govuk-hint govuk-!-margin-bottom-0"><%= service_update.date.to_date.to_fs(:govuk) %></p>
       </div>
       <% unless service_update == @service_updates.last %>
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/service_updates/index.html.erb
+++ b/app/views/service_updates/index.html.erb
@@ -11,18 +11,17 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 
-    <h2 class="govuk-heading-m"><%= t(".contents") %></h2>
-    <ul class="govuk-list app-list--dash govuk-!-margin-bottom-8 govuk-!-margin-left-3">
-      <% @service_updates.each do |service_update| %>
-        <li><a class="govuk-link" href="#<%= service_update.id %>"><%= service_update.title %></a></li>
-      <% end %>
-    </ul>
-
-
     <% @service_updates.each do |service_update| %>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-      <%= render ServiceUpdate::View.new(service_update: service_update) %>
+      <div class="govuk-!-margin-bottom-8">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+          <%= link_to service_update.title, service_update_path(service_update.id), class: "govuk-link" %>
+        </h2>
+        <div class="govuk-body govuk-!-margin-bottom-2"><%= service_update.summary_html %></div>
+        <p class="govuk-hint govuk-!-margin-bottom-0"><%= service_update.date.to_date.strftime("%e %B %Y") %></p>
+      </div>
+      <% unless service_update == @service_updates.last %>
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <% end %>
     <% end %>
-
   </div>
 </div>

--- a/app/views/service_updates/show.html.erb
+++ b/app/views/service_updates/show.html.erb
@@ -1,0 +1,14 @@
+<%= render PageTitle::View.new(text: @service_update.title) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t("back"),
+    href: service_updates_path,
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= render ServiceUpdate::View.new(service_update: @service_update, title_tag: "h1") %>
+  </div>
+</div> 

--- a/app/views/service_updates/show.html.erb
+++ b/app/views/service_updates/show.html.erb
@@ -9,6 +9,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= render ServiceUpdate::View.new(service_update: @service_update, title_tag: "h1") %>
+    <%= render ServiceUpdate::View.new(service_update: @service_update, title_tag: "h1", title_size: "l") %>
   </div>
 </div> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -246,7 +246,7 @@ Rails.application.routes.draw do
   resources :trn_submissions, only: %i[create show], param: :trainee_id, path: "trainee-registrations"
   resource :cookie_preferences, only: %i[show update], path: "/cookies"
 
-  resources :service_updates, only: %i[index], path: "service-updates"
+  resources :service_updates, only: %i[index show], path: "service-updates"
 
   resources :organisations, only: %i[index show], path: "organisations"
 

--- a/spec/controllers/service_updates_controller_spec.rb
+++ b/spec/controllers/service_updates_controller_spec.rb
@@ -9,12 +9,12 @@ describe ServiceUpdatesController do
         {
           date: "2021-09-17",
           title: "Most recent item",
-          content: "Ths is another **Markdown** content.",
+          content: "This is another **Markdown** content.",
         },
         {
           date: "2021-09-01",
           title: "Lead and employing schools",
-          content: "Ths is **Markdown** content.",
+          content: "This is **Markdown** content.",
         },
       ],
     )
@@ -26,6 +26,22 @@ describe ServiceUpdatesController do
 
       expect(response).to have_http_status(:ok)
       expect(assigns(:service_updates).count).to eq(2)
+    end
+  end
+
+  describe "GET #show" do
+    it "renders individual service update" do
+      get :show, params: { id: "most-recent-item" }
+
+      expect(response).to have_http_status(:ok)
+      expect(assigns(:service_update)).to be_present
+      expect(assigns(:service_update).title).to eql("Most recent item")
+    end
+
+    it "raises 404 for non-existent service update" do
+      expect {
+        get :show, params: { id: "non-existent" }
+      }.to raise_error(ActionController::RoutingError)
     end
   end
 end

--- a/spec/models/service_update_spec.rb
+++ b/spec/models/service_update_spec.rb
@@ -9,56 +9,90 @@ describe ServiceUpdate do
         {
           date: "2021-09-21",
           title: "Most recent item",
-          content: "Ths is also another **Markdown** content.",
+          content: "This is also another **Markdown** content.",
         },
         {
           date: "2021-09-17",
           title: "Second most recent item",
-          content: "Ths is another **Markdown** content.",
+          content: "This is another **Markdown** content.",
         },
         {
           date: "2021-09-01",
           title: "Lead and employing schools",
-          content: "Ths is **Markdown** content.",
+          content: "This is **Markdown** content.",
         },
       ],
     )
   end
 
-  describe "#all" do
-    it "returns all items" do
-      expect(ServiceUpdate.all.count).to be(3)
+  describe ".all" do
+    it "returns all items sorted by date descending" do
+      updates = ServiceUpdate.all
 
-      expect(ServiceUpdate.all[0].title).to eql("Most recent item")
-      expect(ServiceUpdate.all[0].content).to eql("Ths is also another **Markdown** content.")
-      expect(ServiceUpdate.all[0].date).to eql("2021-09-21")
-
-      expect(ServiceUpdate.all[1].title).to eql("Second most recent item")
-      expect(ServiceUpdate.all[1].content).to eql("Ths is another **Markdown** content.")
-      expect(ServiceUpdate.all[1].date).to eql("2021-09-17")
-
-      expect(ServiceUpdate.all[2].title).to eql("Lead and employing schools")
-      expect(ServiceUpdate.all[2].content).to eql("Ths is **Markdown** content.")
-      expect(ServiceUpdate.all[2].date).to eql("2021-09-01")
+      expect(updates.count).to be(3)
+      expect(updates[0].title).to eql("Most recent item")
+      expect(updates[0].date).to eql("2021-09-21")
+      expect(updates[1].title).to eql("Second most recent item")
+      expect(updates[2].title).to eql("Lead and employing schools")
     end
   end
 
-  describe "#recent_update" do
+  describe ".find_by_id" do
+    it "finds service update by parameterized title" do
+      update = ServiceUpdate.find_by_id("most-recent-item")
+
+      expect(update).to be_present
+      expect(update.title).to eql("Most recent item")
+    end
+
+    it "returns nil for non-existent id" do
+      update = ServiceUpdate.find_by_id("non-existent")
+
+      expect(update).to be_nil
+    end
+  end
+
+  describe "#summary_text" do
+    context "when summary field is present" do
+      it "returns the summary field" do
+        update_data = { summary: "Custom summary", content: "Long content..." }
+        service_update = ServiceUpdate.new(update_data)
+
+        expect(service_update.summary_text).to eq("Custom summary")
+      end
+    end
+
+    context "when summary field is not present" do
+      it "generates summary from first paragraph" do
+        update_data = { content: "First paragraph\n\nSecond paragraph" }
+        service_update = ServiceUpdate.new(update_data)
+
+        expect(service_update.summary_text).to eq("First paragraph")
+      end
+
+      it "truncates long first paragraphs" do
+        long_content = "A" * 250
+        update_data = { content: long_content }
+        service_update = ServiceUpdate.new(update_data)
+
+        expect(service_update.summary_text).to eq("#{'A' * 200}...")
+      end
+    end
+  end
+
+  describe ".recent_updates" do
     around do |example|
       Timecop.freeze(2021, 10, 4) do
         example.run
       end
     end
 
-    it "returns all item within the last month" do
-      su = ServiceUpdate.recent_updates
+    it "returns items within the last month" do
+      updates = ServiceUpdate.recent_updates
 
-      expect(su.first.title).to eql("Most recent item")
-      expect(su.first.content).to eql("Ths is also another **Markdown** content.")
-      expect(su.first.date).to eql("2021-09-21")
-      expect(su.last.title).to eql("Second most recent item")
-      expect(su.last.content).to eql("Ths is another **Markdown** content.")
-      expect(su.last.date).to eql("2021-09-17")
+      expect(updates.first.title).to eql("Most recent item")
+      expect(updates.last.title).to eql("Second most recent item")
+      expect(updates.count).to eq(2)
     end
   end
 end

--- a/spec/models/service_update_spec.rb
+++ b/spec/models/service_update_spec.rb
@@ -7,17 +7,17 @@ describe ServiceUpdate do
     allow(YAML).to receive(:load_file).and_return(
       [
         {
-          date: "2021-09-21",
+          date: "2025-01-21",
           title: "Most recent item",
           content: "This is also another **Markdown** content.",
         },
         {
-          date: "2021-09-17",
+          date: "2025-01-17",
           title: "Second most recent item",
           content: "This is another **Markdown** content.",
         },
         {
-          date: "2021-09-01",
+          date: "2025-01-01",
           title: "Lead and employing schools",
           content: "This is **Markdown** content.",
         },
@@ -31,7 +31,7 @@ describe ServiceUpdate do
 
       expect(updates.count).to be(3)
       expect(updates[0].title).to eql("Most recent item")
-      expect(updates[0].date).to eql("2021-09-21")
+      expect(updates[0].date).to eql("2025-01-21")
       expect(updates[1].title).to eql("Second most recent item")
       expect(updates[2].title).to eql("Lead and employing schools")
     end
@@ -111,7 +111,7 @@ describe ServiceUpdate do
 
   describe ".recent_updates" do
     around do |example|
-      Timecop.freeze(2021, 10, 4) do
+      Timecop.freeze(2025, 2, 4) do
         example.run
       end
     end

--- a/spec/models/service_update_spec.rb
+++ b/spec/models/service_update_spec.rb
@@ -80,6 +80,35 @@ describe ServiceUpdate do
     end
   end
 
+  describe "#summary_html" do
+    it "converts markdown summary to HTML with govuk-link classes" do
+      update_data = {
+        summary: "This is a [test link](https://example.com) in **bold** text",
+        content: "Some content",
+      }
+      service_update = ServiceUpdate.new(update_data)
+
+      html_output = service_update.summary_html
+
+      expect(html_output).to include('href="https://example.com" class="govuk-link"')
+      expect(html_output).to include("test link")
+      expect(html_output).to include("<strong>bold</strong>")
+      expect(html_output).to be_html_safe
+    end
+
+    it "falls back to content when no summary is present" do
+      update_data = { content: "This is **markdown** content with a [link](https://example.com)" }
+      service_update = ServiceUpdate.new(update_data)
+
+      html_output = service_update.summary_html
+
+      expect(html_output).to include("<strong>markdown</strong>")
+      expect(html_output).to include('href="https://example.com" class="govuk-link"')
+      expect(html_output).to include(">link<")
+      expect(html_output).to be_html_safe
+    end
+  end
+
   describe ".recent_updates" do
     around do |example|
       Timecop.freeze(2021, 10, 4) do


### PR DESCRIPTION
### Context

[Trello Ticket](https://trello.com/c/WieebKrO/8630-implement-new-news-service-updates-front-end)

With the new role of communicating changes to the sector, we need a means for communications to persist.

Part of the solution is to direct users from email notifications containing high-level information to the Register News and Updates section for more comprehensive content. Currently, that section is just a list of in-page links with short posts below.

We want to expand this to utilise a standard blog post format, similar to what is used via 11ty for the design histories.

### Changes proposed in this pull request

Updates the existing code to move the content to a show view

### Guidance to review

The review app can be used

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
