### PR TITLE
[8753] Remove long asset paths from views

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,14 +7,14 @@
     <%= canonical_tag %>
 
     <%= tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
-    <%= tag.meta(property: "og:image", content: image_path("govuk-frontend/dist/govuk/assets/rebrand/images/govuk-opengraph-image.png")) %>
+    <%= tag.meta(property: "og:image", content: image_path("rebrand/images/govuk-opengraph-image.png")) %>
     <%= tag.meta(name: "theme-color", content: "#0b0c0c") %>
     <%= tag.meta(name: "format-detection", content: "telephone=no") %>
 
-    <%= favicon_link_tag image_path("govuk-frontend/dist/govuk/assets/rebrand/images/favicon.ico"), type: nil, sizes: "48x48" %>
-    <%= favicon_link_tag image_path("govuk-frontend/dist/govuk/assets/rebrand/images/favicon.svg"), type: "image/svg+xml", sizes: "any" %>
-    <%= favicon_link_tag image_path("govuk-frontend/dist/govuk/assets/rebrand/images/govuk-icon-mask.svg"), rel: "mask-icon", color: "#0b0c0c", type: nil %>
-    <%= favicon_link_tag image_path("govuk-frontend/dist/govuk/assets/rebrand/images/govuk-icon-180.png"), rel: "apple-touch-icon", type: nil %>
+    <%= favicon_link_tag image_path("rebrand/images/favicon.ico"), type: nil, sizes: "48x48" %>
+    <%= favicon_link_tag image_path("rebrand/images/favicon.svg"), type: "image/svg+xml", sizes: "any" %>
+    <%= favicon_link_tag image_path("rebrand/images/govuk-icon-mask.svg"), rel: "mask-icon", color: "#0b0c0c", type: nil %>
+    <%= favicon_link_tag image_path("rebrand/images/govuk-icon-180.png"), rel: "apple-touch-icon", type: nil %>
 
     <%= stylesheet_link_tag "accessible-autocomplete/dist/accessible-autocomplete.min" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -16,6 +16,7 @@ Rails.application.config.assets.version = "1.1"
 # govuk-frontend related assets
 Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets/rebrand/images")
 Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets/fonts")
+Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets")
 
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join("node_modules")


### PR DESCRIPTION
### Context

Since the recent GOV.UK rebrand we have seen intermittent 404 errors like this one:

https://dfe-teacher-services.sentry.io/issues/6769193427/events/b99d9a2c3a464367833b70893ed6d6de/?project=5552118

They typically happen immediately after a deploy, though not on every deploy.

### Changes proposed in this pull request

We are using a full path for several of the assets included in our main `application.html.erb` layout. This is a bit non-standard. This PR adds a path to `config.asset.paths` to follow a more conventional.

### Guidance to review

To attempt to reproduce the circumstances where we see this issue this potential fix will need to be tested manually on the review app and potentially another environment at the point of deploy.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
