### PR TITLE
Set BigQuery credentials to send events to Disaster Recovery test project

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -19,15 +19,15 @@ DfE::Analytics.configure do |config|
 
   # The name of the BigQuery table we’re writing to.
   #
-  config.bigquery_table_name = Settings.google.big_query.table_name
+  config.bigquery_table_name = "events"
 
   # The name of the BigQuery project we’re writing to.
   #
-  config.bigquery_project_id = Settings.google.big_query.project_id
+  config.bigquery_project_id = "data-insights-test-462115"
 
   # The name of the BigQuery dataset we're writing to.
   #
-  config.bigquery_dataset = Settings.google.big_query.dataset
+  config.bigquery_dataset = "register_events_dr_test_qa"
 
   # Passed directly to the retries: option on the BigQuery client
   #
@@ -53,4 +53,20 @@ DfE::Analytics.configure do |config|
   # instead of the BigQuery API JSON Key. Note that this also will also
   # use a new version of the BigQuery streaming APIs.
   config.azure_federated_auth = true
+
+  # Google cloud credentials for federated auth
+  config.google_cloud_credentials = {
+    universe_domain: "googleapis.com",
+    type: "external_account",
+    audience: "//iam.googleapis.com/projects/242041527027/locations/global/workloadIdentityPools/azure-cip-identity-pool/providers/azure-cip-oidc-provider",
+    subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
+    token_url: "https://sts.googleapis.com/v1/token",
+    credential_source: {
+      url: "https://login.microsoftonline.com/9c7d9dd3-840c-4b3f-818e-552865082e16/oauth2/v2.0/token",
+    },
+    service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/register-bigquery-dr-test-qa@data-insights-test-462115.iam.gserviceaccount.com:generateAccessToken",
+    service_account_impersonation: {
+      token_lifetime_seconds: 3600,
+    },
+  }
 end


### PR DESCRIPTION
### Context

BigQuery Disaster Recovery Test review env.

### Changes proposed in this pull request

Change BigQuery credentials to send events to Disaster Recovery test project

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
