### PR TITLE
[8775] Fix broken links in privacy notice

### DIFF
--- a/app/views/pages/privacy_notice.md
+++ b/app/views/pages/privacy_notice.md
@@ -3,6 +3,8 @@ page_title: Register trainee teachers (Register) privacy notice
 title: Register trainee teachers (Register) privacy notice 
 ---
 
+<p class="govuk-body">Last updated 13 August 2025</p>
+
 <p class='govuk-body'>
   Read the <a class="govuk-link" target="_blank" href="https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-so-we-can-support-your-teaching-career">Privacy information: education providers’ workforce, including teachers (opens in new tab)</a>.
 </p>


### PR DESCRIPTION
### Context

DfE's [_Privacy information: education providers’ workforce, including teachers_](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-so-we-can-support-your-teaching-career) Web page was updated in March and several of the anchors that we linked to from the Register privacy notice were broken as a result. This PR attempts to fix that.

### Changes proposed in this pull request
Replace the existing privacy notice with the new content and links:

<img width="1500" height="934" alt="image" src="https://github.com/user-attachments/assets/53a2bdfb-afbf-42c0-856b-b049e85eab03" />


### Guidance to review

Do the links work?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
