### PR TITLE
[8667] Convert inline reference data in API docs to links

### DIFF
--- a/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
+++ b/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
@@ -75,7 +75,7 @@
   technical: sex
   hesa_alignment: SEXID
   description: This field records the gender of the student.
-  format: "[sex reference codes](/reference-data/v2025.0/sex.html)"
+  format: "[Sex reference codes](/reference-data/v2025.0/sex.html)"
   example: |-
     `10`
   validation: Mandatory
@@ -95,14 +95,14 @@
   technical: nationality
   hesa_alignment: NATION
   description: This field defines the country of legal nationality.
-  format: "[nationality reference codes](/reference-data/v2025.0/nationality.html)"
+  format: "[Nationality reference codes](/reference-data/v2025.0/nationality.html)"
   example: "`GB`"
   validation: Optional
 - field_name: Ethnicity
   technical: ethnicity
   hesa_alignment: ETHNIC
   description: This field records a student’s ethnicity.
-  format: "[ethnicity reference codes](/reference-data/v2025.0/ethnicity.html)"
+  format: "[Ethnicity reference codes](/reference-data/v2025.0/ethnicity.html)"
   example:
     "`103` for example is the code to use if the ethnicity is Asian - Indian or Indian British."
   validation: Optional
@@ -112,7 +112,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability1.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability1.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: Disability 2
@@ -121,7 +121,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability2.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability2.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: Disability 3
@@ -130,7 +130,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability3.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability3.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: Disability 4
@@ -139,7 +139,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability4.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability4.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: Disability 5
@@ -148,7 +148,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability5.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability5.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: Disability 6
@@ -157,7 +157,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability6.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability6.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: Disability 7
@@ -166,7 +166,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability7.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability7.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: Disability 8
@@ -175,7 +175,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability8.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability8.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: Disability 9
@@ -184,7 +184,7 @@
   description:
     This field records the type of disability that a student has, on the
     basis of the student’s own self-assessment.
-  format: "[disability reference codes](/reference-data/v2025.0/disability9.html)"
+  format: "[Disability reference codes](/reference-data/v2025.0/disability9.html)"
   example: "`51` for example is the code to use for learning difference such as dyslexia, dyspraxia or ADHD"
   validation: Optional
 - field_name: ITT Aim
@@ -194,7 +194,7 @@
     This field is a three characters field completed for students on courses
     that lead to teacher qualifications. The selection will determine the type of
     the teacher training.
-  format: "[ITT aim reference codes](/reference-data/v2025.0/itt-aim.html)"
+  format: "[ITT Aim reference codes](/reference-data/v2025.0/itt-aim.html)"
   example: |-
     - `201`
   validation: Mandatory
@@ -205,7 +205,7 @@
   description:
     This field describes the route by which the student has accessed Initial
     Teacher Training provision.
-  format: "[training route reference codes](/reference-data/v2025.0/training-route.html)"
+  format: "[Training Route reference codes](/reference-data/v2025.0/training-route.html)"
   example: "`03` for example is code to use if it is School Direct salaried"
   validation: Mandatory
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/6c20409c393ca3e753eda0b674e1435948c27e24/app/models/trainee.rb#L213-L215
@@ -215,7 +215,7 @@
   description: This field describes the qualification aim of the Initial Teacher
     Training course and is intended to record the qualification that will be attained
     as a result of successful completion of studies.
-  format: "[qualification aim reference codes](/reference-data/v2025.0/itt-qualification-aim.html)"
+  format: "[Qualification Aim reference codes](/reference-data/v2025.0/itt-qualification-aim.html)"
   example: |-
     `007`
   validation: "Conditional - mandatory if ITT Aim is `202`"
@@ -227,7 +227,7 @@
     First subject of the ITT course
 
     Notes\: Where trainees continue to study a primary specialism, a valid HECoS code should be used in this field
-  format: "[course subject reference codes](/reference-data/v2025.0/course-subject-one.html)"
+  format: "[Course Subject reference codes](/reference-data/v2025.0/course-subject-one.html)"
   example: "`100048` for example is the code used for design as a subject"
   validation: Mandatory
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/forms/validate_publish_course_form.rb#L13
@@ -238,7 +238,7 @@
     Second subject of the ITT course.
 
     Notes\: Where trainees continue to study a primary specialism, a valid HECoS code should be used in this field
-  format: "[course subject reference codes](/reference-data/v2025.0/course-subject-two.html)"
+  format: "[Course Subject reference codes](/reference-data/v2025.0/course-subject-two.html)"
   example: "`100048` for example is the code used for design as a subject"
   validation: Optional
 - field_name: Course Subject Three
