### PR TITLE
[8681] Limit provider checks to production

### DIFF
--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -56,7 +56,7 @@ sync_hesa_students:
   class: "Hesa::SyncStudentsJob"
   queue: hesa
 check_publish_providers:
-  cron: "0 6 * * *" # Every day at 06:00.
+  cron: <%= '"0 6 * * *" # Every day at 06:00.' if ENV.fetch("RAILS_ENV") == "production" %>
   class: "TeacherTrainingApi::PublishProviderCheckerJob"
   queue: default
 upload_trn_file_to_hesa:


### PR DESCRIPTION
### Context
This PR is a follow-up to https://github.com/DFE-Digital/register-trainee-teachers/pull/5444

The new automated provider checks are scheduled to run on Sidekiq nightly in all environments. They are generate quite a lot of noise in the Register support Slack channel.

### Changes proposed in this pull request
The checks are only really useful on `production` so we think it makes sense to add a conditional to the cron table to only run the job on production.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
