### PR TITLE
[8719] - additional country mapping for professional status params

### DIFF
--- a/app/lib/trs/params/professional_status.rb
+++ b/app/lib/trs/params/professional_status.rb
@@ -43,6 +43,9 @@ module Trs
         "Jarvis Island" => "US",
         "Kingman Reef" => "US",
         "Palmyra Atoll" => "US",
+
+        # Taiwan - map to China
+        "Taiwan" => "CH",
       }.freeze
 
       def initialize(trainee:)

--- a/app/lib/trs/params/professional_status.rb
+++ b/app/lib/trs/params/professional_status.rb
@@ -45,7 +45,7 @@ module Trs
         "Palmyra Atoll" => "US",
 
         # Taiwan - map to China
-        "Taiwan" => "CH",
+        "Taiwan" => "CN",
       }.freeze
 
       def initialize(trainee:)

--- a/spec/lib/trs/params/professional_status_spec.rb
+++ b/spec/lib/trs/params/professional_status_spec.rb
@@ -143,8 +143,8 @@ module Trs
         context "trainee is iQTS in Taiwan" do
           let(:trainee) { create(:trainee, :iqts, :trn_received, iqts_country: "Taiwan") }
 
-          it "maps Taiwan to CH for country code" do
-            expect(subject["trainingCountryReference"]).to eq("CH")
+          it "maps Taiwan to CN for country code" do
+            expect(subject["trainingCountryReference"]).to eq("CN")
           end
         end
 

--- a/spec/lib/trs/params/professional_status_spec.rb
+++ b/spec/lib/trs/params/professional_status_spec.rb
@@ -140,6 +140,14 @@ module Trs
           end
         end
 
+        context "trainee is iQTS in Taiwan" do
+          let(:trainee) { create(:trainee, :iqts, :trn_received, iqts_country: "Taiwan") }
+
+          it "maps Taiwan to CH for country code" do
+            expect(subject["trainingCountryReference"]).to eq("CH")
+          end
+        end
+
         context "trainee is iQTS with a territory country that's in the fallback mapping" do
           let(:trainee) { create(:trainee, :iqts, :trn_received, iqts_country: "Abu Dhabi") }
 


### PR DESCRIPTION
### Context

A trainee record is stuck in pending due to an unsupported country code. See [this ticket](https://trello.com/c/I6Jx4rFx/8719-record-stuck-in-pending-awards-queue)

### Changes proposed in this pull request

Adds an additional mapping to `TERRITORY_FALLBACK_MAPPING`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
