### PR TITLE
[SPIKE] Add an option to toggle 'enhanced' errors in API responses

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -71,6 +71,11 @@ module Api
       auth_token.update_last_used_at!
     end
 
+    def enhanced_errors?
+      request.headers["ENHANCED_ERRORS"] == "true"
+    end
+    alias_method :enhanced_errors, :enhanced_errors?
+
   private
 
     alias_method :version, :current_version

--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -38,7 +38,7 @@ module Api
       trainee_attributes = trainee_attributes_service.new(hesa_mapped_params)
 
       render(
-        CreateTrainee.call(current_provider:, trainee_attributes:, version:),
+        CreateTrainee.call(current_provider:, trainee_attributes:, version:, enhanced_errors:),
       )
     end
 

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -5,6 +5,16 @@ module ApiHelper
     {
       "ACCEPT" => "application/json",
       "CONTENT_TYPE" => "application/json",
+    }.merge(enhanced_errors_headers)
+  end
+
+private
+
+  def enhanced_errors_headers
+    return {} unless defined?(enhanced_errors) && enhanced_errors
+
+    {
+      "ENHANCED_ERRORS" => "true",
     }
   end
 end


### PR DESCRIPTION
### Context

Prompted by a request by a vendor this PR sketches out an implementation for toggling the errors to a different more structured form

### Changes proposed in this pull request

This feature is implemented as an opt-in, to maintain backwards compatibility. To switch it on set the `ENHANCED_ERRORS` header to `"true"`. There are other ways to do this of course.

### Guidance to review

#### Simple case (top-level attributes only)

Before:

```
["provider_trainee_id is too long (maximum is 50 characters)"]
```

After:

```
{"provider_trainee_id" => ["is too long (maximum is 50 characters)"]}
```

#### More complex case (errors on nested attributes)

Before:
```
{"message" => "Validation failed: 3 errors prohibited this trainee from being saved",
 "errors" =>
  ["graduation_year must be entered if specifying a previous UK degree or non-UK degree",
   "subject must be entered if specifying a previous UK degree or non-UK degree",
   "non_uk_degree must be entered if specifying a previous non-UK degree"]}
```

After:
```
{"message" => "Validation failed: 1 error prohibited this trainee from being saved",
 "errors" =>
  {"degrees_attributes" =>
    ["graduation_year must be entered if specifying a previous UK degree or non-UK degree",
     "subject must be entered if specifying a previous UK degree or non-UK degree",
     "non_uk_degree must be entered if specifying a previous non-UK degree"]}}
```

Here we are only structuring one level so the error messages on the degree model embed the attribute name like they did originally just organised under a `degrees_attributes` key.

Note that I've only tried to apply this change to the 'create trainee' endpoint.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
