### PR TITLE
[8645] Update TRS Professional Statuses endpoint integration

### DIFF
--- a/app/lib/code_sets/trs.rb
+++ b/app/lib/code_sets/trs.rb
@@ -51,8 +51,8 @@ module CodeSets
     ROUTE_STATUSES = {
       "withdrawn" => "Withdrawn",
       "deferred" => "Deferred",
-      "awarded" => "Awarded",
-      "recommended_for_award" => "Awarded",
+      "awarded" => "Holds",
+      "recommended_for_award" => "Holds",
     }.freeze
 
     # Special case statuses based on state and route

--- a/app/lib/trs/params/professional_status.rb
+++ b/app/lib/trs/params/professional_status.rb
@@ -55,7 +55,7 @@ module Trs
 
       def params
         @params ||= {
-          "routeTypeId" => route_type_id,
+          "routeToProfessionalStatusTypeId" => route_to_professional_status_type_id,
           "status" => status,
           "awardedDate" => trainee.outcome_date&.to_date&.iso8601,
           "trainingStartDate" => trainee.itt_start_date&.iso8601 || trainee.trainee_start_date&.iso8601,
@@ -77,7 +77,7 @@ module Trs
         trainee.hesa_metadatum&.itt_qualification_aim || trainee.hesa_trainee_detail&.itt_qualification_aim
       end
 
-      def route_type_id
+      def route_to_professional_status_type_id
         ::CodeSets::Trs::ROUTE_TYPES[trainee.training_route]
       end
 

--- a/app/lib/trs/params/professional_status.rb
+++ b/app/lib/trs/params/professional_status.rb
@@ -57,7 +57,7 @@ module Trs
         @params ||= {
           "routeToProfessionalStatusTypeId" => route_to_professional_status_type_id,
           "status" => status,
-          "awardedDate" => trainee.outcome_date&.to_date&.iso8601,
+          "holdsFrom" => trainee.outcome_date&.to_date&.iso8601,
           "trainingStartDate" => trainee.itt_start_date&.iso8601 || trainee.trainee_start_date&.iso8601,
           "trainingEndDate" => trainee.itt_end_date&.iso8601 || trainee.estimated_end_date&.iso8601,
           "trainingSubjectReferences" => training_subject_references,

--- a/app/services/trs/update_professional_status.rb
+++ b/app/services/trs/update_professional_status.rb
@@ -45,7 +45,7 @@ module Trs
     end
 
     def update_professional_status
-      Client.put("/v3/persons/#{trainee.trn}/professional-statuses/#{trainee.slug}", body: payload.to_json)
+      Client.put("/v3/persons/#{trainee.trn}/routes-to-professional-statuses/#{trainee.slug}", body: payload.to_json)
     rescue Client::HttpError => e
       # If the error indicates the status is already awarded, consider this a success
       if ignorable_error?(e.message)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,7 +36,7 @@ dqt:
 trs:
   base_url: https://teacher-qualifications-api.education.gov.uk
   api_key: <get from secrets>
-  version: "20250425"
+  version: "20250627"
 
 azure:
   storage:

--- a/spec/lib/code_sets/trs_spec.rb
+++ b/spec/lib/code_sets/trs_spec.rb
@@ -15,11 +15,11 @@ module CodeSets
         end
 
         it "returns the correct status for awarded" do
-          expect(described_class.training_status("awarded", "school_direct")).to eq("Awarded")
+          expect(described_class.training_status("awarded", "school_direct")).to eq("Holds")
         end
 
         it "returns the correct status for recommended_for_award" do
-          expect(described_class.training_status("recommended_for_award", "teach_first")).to eq("Awarded")
+          expect(described_class.training_status("recommended_for_award", "teach_first")).to eq("Holds")
         end
       end
 

--- a/spec/lib/trs/params/professional_status_spec.rb
+++ b/spec/lib/trs/params/professional_status_spec.rb
@@ -95,7 +95,7 @@ module Trs
           let(:trainee) { create(:trainee, :provider_led_postgrad, :trn_received) }
 
           it "sets appropriate route type ID" do
-            expect(subject["routeTypeId"]).to eq(CodeSets::Trs::ROUTE_TYPES["provider_led_postgrad"])
+            expect(subject["routeToProfessionalStatusTypeId"]).to eq(CodeSets::Trs::ROUTE_TYPES["provider_led_postgrad"])
           end
         end
 
@@ -106,8 +106,8 @@ module Trs
           it "uses a different route type ID than provider led postgrad" do
             provider_led_params = described_class.new(trainee: provider_led_trainee).params
 
-            expect(subject["routeTypeId"]).to eq(CodeSets::Trs::ROUTE_TYPES["school_direct_tuition_fee"])
-            expect(subject["routeTypeId"]).not_to eq(provider_led_params["routeTypeId"])
+            expect(subject["routeToProfessionalStatusTypeId"]).to eq(CodeSets::Trs::ROUTE_TYPES["school_direct_tuition_fee"])
+            expect(subject["routeToProfessionalStatusTypeId"]).not_to eq(provider_led_params["routeToProfessionalStatusTypeId"])
           end
         end
 

--- a/spec/lib/trs/params/professional_status_spec.rb
+++ b/spec/lib/trs/params/professional_status_spec.rb
@@ -91,7 +91,7 @@ module Trs
           end
 
           it "includes awarded date" do
-            expect(subject["awardedDate"]).to eq(trainee.awarded_at.to_date.iso8601)
+            expect(subject["holdsFrom"]).to eq(trainee.awarded_at.to_date.iso8601)
           end
         end
 

--- a/spec/lib/trs/params/professional_status_spec.rb
+++ b/spec/lib/trs/params/professional_status_spec.rb
@@ -62,7 +62,7 @@ module Trs
         context "trainee is deferred" do
           let(:trainee) { create(:trainee, :deferred) }
 
-          it "sets the correcrt status" do
+          it "sets the correct status" do
             expect(subject["status"]).to eq("Deferred")
           end
         end
@@ -78,13 +78,17 @@ module Trs
         context "trainee is recommended for award" do
           let(:trainee) { create(:trainee, :recommended_for_award) }
 
-          it "sets the correcrt status" do
-            expect(subject["status"]).to eq("Awarded")
+          it "sets the correct status" do
+            expect(subject["status"]).to eq("Holds")
           end
         end
 
         context "trainee is awarded" do
           let(:trainee) { create(:trainee, :awarded) }
+
+          it "sets the correct status" do
+            expect(subject["status"]).to eq("Holds")
+          end
 
           it "includes awarded date" do
             expect(subject["awardedDate"]).to eq(trainee.awarded_at.to_date.iso8601)

--- a/spec/services/trs/update_professional_status_spec.rb
+++ b/spec/services/trs/update_professional_status_spec.rb
@@ -16,7 +16,7 @@ module Trs
       subject { described_class.call(trainee:) }
 
       it "submits the correct data to TRS" do
-        path = "/v3/persons/#{trainee.trn}/professional-statuses/#{trainee.slug}"
+        path = "/v3/persons/#{trainee.trn}/routes-to-professional-statuses/#{trainee.slug}"
         body = instance_of(String)
 
         expect(Client).to receive(:put).with(path, body:)
@@ -31,7 +31,7 @@ module Trs
         let(:trainee) { create(:trainee, :withdrawn) }
 
         it "makes a request to TRS" do
-          path = "/v3/persons/#{trainee.trn}/professional-statuses/#{trainee.slug}"
+          path = "/v3/persons/#{trainee.trn}/routes-to-professional-statuses/#{trainee.slug}"
           body = instance_of(String)
           expect(Client).to receive(:put).with(path, body:)
           subject


### PR DESCRIPTION
### Context

[8645-update-trs-professional-statuses-endpoint-integration](https://trello.com/c/E9nuRTUa/8645-update-trs-professional-statuses-endpoint-integration)

Refactor the integration with PUT `/v3/persons/<trn>/professional-statuses/<reference>` according to [20250627 ](https://github.com/DFE-Digital/teaching-record-system/blob/main/CHANGELOG.md#put-v3personstrnprofessional-statusesreference)

### Changes proposed in this pull request

* Change endpoint to routes-to-professional-statuses
* Replace routeTypeId with routeToProfessionalStatusTypeId
* Replace Awarded with Holds
* Replace awardedDate with holdsFrom

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
