### PR TITLE
[8644] 2025 cycle prep - disable the `productiondata` DB sync

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -152,10 +152,11 @@ jobs:
     - name: Setup postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
 
-    - name: Restore backup to aks productiondata database
-      shell: bash
-      run: |
-        bin/konduit.sh -n bat-production -i ${{ env.BACKUP_FILE }} -c -t 7200 register-productiondata -- psql
+    # Temporarily disabled to support next academic year testing on productiondata
+    # - name: Restore backup to aks productiondata database
+    #   shell: bash
+    #   run: |
+    #     bin/konduit.sh -n bat-production -i ${{ env.BACKUP_FILE }} -c -t 7200 register-productiondata -- psql
 
     - name: Restore backup to aks analysis database
       shell: bash


### PR DESCRIPTION
### Context

In preparation for the next academic cycle we need to test the configuration for the next cycle in advance using the `productiondata` environment. This is part of a set of PRs that make the necessary changes.

Normally the `productiondata` database is restored from a `production` database backup overnight. We don't want that to happen while we are testing next academic year configuration.

### Changes proposed in this pull request

Comment out the Github workflow step that restores a `production` DB backup to `productiondata` every night.

### Guidance to review

Anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
