### PR TITLE
[8735] Skip precompiled asset checks in prod etc.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,4 +88,7 @@ Rails.application.configure do
   )
 
   config.active_record.logger = nil # Don't log SQL in production
+
+  # To stop missing precompiled assets causing 500 errors in production
+  config.assets.check_precompiled_asset = false
 end


### PR DESCRIPTION
### Context

We have seen occasional asset not precompiled `Sprockets::Rails::Helper::AssetNotPrecompiledError` errors on `production`, `sandbox` and `csv-sandbox`. e.g. https://dfe-teacher-services.sentry.io/issues/6796246185/events/f12485002a3146379500190ab389680a/

Twice this has triggered production incidents.

### Changes proposed in this pull request

Drop the checks for precompiled assets. 

### Guidance to review

This will apply to `production`, `productiondata`, `sandbox` and `csv-sandbox`. It is hard to test the full impact because the issue we are addressing is intermittent. We can deploy to `productiondata` initially before merging and deploying to the other environments.

Drawbacks of this approach:

- it masks the errors that we've been seeing so we won't necessarily be aware if assets are missing. 

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
