### PR TITLE
[8735] Remove `rebrand/images/` from image paths

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,14 +7,14 @@
     <%= canonical_tag %>
 
     <%= tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
-    <%= tag.meta(property: "og:image", content: image_path("rebrand/images/govuk-opengraph-image.png")) %>
+    <%= tag.meta(property: "og:image", content: image_path("govuk-opengraph-image.png")) %>
     <%= tag.meta(name: "theme-color", content: "#0b0c0c") %>
     <%= tag.meta(name: "format-detection", content: "telephone=no") %>
 
-    <%= favicon_link_tag image_path("rebrand/images/favicon.ico"), type: nil, sizes: "48x48" %>
-    <%= favicon_link_tag image_path("rebrand/images/favicon.svg"), type: "image/svg+xml", sizes: "any" %>
-    <%= favicon_link_tag image_path("rebrand/images/govuk-icon-mask.svg"), rel: "mask-icon", color: "#0b0c0c", type: nil %>
-    <%= favicon_link_tag image_path("rebrand/images/govuk-icon-180.png"), rel: "apple-touch-icon", type: nil %>
+    <%= favicon_link_tag image_path("favicon.ico"), type: nil, sizes: "48x48" %>
+    <%= favicon_link_tag image_path("favicon.svg"), type: "image/svg+xml", sizes: "any" %>
+    <%= favicon_link_tag image_path("govuk-icon-mask.svg"), rel: "mask-icon", color: "#0b0c0c", type: nil %>
+    <%= favicon_link_tag image_path("govuk-icon-180.png"), rel: "apple-touch-icon", type: nil %>
 
     <%= stylesheet_link_tag "accessible-autocomplete/dist/accessible-autocomplete.min" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>


### PR DESCRIPTION
### Context

We have seen occasional asset not precompiled `Sprockets::Rails::Helper::AssetNotPrecompiledError` errors on `production`, `sandbox` and `csv-sandbox`. e.g. https://dfe-teacher-services.sentry.io/issues/6796246185/events/f12485002a3146379500190ab389680a/

Twice this has triggered production incidents.

### Changes proposed in this pull request

This PR just simplifies the image paths for `govuk-frontend` assets.

### Guidance to review

I've tested locally and on a review app. Should deploy temporarily to `productiondata` before merging and deploying to production.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
