### PR TITLE
Add statuscake apex ssl monitors

### DIFF
--- a/terraform/aks/statuscake.tf
+++ b/terraform/aks/statuscake.tf
@@ -3,7 +3,8 @@ module "statuscake" {
 
   source = "./vendor/modules/aks//monitoring/statuscake"
 
-  uptime_urls    = each.value.website_url
-  contact_groups = each.value.contact_group
-  trigger_rate   = each.value.trigger_rate
+  uptime_urls    = try(each.value.website_url, null)
+  contact_groups = try(each.value.contact_group, null)
+  trigger_rate   = try(each.value.trigger_rate, null)
+  ssl_urls       = try(each.value.ssl_urls, null)
 }

--- a/terraform/aks/workspace-variables/production.tfvars.json
+++ b/terraform/aks/workspace-variables/production.tfvars.json
@@ -47,11 +47,22 @@
   "statuscake_alerts": {
     "dependencies": {
       "website_url": [ "https://www.register-trainee-teachers.service.gov.uk/healthcheck" ],
+      "ssl_urls": [],
       "contact_group": [309326,282453],
       "trigger_rate": 1
     },
     "ping": {
       "website_url": [ "https://www.register-trainee-teachers.service.gov.uk/ping" ],
+      "ssl_urls": [],
+      "contact_group": [309326,282453],
+      "trigger_rate": 0
+    },
+    "ssl": {
+      "website_url": [],
+      "ssl_urls": [
+        "https://register-trainee-teachers.service.gov.uk",
+        "https://register-trainee-teachers.education.gov.uk"
+      ],
       "contact_group": [309326,282453],
       "trigger_rate": 0
     }


### PR DESCRIPTION
### Context

We aren't monitoring the apex ssl certificates

### Changes proposed in this pull request

Add monitoring

### Guidance to review

make env deploy-plan 
- production should add 2 ssl monitors, other envs no change

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
