### PR TITLE
[8715] Load test CSV bulk add trainees

### DIFF
--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -74,12 +74,13 @@ namespace :load_test do
         end
       end
 
-      tempfile = Tempfile.new(["load_test", "csv"])
+      filename = "load_test.csv"
+      tempfile = Tempfile.new(filename.split("."))
       tempfile.write(content)
       tempfile.rewind
 
       uploaded_file = ActionDispatch::Http::UploadedFile.new(
-        filename: "load_test.csv",
+        filename: filename,
         tempfile: tempfile,
         type: "text/csv",
       )

--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -74,8 +74,6 @@ namespace :load_test do
         end
       end
 
-      file_path = Rails.root.join("tmp/load_test.csv")
-
       tempfile = Tempfile.new(["load_test", "csv"])
       tempfile.write(content)
       tempfile.rewind

--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -4,7 +4,7 @@ unless Rails.env.production?
   namespace :load_test do
     desc "Create multiple bulk update trainee uploads in the background"
     task csv_trainee_upload: :environment do
-      number_of_uploads = ENV.fetch("UPLOADS", 2).to_i
+      number_of_uploads = ENV.fetch("UPLOADS", 1).to_i
       rows              = ENV.fetch("ROWS", 100).to_i
 
       if number_of_uploads.zero? || rows.zero?

--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -3,8 +3,12 @@
 namespace :load_test do
   desc "Create multiple bulk update trainee uploads in the background"
   task csv_trainee_upload: :environment do
-    number_of_uploads = ENV["UPLOADS"].to_i || 2
-    rows              = ENV["ROWS"].to_i || 100
+    number_of_uploads = ENV.fetch("UPLOADS", 2).to_i
+    rows              = ENV.fetch("ROWS", 100).to_i
+
+    if number_of_uploads.zero? || rows.zero?
+      raise "Arguments must be Integers"
+    end
 
     upload_ids = []
 

--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+namespace :load_test do
+  desc "Create multiple bulk update trainee uploads in the background"
+  task csv_trainee_upload: :environment do
+    number_of_uploads = ENV["UPLOADS"].to_i || 2
+    rows              = ENV["ROWS"].to_i || 100
+
+    upload_ids = []
+
+    data = -> do
+      {
+        "Provider Trainee ID" => "99157234/2/01",
+        "Application ID" => nil,
+        "HESA ID" => "0310261553101",
+        "First Names" => "John",
+        "Last Name" => SecureRandom.alphanumeric,
+        "Previous Last Name" => "Smith",
+        "Date of Birth" => "1990-01-01",
+        "NI Number" => nil,
+        "Sex" => "10",
+        "Email" => "john.doe@example.com",
+        "Nationality" => "GB",
+        "Ethnicity" => nil,
+        "Disability 1" => "58",
+        "Disability 2" => "57",
+        "Disability 3" => nil,
+        "Disability 4" => nil,
+        "Disability 5" => nil,
+        "Disability 6" => nil,
+        "Disability 7" => nil,
+        "Disability 8" => nil,
+        "Disability 9" => nil,
+        "ITT Aim" => "202",
+        "Training Route" => "11",
+        "Qualification Aim" => "001",
+        "Course Subject One" => "100346",
+        "Course Subject Two" => nil,
+        "Course Subject Three" => nil,
+        "Study Mode" => "63",
+        "ITT Start Date" => "2024-08-01",
+        "ITT End Date" => "2025-08-01",
+        "Course Age Range" => "13918",
+        "Course Year" => "2012",
+        "Lead Partner URN" => nil,
+        "Employing School URN" => nil,
+        "Trainee Start Date" => "2024-08-01",
+        "PG Apprenticeship Start Date" => "2024-03-11",
+        "Fund Code" => "2",
+        "Funding Method" => "6",
+        "Training Initiative" => nil,
+        "Additional Training Initiative" => nil,
+        "Placement 1 URN" => "900020",
+        "Placement 2 URN" => nil,
+        "Placement 3 URN" => nil,
+        "UK Degree Type" => "083",
+        "Non-UK Degree Type" => nil,
+        "Degree Subject" => "100485",
+        "Degree Grade" => "02",
+        "Degree Graduation Year" => "2012",
+        "Awarding Institution" => "0117",
+        "Degree Country" => nil
+      }
+    end
+
+    start_time = Time.current
+
+    number_of_uploads.times do
+      content = CSV.generate do |csv|
+        csv << data.call.keys
+
+        rows.times do
+          csv << data.call.values
+        end
+      end
+
+      file_path = Rails.root.join("tmp/load_test.csv")
+
+      tempfile = Tempfile.new(["load_test", "csv"])
+      tempfile.write(content)
+      tempfile.rewind
+
+      uploaded_file = ActionDispatch::Http::UploadedFile.new(
+        filename: "load_test.csv",
+        tempfile: tempfile,
+        type: "text/csv",
+      )
+
+      bulk_add_trainee_upload_form = BulkUpdate::BulkAddTraineesUploadForm.new(
+        provider: Provider.last,
+        file: uploaded_file,
+      )
+
+      if bulk_add_trainee_upload_form.save
+        BulkUpdate::BulkAddTraineesImportRowsForm.new(
+          upload: bulk_add_trainee_upload_form.upload,
+        ).save
+
+        upload_ids << bulk_add_trainee_upload_form.upload
+      else
+        raise "Something went wrong", bulk_add_trainee_upload_form.errors.full_messages
+      end
+    end
+
+    uploads = BulkUpdate::TraineeUpload.where(id: upload_ids)
+
+    puts "***Uploads validating***"
+
+    while uploads.reload.exists?(status: :pending)
+      print "."
+
+      sleep 2
+    end
+
+    puts ""
+    puts "***Uploads validated***"
+
+    non_validated_uploads = uploads.where.not(status: :validated)
+
+    if non_validated_uploads.any?
+      raise "The following upload ids are not valid uploads #{non_validated_uploads.pluck(:id)}"
+    end
+
+    uploads.each do |upload|
+      bulk_add_trainee_submit_form = BulkUpdate::BulkAddTraineesSubmitForm.new(
+        upload: upload,
+      )
+
+      if bulk_add_trainee_submit_form.save
+        puts "***Upload #{bulk_add_trainee_submit_form.upload.id} in progress***"
+      else
+        raise "Something went wrong with upload #{bulk_add_trainee_submit_form.upload.id}"
+      end
+    end
+
+    while uploads.reload.exists?(status: :in_progress)
+      print "."
+
+      sleep 2
+    end
+
+    puts ""
+
+    non_succeeded_uploads = uploads.where.not(status: :succeeded)
+
+    if non_succeeded_uploads.any?
+      raise "The following upload ids have not succeeded #{non_succeeded_uploads.pluck(:id)}"
+    else
+      puts "***Uploads succeeded 🎉 in #{((Time.current - start_time) / 60.0).round(2)} minutes***"
+    end
+  end
+end

