### PR TITLE
[8684] Scale up `staging` to match `production`

### DIFF
--- a/terraform/aks/workspace-variables/staging.tfvars.json
+++ b/terraform/aks/workspace-variables/staging.tfvars.json
@@ -7,19 +7,19 @@
   "cluster": "test",
   "namespace": "bat-staging",
   "db_sslmode": "prefer",
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
   "main_app": {
     "main": {
       "startup_command": ["/bin/sh", "-c", "STATEMENT_TIMEOUT=90s bundle exec rails db:migrate && unset STATEMENT_TIMEOUT && bundle exec rails server -b 0.0.0.0"],
       "probe_path": "/ping",
-      "replicas": 2,
+      "replicas": 4,
       "memory_max": "1536Mi"
     }
   },
   "worker_apps": {
     "worker": {
       "startup_command": ["/bin/sh", "-c", "bundle exec sidekiq -C config/sidekiq.yml"],
-      "replicas": 1,
+      "replicas": 2,
       "memory_max": "3Gi"
     }
   },


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/UpIFKSkY/8684-spike-carry-out-load-testing-part-2)

### Changes proposed in this pull request

* Scale up `staging` temporarily to match `production` for load testing

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
