### PR TITLE
[8678] Set `same_site` on session cookie

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,7 @@ module RegisterTraineeTeachers
       key: "_register_trainee_teachers_session",
       httponly: true,
       secure: !Rails.env.local?,
-      same_site: :strict,
+      same_site: :lax,
     )
 
     config.i18n.load_path += Rails.root.glob("config/locales/**/*.yml")


### PR DESCRIPTION
### Context
This PR sets the `same_site: :strict` property on the Register on session cookie, as recommended during recent ITHC review

### Changes proposed in this pull request

Set `same_site: :lax` (previously not set). Setting `same_site: :string` breaks DfE Sign In due to a CSRF error in the login flow.

### Guidance to review
How do we make sure this hasn't broken anything? I've tested the review app and it seems fine. We've also tested on a DfE Sign-in environment (`staging`). Can you think of anything else?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