@@ -248,7 +248,7 @@
     Third subject of the ITT course.
 
     Notes\: Where trainees continue to study a primary specialism, a valid HECoS code should be used in this field
-  format: "[course subject reference codes](/reference-data/v2025.0/course-subject-three.html)"
+  format: "[Course Subject reference codes](/reference-data/v2025.0/course-subject-three.html)"
   example: "`100048` for example is the code used for design as a subject"
   validation: Optional
 - field_name: Study Mode
@@ -257,7 +257,7 @@
   description:
     This field indicates the method by which a student is being taught
     their course.
-  format: "[study mode reference codes](/reference-data/v2025.0/study-mode.html)"
+  format: "[Study Mode reference codes](/reference-data/v2025.0/study-mode.html)"
   example: "`01`"
   validation: "Conditional - mandatory when the training route is not Assessment only or Early years assessment only"
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/lib/training_route_manager.rb#L42-L47
@@ -286,7 +286,7 @@
   description: This field describes in more detail the student’s initial teacher
     training aim
   format: |-
-    [course age range reference codes](/reference-data/v2025.0/course-age-range.html)
+    [Course Age Range reference codes](/reference-data/v2025.0/course-age-range.html)
 
     The following values are invalid for this field:
 
@@ -395,7 +395,7 @@
   technical: fund_code
   hesa_alignment: FUNDCODE
   description: "This field indicates whether the student is counted as 'fundable', i.e. 'eligible for funding' for the course by the appropriate funding council/body. NOTE: Use `7` if the trainee chooses not to receive finance they are eligible for."
-  format: "[fund code reference codes](/reference-data/v2025.0/fund-code.html)"
+  format: "[Fund Code reference codes](/reference-data/v2025.0/fund-code.html)"
   example: "`2`"
   validation: Mandatory
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v2025_0_rc/hesa_trainee_detail_attributes.rb#L66
@@ -408,7 +408,7 @@
     classification if applicable and the subject specialism in which they wish to
     train to teach.
 
-  format: "[funding method reference codes](/reference-data/v2025.0/funding-method.html)"
+  format: "[Funding Method reference codes](/reference-data/v2025.0/funding-method.html)"
   example: "`E`"
   validation: Mandatory
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v2025_0_rc/hesa_trainee_detail_attributes.rb#L31
@@ -420,7 +420,7 @@
     is to be monitored independently. Valid entries will change from year to year
     to reflect current schemes.
   format: |-
-    [training initiative reference codes](/reference-data/v2025.0/training-initiative.html)
+    [Training Initiative reference codes](/reference-data/v2025.0/training-initiative.html)
 
     The following codes are not mapped to Register:
       `001`, `011`, `019`
@@ -432,7 +432,7 @@
   hesa_alignment: INITIATIVES
   description: The secondary training initiative that the trainee is on.
   format: |-
-    [training initiative reference codes](/reference-data/v2025.0/training-initiative.html)
+    [Training Initiative reference codes](/reference-data/v2025.0/training-initiative.html)
 
     The following codes are not mapped to Register:
       `001`, `011`, `019`
@@ -447,7 +447,7 @@
     The type of UK degree if the trainee holds any previous UK degrees.
 
     Only the highest previous degree qualification should be submitted.
-  format: "[UK degree type reference codes](/reference-data/v2025.0/uk-degree.html)"
+  format: "[UK Degree Type reference codes](/reference-data/v2025.0/uk-degree.html)"
   example: "`051` for example is Bachelor of Arts (BA)"
   validation: Conditional - mandatory if specifying a UK degree
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v2025_0_rc/degree_attributes.rb#L37
@@ -455,7 +455,7 @@
   technical: non_uk_degree
   hesa_alignment: DEGTYPE
   description: The type of non-UK degree.
-  format: "[non-UK degree type reference codes](/reference-data/v2025.0/non-uk-degree.html) for degree type list of unique 3 digit numbers."
+  format: "[Non-UK Degree Type reference codes](/reference-data/v2025.0/non-uk-degree.html) for degree type list of unique 3 digit numbers."
   example: "`051` for example is Bachelor of Arts (BA)"
   validation: Conditional - mandatory if specifying a non-UK degree
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v2025_0_rc/degree_attributes.rb#L42
@@ -463,7 +463,7 @@
   technical: subject
   hesa_alignment: DEGSBJ
   description: This field holds the subject(s) of the student’s previous degree. For those with complex previous degrees, return the major subject that you would have previously returned as degree subject 1.
-  format: "[degree subject reference codes](/reference-data/v2025.0/subject.html)"
+  format: "[Degree Subject reference codes](/reference-data/v2025.0/subject.html)"
   example: "`100048` for example is the design degree subject as part of a previous degree"
   validation: Conditional - mandatory if specifying a degree
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v2025_0_rc/degree_attributes.rb#L34
@@ -471,7 +471,7 @@
   technical: grade
   hesa_alignment: DEGCLSS
   description: The grade of the degree.