--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -1,155 +1,157 @@
 # frozen_string_literal: true
 
-namespace :load_test do
-  desc "Create multiple bulk update trainee uploads in the background"
-  task csv_trainee_upload: :environment do
-    number_of_uploads = ENV.fetch("UPLOADS", 2).to_i
-    rows              = ENV.fetch("ROWS", 100).to_i
+unless Rails.env.production?
+  namespace :load_test do
+    desc "Create multiple bulk update trainee uploads in the background"
+    task csv_trainee_upload: :environment do
+      number_of_uploads = ENV.fetch("UPLOADS", 2).to_i
+      rows              = ENV.fetch("ROWS", 100).to_i
 
-    if number_of_uploads.zero? || rows.zero?
-      raise "Arguments must be Integers"
-    end
+      if number_of_uploads.zero? || rows.zero?
+        raise "Arguments must be Integers"
+      end
 
-    upload_ids = []
+      upload_ids = []
 
-    data = lambda do
-      {
-        "Provider Trainee ID" => "99157234/2/01",
-        "Application ID" => nil,
-        "HESA ID" => "0310261553101",
-        "First Names" => "John",
-        "Last Name" => SecureRandom.alphanumeric,
-        "Previous Last Name" => "Smith",
-        "Date of Birth" => "1990-01-01",
-        "NI Number" => nil,
-        "Sex" => "10",
-        "Email" => "john.doe@example.com",
-        "Nationality" => "GB",
-        "Ethnicity" => nil,
-        "Disability 1" => "58",
-        "Disability 2" => "57",
-        "Disability 3" => nil,
-        "Disability 4" => nil,
-        "Disability 5" => nil,
-        "Disability 6" => nil,
-        "Disability 7" => nil,
-        "Disability 8" => nil,
-        "Disability 9" => nil,
-        "ITT Aim" => "202",
-        "Training Route" => "11",
-        "Qualification Aim" => "001",
-        "Course Subject One" => "100346",
-        "Course Subject Two" => nil,
-        "Course Subject Three" => nil,
-        "Study Mode" => "63",
-        "ITT Start Date" => "2024-08-01",
-        "ITT End Date" => "2025-08-01",
-        "Course Age Range" => "13918",
-        "Course Year" => "2012",
-        "Lead Partner URN" => nil,
-        "Employing School URN" => nil,
-        "Trainee Start Date" => "2024-08-01",
-        "PG Apprenticeship Start Date" => "2024-03-11",
-        "Fund Code" => "2",
-        "Funding Method" => "6",
-        "Training Initiative" => nil,
-        "Additional Training Initiative" => nil,
-        "Placement 1 URN" => "900020",
-        "Placement 2 URN" => nil,
-        "Placement 3 URN" => nil,
-        "UK Degree Type" => "083",
-        "Non-UK Degree Type" => nil,
-        "Degree Subject" => "100485",
-        "Degree Grade" => "02",
-        "Degree Graduation Year" => "2012",
-        "Awarding Institution" => "0117",
-        "Degree Country" => nil,
-      }
-    end
+      data = lambda do
+        {
+          "Provider Trainee ID" => "99157234/2/01",
+          "Application ID" => nil,
+          "HESA ID" => "0310261553101",
+          "First Names" => "John",
+          "Last Name" => SecureRandom.alphanumeric,
+          "Previous Last Name" => "Smith",
+          "Date of Birth" => "1990-01-01",
+          "NI Number" => nil,
+          "Sex" => "10",
+          "Email" => "john.doe@example.com",
+          "Nationality" => "GB",
+          "Ethnicity" => nil,
+          "Disability 1" => "58",
+          "Disability 2" => "57",
+          "Disability 3" => nil,
+          "Disability 4" => nil,
+          "Disability 5" => nil,
+          "Disability 6" => nil,
+          "Disability 7" => nil,
+          "Disability 8" => nil,
+          "Disability 9" => nil,
+          "ITT Aim" => "202",
+          "Training Route" => "11",
+          "Qualification Aim" => "001",
+          "Course Subject One" => "100346",
+          "Course Subject Two" => nil,
+          "Course Subject Three" => nil,
+          "Study Mode" => "63",
+          "ITT Start Date" => "2024-08-01",
+          "ITT End Date" => "2025-08-01",
+          "Course Age Range" => "13918",
+          "Course Year" => "2012",
+          "Lead Partner URN" => nil,
+          "Employing School URN" => nil,
+          "Trainee Start Date" => "2024-08-01",
+          "PG Apprenticeship Start Date" => "2024-03-11",
+          "Fund Code" => "2",
+          "Funding Method" => "6",
+          "Training Initiative" => nil,
+          "Additional Training Initiative" => nil,
+          "Placement 1 URN" => "900020",
+          "Placement 2 URN" => nil,
+          "Placement 3 URN" => nil,
+          "UK Degree Type" => "083",
+          "Non-UK Degree Type" => nil,
+          "Degree Subject" => "100485",
+          "Degree Grade" => "02",
+          "Degree Graduation Year" => "2012",
+          "Awarding Institution" => "0117",
+          "Degree Country" => nil,
+        }
+      end
 
