### PR TITLE
[8710] Bug: Download CSV template link not working

### DIFF
--- a/app/controllers/bulk_update/add_trainees/empty_templates_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/empty_templates_controller.rb
@@ -2,7 +2,9 @@
 
 module BulkUpdate
   module AddTrainees
-    class EmptyTemplatesController < CsvDocs::BaseController
+    class EmptyTemplatesController < ApplicationController
+      skip_before_action :authenticate
+
       FILE = "bulk_create_trainee.csv"
 
       def show

--- a/app/controllers/csv_docs/base_controller.rb
+++ b/app/controllers/csv_docs/base_controller.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module CsvDocs
-  class BaseController < ::ApplicationController
-    skip_before_action :authenticate
-    before_action { require_feature_flag(:bulk_add_trainees) }
-  end
-end

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -61,7 +61,7 @@ feature "bulk add trainees" do
         given_i_am_authenticated
       end
 
-      scenario "the bulk add trainees page is not-visible when feature flag is off" do
+      scenario "the bulk add trainees page is not-visible" do
         when_i_visit_the_bulk_update_index_page
         then_i_cannot_see_the_bulk_add_trainees_link
         and_i_cannot_navigate_directly_to_the_bulk_add_trainees_page

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -54,16 +54,26 @@ feature "bulk add trainees" do
   end
 
   context "when the feature flag is off", feature_bulk_add_trainees: false do
-    let(:user) { create(:user, :hei) }
+    context "when the User is signed in as an HEI Provider" do
+      let(:user) { create(:user, :hei) }
 
-    before do
-      given_i_am_authenticated
+      before do
+        given_i_am_authenticated
+      end
+
+      scenario "the bulk add trainees page is not-visible when feature flag is off" do
+        when_i_visit_the_bulk_update_index_page
+        then_i_cannot_see_the_bulk_add_trainees_link
+        and_i_cannot_navigate_directly_to_the_bulk_add_trainees_page
+      end
     end
 
-    scenario "the bulk add trainees page is not-visible when feature flag is off" do
-      when_i_visit_the_bulk_update_index_page
-      then_i_cannot_see_the_bulk_add_trainees_link
-      and_i_cannot_navigate_directly_to_the_bulk_add_trainees_page
+    context "when the User is not signed in", js: true do
+      scenario "they can download the empty CSV template from the documentation page" do
+        when_i_visit_the_csv_docs_home_path
+        when_i_click_the_documentation_empty_csv_link
+        then_i_receive_the_empty_csv_file
+      end
     end
   end
 


### PR DESCRIPTION
### Context

The CSV template download link is not working from the CSV docs page in production

### Changes proposed in this pull request

* Remove the feature flag check for the CSV template download
* Remove unused controller

### Guidance to review

Anything missing?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
