### PR TITLE
[8803] Add guidance page for extracting TRNs

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -13,6 +13,7 @@ class GuidanceController < ApplicationController
   def check_data; end
   def bulk_recommend_trainees; end
   def manually_registering_trainees; end
+  def how_to_extract_trns_from_the_register_service; end
 
   def manage_placements
     render(layout: "application")

--- a/app/views/guidance/how_to_extract_trns_from_the_register_service.md
+++ b/app/views/guidance/how_to_extract_trns_from_the_register_service.md
@@ -1,0 +1,15 @@
+---
+page_title: How to extract TRNs from the Register service
+title: How to extract TRNs from the Register service
+---
+
+This guidance is for Higher Education Institutes (HEIs). 
+ 
+There are instances when you might need to bulk download trainee’s teacher reference numbers (TRNs). This guidance will talk you through a step by step: 
+
+- sign into [Register trainee teachers](https://www.register-trainee-teachers.service.gov.uk/) 
+- navigate to Registered trainees
+- look for **Export these records**. You can use the filters on the left if you only want a selection of trainees
+- a CSV file will download with all the trainee details including a column for TRN 
+
+TRNs are often issued within a few hours of Registering a trainee. If a trainee has a tag that says Pending TRN to the right of their name, it means a TRN hasn’t been issued yet.

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -42,6 +42,12 @@
               registering_trainees_through_hesa_guidance_path,
             ) %>
       </li>
+      <li>
+        <%= govuk_link_to(
+              "How to extract TRNs from the Register service ",
+              how_to_extract_trns_from_the_register_service_guidance_path,
+            ) %>
+      </li>
     </ul>
 
     <h2 class="govuk-heading-m">Recording teacher training outcomes</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,6 +284,7 @@ Rails.application.routes.draw do
     get "/withdraw-defer-reinstate-or-recommend-a-trainee", to: "guidance#withdraw_defer_reinstate_or_recommend_a_trainee"
     get "/manage-placements", to: "guidance#manage_placements"
     get "/bulk-upload-placement-data", to: "guidance#bulk_upload_placement_data"
+    get "/how_to_extract_trns_from_the_register_service", to: "guidance#how_to_extract_trns_from_the_register_service"
   end
 
   if FeatureService.enabled?("funding")

--- a/spec/controllers/guidance_controller_spec.rb
+++ b/spec/controllers/guidance_controller_spec.rb
@@ -94,6 +94,19 @@ describe GuidanceController do
     end
   end
 
+  describe "#how_to_extract_trns_from_the_register_service" do
+    it "returns a 200 status code" do
+      get :how_to_extract_trns_from_the_register_service
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct template and page" do
+      get :how_to_extract_trns_from_the_register_service
+      expect(response).to render_template("guidance")
+      expect(response).to render_template("how_to_extract_trns_from_the_register_service")
+    end
+  end
+
   describe "#check_data" do
     it "returns a 200 status code" do
       get :check_data


### PR DESCRIPTION
### Context
In the 2025-2026 academic year HEIs will move from extracting TRNs via HESA to collecting them directly from register.  We’ve had a few questions about how to do this and should consider producing some sort of guidance on how the process works.

### Changes proposed in this pull request

Add a new guidance page:

<img width="2048" height="894" alt="image" src="https://github.com/user-attachments/assets/8381827e-b9a6-4645-b25a-1da6c7246087" />

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
