### PR TITLE
[8644] 2025 cycle prep - set `productiondata` current cycle to 2025

### DIFF
--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -17,6 +17,16 @@ dfe_sign_in:
   # URL of the users profile
   profile: https://profile.signin.education.gov.uk
 
+current_recruitment_cycle_year: 2025
+current_default_course_year: 2025
+
+apply_applications:
+  import:
+    recruitment_cycle_years:
+      - 2025
+  create:
+    recruitment_cycle_year: 2025
+
 features:
   basic_auth: true
   sign_in_method: dfe-sign-in


### PR DESCRIPTION
### Context

In preparation for the next academic cycle we need to test the configuration for the next cycle in advance using the `productiondata` environment. This is part of a set of PRs that make the necessary changes.

Register's current academic cycle is configured in `Settings`.

### Changes proposed in this pull request

Update the settings for `productiondata` only to switch the current cycle to the 2025-26 academic year.

### Guidance to review

Is this configured anywhere else?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