-    start_time = Time.current
+      start_time = Time.current
 
-    number_of_uploads.times do
-      content = CSV.generate do |csv|
-        csv << data.call.keys
+      number_of_uploads.times do
+        content = CSV.generate do |csv|
+          csv << data.call.keys
 
-        rows.times do
-          csv << data.call.values
+          rows.times do
+            csv << data.call.values
+          end
+        end
+
+        filename = "load_test.csv"
+        tempfile = Tempfile.new(filename.split("."))
+        tempfile.write(content)
+        tempfile.rewind
+
+        uploaded_file = ActionDispatch::Http::UploadedFile.new(
+          filename: filename,
+          tempfile: tempfile,
+          type: "text/csv",
+        )
+
+        bulk_add_trainee_upload_form = BulkUpdate::BulkAddTraineesUploadForm.new(
+          provider: Provider.last,
+          file: uploaded_file,
+        )
+
+        if bulk_add_trainee_upload_form.save
+          BulkUpdate::BulkAddTraineesImportRowsForm.new(
+            upload: bulk_add_trainee_upload_form.upload,
+          ).save
+
+          upload_ids << bulk_add_trainee_upload_form.upload
+        else
+          raise "Something went wrong", bulk_add_trainee_upload_form.errors.full_messages
         end
       end
 
-      filename = "load_test.csv"
-      tempfile = Tempfile.new(filename.split("."))
-      tempfile.write(content)
-      tempfile.rewind
+      uploads = BulkUpdate::TraineeUpload.where(id: upload_ids)
 
-      uploaded_file = ActionDispatch::Http::UploadedFile.new(
-        filename: filename,
-        tempfile: tempfile,
-        type: "text/csv",
-      )
+      puts "***Uploads validating***"
 
-      bulk_add_trainee_upload_form = BulkUpdate::BulkAddTraineesUploadForm.new(
-        provider: Provider.last,
-        file: uploaded_file,
-      )
+      while uploads.reload.exists?(status: :pending)
+        print(".")
 
-      if bulk_add_trainee_upload_form.save
-        BulkUpdate::BulkAddTraineesImportRowsForm.new(
-          upload: bulk_add_trainee_upload_form.upload,
-        ).save
-
-        upload_ids << bulk_add_trainee_upload_form.upload
-      else
-        raise "Something went wrong", bulk_add_trainee_upload_form.errors.full_messages
+        sleep(2)
       end
