### PR TITLE
[8644] 2025 cycle prep - Enable background jobs on `productiondata`

### DIFF
--- a/terraform/aks/workspace-variables/productiondata.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata.tfvars.json
@@ -18,7 +18,7 @@
   "worker_apps": {
     "worker": {
       "startup_command": ["/bin/sh", "-c", "bundle exec sidekiq -C config/sidekiq.yml"],
-      "replicas": 0,
+      "replicas": 1,
       "memory_max": "1Gi"
     }
   },


### PR DESCRIPTION
### Context

In preparation for the next academic cycle we need to test the configuration for the next cycle in advance using the `productiondata` environment. This is part of a set of PRs that make the necessary changes.

Normally `productiondata` doesn't have a background processor working. To test the whole system properly this will need to be enabled as many application features depend on it.

### Changes proposed in this pull request

Scale productiondata `worker_apps` to have 1 replica (normally 0).

### Guidance to review

What are the dangers of doing this on a system that has a copy of some production data?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
