### PR TITLE
[8735] Add explicit link statements for missing precompiled images

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,7 +3,7 @@
 //= link_tree ../images
 
 // govuk-frontend assets
-//= link govuk-opengraph-image.png
+//= link favicon.ico
 //= link favicon.svg
 //= link govuk-crest.svg
 //= link govuk-icon-180.png
@@ -11,4 +11,8 @@
 //= link govuk-icon-512.png
 //= link govuk-icon-mask.svg
 //= link govuk-opengraph-image.png
-//= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/fonts
+//
+//= link bold-affa96571d-v2.woff
+//= link bold-b542beb274-v2.woff2
+//= link light-94a07e06a1-v2.woff2
+//= link light-f591b13f7d-v2.woff


### PR DESCRIPTION
### Context

We have seen occasional asset not precompiled `Sprockets::Rails::Helper::AssetNotPrecompiledError` errors on `production`, `sandbox` and `csv-sandbox`. e.g. https://dfe-teacher-services.sentry.io/issues/6796246185/events/f12485002a3146379500190ab389680a/

Twice this has triggered production incidents.

### Changes proposed in this pull request

Link individual `govuk-frontend` images rather than using `link_directory`. 

### Guidance to review

We should test this on any `productiondata` before merging.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