-  format: "[degree grade reference codes](/reference-data/v2025.0/grade.html)"
+  format: "[Degree Grade reference codes](/reference-data/v2025.0/grade.html)"
   example: "`01` for example is First class honours"
   validation: Conditional - mandatory if specifying a UK degree
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v2025_0_rc/degree_attributes.rb#L38
@@ -495,7 +495,7 @@
   description:
     This records the provider where the student’s previous qualification
     was awarded, if a UK provider.
-  format: "[awarding institution reference codes if a UK provider](/reference-data/v2025.0/institution.html)"
+  format: "[Awarding Institution reference codes if a UK provider](/reference-data/v2025.0/institution.html)"
   example: "`1101` for example is Hull College"
   validation: Conditional - mandatory if specifying a UK degree
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/api/v2025_0_rc/degree_attributes.rb#L36
@@ -505,7 +505,7 @@
   description:
     This records the country where the student’s previous qualification
     was awarded
-  format: "[degree country reference codes](/reference-data/v2025.0/country.html)"
+  format: "[Degree Country reference codes](/reference-data/v2025.0/country.html)"
   example:
     "`AU` is an example of using the previous qualification country code for Australia"
   validation: Conditional - mandatory if specifying a non-UK degree

--- a/tech_docs/source/api-docs/v2025.0/objects/degree.html.md
+++ b/tech_docs/source/api-docs/v2025.0/objects/degree.html.md
@@ -29,7 +29,7 @@ weight: 3
       <p class="govuk-body">
         The country where the degree was awarded.
         Coded according to the
-        <a href="/reference-data/v2025.0/country.html">degree country reference data specification</a>.
+        <a href="/reference-data/v2025.0/country.html">Degree Country reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>US</code>
@@ -44,7 +44,7 @@ weight: 3
       </p>
       <p class="govuk-body">
         The grade of the degree. Coded according to
-        <a href="/reference-data/v2025.0/grade.html">degree grade reference data specification</a>.
+        <a href="/reference-data/v2025.0/grade.html">Degree Grade reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>02</code>
@@ -59,7 +59,7 @@ weight: 3
       </p>
       <p class="govuk-body">
         The type of UK degree. Coded according to
-        <a href="/reference-data/v2025.0/uk-degree.html">degree type reference data specification</a>.
+        <a href="/reference-data/v2025.0/uk-degree.html">UK Degree Type reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>083</code>
@@ -74,7 +74,7 @@ weight: 3
       </p>
       <p class="govuk-body">
         The type of non-UK degree. Coded according to
-        <a href="/reference-data/v2025.0/non-uk-degree.html">non-UK degree type reference data specification</a>.
+        <a href="/reference-data/v2025.0/non-uk-degree.html">Non-UK Degree Type reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>051</code>
@@ -89,7 +89,7 @@ weight: 3
       </p>
       <p class="govuk-body">
         The degree subject. For those with complex previous degrees, return the major subject that you would have previously returned as degree subject 1. Coded according to
-        <a href="/reference-data/v2025.0/subject.html">degree subject reference data specification</a>.
+        <a href="/reference-data/v2025.0/subject.html">Degree Subject reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>100425</code>
@@ -104,7 +104,7 @@ weight: 3
       </p>
       <p class="govuk-body">
         The awarding institution. Coded according to the
-        <a href="/reference-data/v2025.0/institution.html">awarding institution reference data specification</a>.
+        <a href="/reference-data/v2025.0/institution.html">Awarding Institution reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>0116</code>

--- a/tech_docs/source/api-docs/v2025.0/objects/trainee.html.md
+++ b/tech_docs/source/api-docs/v2025.0/objects/trainee.html.md
@@ -126,7 +126,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The sex of the trainee. Coded according to the <a
-          href="/reference-data/v2025.0/sex.html">sex reference data specification</a>.
+          href="/reference-data/v2025.0/sex.html">Sex reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>10</code>
@@ -141,7 +141,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The nationality of the trainee. Coded according to the <a
-          href="/reference-data/v2025.0/nationality.html">nationality reference data specification</a>.
+          href="/reference-data/v2025.0/nationality.html">Nationality reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>GB</code>
@@ -170,7 +170,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The ethnicity of the trainee. Coded according to the <a
-          href="/reference-data/v2025.0/ethnicity.html">ethnicity reference data specification</a>. The values for
+          href="/reference-data/v2025.0/ethnicity.html">Ethnicity reference data specification</a>. The values for
         <code>ethnic_background</code> and <code>ethnic_group</code> will be set based on the <code>ethnicity</code>
         value.
       </p>