-    end
 
-    uploads = BulkUpdate::TraineeUpload.where(id: upload_ids)
+      puts ""
+      puts "***Uploads validated***"
 
-    puts "***Uploads validating***"
+      non_validated_uploads = uploads.where.not(status: :validated)
 
-    while uploads.reload.exists?(status: :pending)
-      print(".")
-
-      sleep(2)
-    end
-
-    puts ""
-    puts "***Uploads validated***"
-
-    non_validated_uploads = uploads.where.not(status: :validated)
-
-    if non_validated_uploads.any?
-      raise "The following upload ids are not valid uploads #{non_validated_uploads.pluck(:id)}"
-    end
-
-    uploads.each do |upload|
-      bulk_add_trainee_submit_form = BulkUpdate::BulkAddTraineesSubmitForm.new(
-        upload:,
-      )
-
-      if bulk_add_trainee_submit_form.save
-        puts "***Upload #{bulk_add_trainee_submit_form.upload.id} in progress***"
-      else
-        raise "Something went wrong with upload #{bulk_add_trainee_submit_form.upload.id}"
+      if non_validated_uploads.any?
+        raise "The following upload ids are not valid uploads #{non_validated_uploads.pluck(:id)}"
       end
-    end
 
-    while uploads.reload.exists?(status: :in_progress)
-      print(".")
+      uploads.each do |upload|
+        bulk_add_trainee_submit_form = BulkUpdate::BulkAddTraineesSubmitForm.new(
+          upload:,
+        )
 
-      sleep(2)
-    end
+        if bulk_add_trainee_submit_form.save
+          puts "***Upload #{bulk_add_trainee_submit_form.upload.id} in progress***"
+        else
+          raise "Something went wrong with upload #{bulk_add_trainee_submit_form.upload.id}"
+        end
+      end
 
-    puts ""
+      while uploads.reload.exists?(status: :in_progress)
+        print(".")
 
-    non_succeeded_uploads = uploads.where.not(status: :succeeded)
+        sleep(2)
+      end
 
-    if non_succeeded_uploads.any?
-      raise "The following upload ids have not succeeded #{non_succeeded_uploads.pluck(:id)}"
-    else
-      puts "***Uploads succeeded 🎉 in #{((Time.current - start_time) / 60.0).round(2)} minutes***"
+      puts ""
+
+      non_succeeded_uploads = uploads.where.not(status: :succeeded)
+
+      if non_succeeded_uploads.any?
+        raise "The following upload ids have not succeeded #{non_succeeded_uploads.pluck(:id)}"
+      else
+        puts "***Uploads succeeded 🎉 in #{((Time.current - start_time) / 60.0).round(2)} minutes***"
+      end
     end
   end
 end

--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -8,7 +8,7 @@ namespace :load_test do
 
     upload_ids = []
 
-    data = -> do
+    data = lambda do
       {
         "Provider Trainee ID" => "99157234/2/01",
         "Application ID" => nil,
@@ -59,7 +59,7 @@ namespace :load_test do
         "Degree Grade" => "02",
         "Degree Graduation Year" => "2012",
         "Awarding Institution" => "0117",
-        "Degree Country" => nil
+        "Degree Country" => nil,
       }
     end
 
@@ -106,9 +106,9 @@ namespace :load_test do
     puts "***Uploads validating***"
 
     while uploads.reload.exists?(status: :pending)
-      print "."
+      print(".")
 
-      sleep 2
+      sleep(2)
     end
 
     puts ""
@@ -122,7 +122,7 @@ namespace :load_test do
 
     uploads.each do |upload|
       bulk_add_trainee_submit_form = BulkUpdate::BulkAddTraineesSubmitForm.new(
-        upload: upload,
+        upload:,
       )
 
       if bulk_add_trainee_submit_form.save
@@ -133,9 +133,9 @@ namespace :load_test do
     end
 
     while uploads.reload.exists?(status: :in_progress)
-      print "."
+      print(".")
 
-      sleep 2
+      sleep(2)
     end
 
     puts ""

--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -7,8 +7,8 @@ unless Rails.env.production?
       number_of_uploads = ENV.fetch("UPLOADS", 1).to_i
       rows              = ENV.fetch("ROWS", 100).to_i
 
-      if number_of_uploads.zero? || rows.zero?
-        raise "Arguments must be Integers"
+      unless number_of_uploads.positive? && rows.postive?
+        raise "Arguments must be positive integers"
       end
 
       upload_ids = []


### PR DESCRIPTION
### Context

[8715-load-test-csv-bulk-add-trainees
](https://trello.com/c/Xue2dnyS/8715-load-test-csv-bulk-add-trainees)

### Changes proposed in this pull request

* Add task to execute multiple bulk trainee uploads on the background for load testing purposes

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
