### PR TITLE
[8712] - non_language_subject not defined error fix

### DIFF
--- a/app/forms/language_specialisms_form.rb
+++ b/app/forms/language_specialisms_form.rb
@@ -60,7 +60,7 @@ class LanguageSpecialismsForm < TraineeForm
   end
 
   def non_language_subject
-    @non_language_subject ||= (@trainee.published_course.subjects.map(&:name) - PUBLISH_MODERN_LANGUAGES).first
+    @non_language_subject ||= ((@trainee.published_course&.subjects&.map(&:name) || []) - PUBLISH_MODERN_LANGUAGES).first
   end
 
 private

--- a/app/forms/language_specialisms_form.rb
+++ b/app/forms/language_specialisms_form.rb
@@ -60,7 +60,9 @@ class LanguageSpecialismsForm < TraineeForm
   end
 
   def non_language_subject
-    @non_language_subject ||= ((@trainee.published_course&.subjects&.map(&:name) || []) - PUBLISH_MODERN_LANGUAGES).first
+    return nil unless @trainee.published_course&.subjects&.any?
+
+    @non_language_subject ||= (@trainee.published_course.subjects.map(&:name) - PUBLISH_MODERN_LANGUAGES).first
   end
 
 private


### PR DESCRIPTION
### Context

The trainee in [this ticket](https://trello.com/c/sjij95OA/8712-amendment-for-subject-on-qts) needs their course updated but are getting a "something went wrong" message. The error thrown can be [seen here](https://dfe-teacher-services.sentry.io/issues/6592903172/events/16113ea44ad24d9297d7475abe1fbc2b/?project=5552118).

### Changes proposed in this pull request

Guard clauses for the `non_language_subject` method.

### Guidance to review

I've tested updating the trainee using sanitised production data and was able to get through to the end of the form without an error.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
