### PR TITLE
[8753] Add training initiatives etc. for 2026-27

### DIFF
--- a/config/initializers/training_routes/funding/2026_2027/training_initiatives.rb
+++ b/config/initializers/training_routes/funding/2026_2027/training_initiatives.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+TRAINING_INITIATIVES_2026_TO_2027 = %w[
+  international_relocation_payment
+  now_teach
+  veterans_teaching_undergraduate_bursary
+  primary_mathematics_specialist
+].freeze


### PR DESCRIPTION
### Context
Several tests are failing today due to the new academic year beginning today.

This PR is an attempt to fix the `features/end_to_end` specs for USE_NEXT_ACADEMIC_YEAR=true.

### Changes proposed in this pull request
Just made a copy of the `training_routes/funding/2025_2026/training_initiatives` config for 26-27. 

### Guidance to review

For now I've not added 26-27 config for bursaries, grants and scholarship config found in the same directory. These will have to be tackled later when we have the correct numbers presumably.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
