### PR TITLE
[8743] - Enable teacher_degree_apprenticeship in prod/prod-data

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -118,15 +118,15 @@ recruits_api:
   base_url: "https://www.apply-for-teacher-training.service.gov.uk/register-api"
   auth_token: "auth-token-from-env"
 
-current_recruitment_cycle_year: 2024
-current_default_course_year: 2024
+current_recruitment_cycle_year: 2025
+current_default_course_year: 2025
 
 apply_applications:
   import:
     recruitment_cycle_years:
-      - 2024
+      - 2025
   create:
-    recruitment_cycle_year: 2024
+    recruitment_cycle_year: 2025
 
 jobs:
   poll_delay_hours: 1

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -39,6 +39,7 @@ features:
     school_direct_salaried: true
     school_direct_tuition_fee: true
     iqts: true
+    teacher_degree_apprenticeship: true
   google:
     send_data_to_big_query: true
   integrate_with_dqt: false

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -47,6 +47,7 @@ features:
     school_direct_salaried: true
     school_direct_tuition_fee: true
     iqts: true
+    teacher_degree_apprenticeship: true
   google:
     send_data_to_big_query: false
   integrate_with_dqt: false

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -17,16 +17,6 @@ dfe_sign_in:
   # URL of the users profile
   profile: https://profile.signin.education.gov.uk
 
-current_recruitment_cycle_year: 2025
-current_default_course_year: 2025
-
-apply_applications:
-  import:
-    recruitment_cycle_years:
-      - 2025
-  create:
-    recruitment_cycle_year: 2025
-
 features:
   basic_auth: true
   sign_in_method: dfe-sign-in

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -112,8 +112,8 @@ module TeacherTrainingApi
           it_behaves_like training_route_and_course_program_type_mapping, 2024, "provider_led_postgrad", %w[scitt_programme scitt_programme higher_education_programme]
           it_behaves_like training_route_and_course_program_type_mapping, 2024, "pg_teaching_apprenticeship", ["pg_teaching_apprenticeship"]
 
-          context "program type is unmapped" do
-            let(:course_attributes) { { program_type: "you_wat_now" } }
+          context "training_route is unmapped" do
+            let(:course_attributes) { { training_route: "you_wat_now" } }
 
             it "raises validation error" do
               expect { subject }.to raise_error(ActiveRecord::RecordInvalid)

--- a/spec/support/api_stubs/teacher_training_api.rb
+++ b/spec/support/api_stubs/teacher_training_api.rb
@@ -41,6 +41,8 @@ module ApiStubs
           level: "secondary",
           name: "Physical Education",
           program_type: "scitt_programme",
+          training_route: "fee_funded_initial_teacher_training",
+          degree_type: "postgraduate",
           qualifications: %w[qts pgce],
           scholarship_amount: nil,
           study_mode: "full_time",


### PR DESCRIPTION
### Context

[Trello Ticket](https://trello.com/c/VF0A5kf9/8743-remove-feature-flag-from-teacher-degree-apprenticeship-route)

We need to enable the `teacher_degree_apprenticeship` route for 2025/26

### Changes proposed in this pull request

Sets flags to true in `production` and `productiondata`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
