### PR TITLE
[8611] Fix error message for training_initiative inclusion

### DIFF
--- a/app/models/api/v2025_0_rc/trainee_attributes.rb
+++ b/app/models/api/v2025_0_rc/trainee_attributes.rb
@@ -138,7 +138,10 @@ module Api
         valid_values: RecruitsApi::CodeSets::Nationalities::MAPPING.keys,
       }, allow_blank: true
 
-      validates :training_initiative, api_inclusion: { in: ROUTE_INITIATIVES.keys }, allow_blank: true
+      validates :training_initiative, api_inclusion: {
+        in: ROUTE_INITIATIVES.keys,
+        valid_values: Hesa::CodeSets::TrainingInitiatives::MAPPING.keys,
+      }, allow_blank: true
 
       validates :trainee_disabilities_attributes, uniqueness: true
 

--- a/spec/models/api/v2025_0_rc/trainee_attributes_spec.rb
+++ b/spec/models/api/v2025_0_rc/trainee_attributes_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Api::V20250Rc::TraineeAttributes do
         .in_array(
           Hesa::CodeSets::TrainingInitiatives::MAPPING.values + [ROUTE_INITIATIVES_ENUMS[:no_initiative]],
         )
-        .with_message(/has invalid reference data value of '.*'/)
+        .with_message(/has invalid reference data value of '.*'. Valid values are #{Hesa::CodeSets::TrainingInitiatives::MAPPING.keys.map { |v| "'#{v}'" }.join(', ')}/)
     }
 
     describe "email" do


### PR DESCRIPTION
### Context

During testing of training initiative validation we spotted an issue with the validation error message for training_initiative inclusion. 

### Changes proposed in this pull request

We should include the list of HESA codes rather than Register values for training initiative.

Instead of:

```
has invalid reference data value of '000'. Valid values are 'future_teaching_scholars', 'maths_physics_chairs_programme_researchers_in_schools', 'now_teach', 'transition_to_teach', 'no_initiative', 'troops_to_teachers', 'veterans_teaching_undergraduate_bursary', 'international_relocation_payment', 'abridged_itt_course', 'primary_mathematics_specialist', 'additional_itt_place_for_pe_with_a_priority_subject'.
```

it should be:

```
has invalid reference data value of '000'. Valid values are '001', '009', '011', '019', '025', '026', '036'
```

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