@@ -191,7 +191,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The type of disabilities that the trainee has. Coded according to the <a
-          href="/reference-data/v2025.0/disability1.html">disability reference data specification</a>
+          href="/reference-data/v2025.0/disability1.html">Disability reference data specification</a>
       </p>
       <p class="govuk-body">
         Example: <code>58</code>
@@ -206,7 +206,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The general qualification aim of the course in terms of qualifications and professional statuses. Coded according to the <a
-          href="/reference-data/v2025.0/itt-aim.html">ITT aim reference data specification</a>
+          href="/reference-data/v2025.0/itt-aim.html">ITT Aim reference data specification</a>
       </p>
       <p class="govuk-body">
         Example: <code>201</code>
@@ -224,7 +224,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The training route that the trainee is on. Coded according to the <a
-          href="/reference-data/v2025.0/training-route.html">training route reference data specification</a>
+          href="/reference-data/v2025.0/training-route.html">Training Route reference data specification</a>
       </p>
       <p class="govuk-body">
         Example: <code>11</code>
@@ -239,7 +239,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The qualification aim of the trainee’s course. Coded according to the <a
-          href="/reference-data/v2025.0/itt-qualification-aim.html">qualification aim reference data specification</a>
+          href="/reference-data/v2025.0/itt-qualification-aim.html">Qualification Aim reference data specification</a>
       </p>
       <p class="govuk-body">
         Example: <code>004</code>
@@ -257,7 +257,7 @@ weight: 1
       <p class="govuk-body">
         The subjects included in the trainee’s course. The first subject is the main one. It represents the bursary or
         scholarship available if applicable. Coded according to the <a
-          href="/reference-data/v2025.0/course-subject-one.html">course subject reference data specification</a>.
+          href="/reference-data/v2025.0/course-subject-one.html">Course Subject reference data specification</a>.
       </p>
       <p class="govuk-body">
        Note: For primary education courses (when the course maximum age is 11 or below), 
@@ -278,7 +278,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         This indicates whether the trainee’s course is full-time or part-time. Coded according to the <a
-          href="/reference-data/v2025.0/study-mode.html">study mode reference data specification</a>
+          href="/reference-data/v2025.0/study-mode.html">Study Mode reference data specification</a>
       </p>
       <p class="govuk-body">
         Example: <code>01</code>
@@ -373,7 +373,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The age range of children taught on the course. Coded according to the <a
-          href="/reference-data/v2025.0/course-age-range.html">course age range reference data specification</a>
+          href="/reference-data/v2025.0/course-age-range.html">Course Age Range reference data specification</a>
       </p>
       <p class="govuk-body">
         Example: <code>13918</code>
@@ -510,7 +510,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The bursary level awarded to the trainee. Coded according to the <a
-          href="/reference-data/v2025.0/funding-method.html">funding method reference data specification</a>
+          href="/reference-data/v2025.0/funding-method.html">Funding Method reference data specification</a>
       </p>
       <p class="govuk-body">
         Example: <code>4</code>
@@ -527,7 +527,7 @@ weight: 1
         This field identifies students who are part of a specific scheme that
         is to be monitored independently. Valid entries will change from year to year
         to reflect current schemes. Coded according to the <a
-          href="/reference-data/v2025.0/training-initiative.html">training initiative reference data specification</a>
+          href="/reference-data/v2025.0/training-initiative.html">Training Initiative reference data specification</a>
       </p>
       <p class="govuk-body">
         Example: <code>026</code>
@@ -542,7 +542,7 @@ weight: 1
       </p>
       <p class="govuk-body">
         The secondary training initiative that the trainee is on. Coded according to the <a
-          href="/reference-data/v2025.0/training-initiative.html">training initiative reference data specification</a>.
+          href="/reference-data/v2025.0/training-initiative.html">Training Initiative reference data specification</a>.
       </p>
       <p class="govuk-body">
         Example: <code>025</code>


### PR DESCRIPTION
### Context

This PR is a follow-up to . We don't want to duplicate reference data specifications in the API documentation. Better to use the authoritative source.

### Changes proposed in this pull request

Where applicable convert inline reference data found in the API documentation to simple links to the relevant reference data documentation page. e.g.

Before:

<img width="2084" height="1006" alt="image" src="https://github.com/user-attachments/assets/838b6572-ae2e-4af2-8269-560c6ee7b60a" />

After:

<img width="2084" height="346" alt="image" src="https://github.com/user-attachments/assets/312ff822-75c9-49dd-86bd-085d9ba967d9" />


### Guidance to review

Any missing?

Note that not all of the lists of possible values for API attributes are reference data. e.g. Trainee `status` and `record_source` are not part of the reference data.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
