### PR TITLE
[8819] - SchoolDataDownload erroring

### DIFF
--- a/app/services/school_data/school_data_downloader.rb
+++ b/app/services/school_data/school_data_downloader.rb
@@ -22,7 +22,7 @@ module SchoolData
     end
 
     def csv_url
-      format(Settings.school_data.downloader.base_url, Date.current.strftime("%Y%m%d"))
+      format(Settings.school_data.downloader.base_url, 1.day.ago.strftime("%Y%m%d"))
     end
   end
 end


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/KxdRCcTv/8819-school-data-download-erroring)
[Slack thread here](https://ukgovernmentdfe.slack.com/archives/C023EC79M6Y/p1754188238213549)

This relates to the error we are seeing when the SchoolDataDownload job runs Sunday AM.

### Changes proposed in this pull request

Instead of grabbing today's CSV, we grab yesterday's as we can be more confident it has been generated on GIAS’s side.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
