### PR TITLE
[8694] Move mailer to slightly later in the process

### DIFF
--- a/app/controllers/bulk_update/add_trainees/imports_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/imports_controller.rb
@@ -13,6 +13,8 @@ module BulkUpdate
           ),
         ).save
 
+        SendCsvSubmittedForProcessingFirstStageEmailService.call(upload: bulk_update_trainee_upload)
+
         redirect_to(
           bulk_update_add_trainees_upload_path(bulk_update_trainee_upload),
         )

--- a/app/controllers/bulk_update/add_trainees/uploads_controller.rb
+++ b/app/controllers/bulk_update/add_trainees/uploads_controller.rb
@@ -48,16 +48,12 @@ module BulkUpdate
         authorize(@bulk_add_trainee_upload_form.upload)
 
         if @bulk_add_trainee_upload_form.save
-          SendCsvSubmittedForProcessingFirstStageEmailService.call(upload: @bulk_add_trainee_upload_form.upload)
-
           redirect_to(
             bulk_update_add_trainees_upload_path(@bulk_add_trainee_upload_form.upload),
             flash: { success: t(".success") },
           )
         elsif bulk_update_trainee_upload_id
           authorize(bulk_update_trainee_upload)
-
-          SendCsvSubmittedForProcessingFirstStageEmailService.call(upload: bulk_update_trainee_upload)
 
           render(:show)
         else

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -166,7 +166,6 @@ feature "bulk add trainees" do
         and_i_click_the_bulk_add_trainees_page
         and_i_attach_a_valid_file
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         then_i_see_the_new_bulk_update_import_page
 
         when_i_click_on_back_link
@@ -174,7 +173,6 @@ feature "bulk add trainees" do
 
         when_i_attach_a_valid_file
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         then_i_see_the_new_bulk_update_import_page
 
         and_i_click_the_cancel_process_link
@@ -184,9 +182,9 @@ feature "bulk add trainees" do
         and_i_see_instructions_on_how_to_bulk_add_trainees
         and_i_attach_a_valid_file
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_see_the_new_bulk_update_import_page
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         then_i_see_that_the_upload_is_processing
         and_i_dont_see_the_cancel_bulk_updates_link
 
@@ -232,9 +230,9 @@ feature "bulk add trainees" do
         and_i_click_the_bulk_add_trainees_page
         and_i_attach_a_valid_file
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_see_the_new_bulk_update_import_page
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         then_a_job_is_queued_to_process_the_upload
         then_i_see_that_the_upload_is_processing
 
@@ -260,8 +258,8 @@ feature "bulk add trainees" do
         Timecop.travel 1.hour.from_now do
           and_i_click_the_upload_button
         end
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         then_i_see_that_the_upload_is_processing
         then_a_job_is_queued_to_process_the_upload
 
@@ -304,8 +302,8 @@ feature "bulk add trainees" do
         and_i_click_the_bulk_add_trainees_page
         and_i_attach_a_valid_file_with_placements
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         then_a_job_is_queued_to_process_the_upload
         then_i_see_that_the_upload_is_processing
 
@@ -336,8 +334,8 @@ feature "bulk add trainees" do
         and_i_click_the_bulk_add_trainees_page
         and_i_attach_a_valid_file_with_a_degree
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         then_a_job_is_queued_to_process_the_upload
         then_i_see_that_the_upload_is_processing
 
@@ -367,8 +365,8 @@ feature "bulk add trainees" do
         and_i_click_the_bulk_add_trainees_page
         and_i_attach_a_valid_file_with_a_disability
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         then_a_job_is_queued_to_process_the_upload
         then_i_see_that_the_upload_is_processing
 
@@ -445,8 +443,8 @@ feature "bulk add trainees" do
 
         when_i_attach_a_file_with_invalid_rows
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         when_the_background_job_is_run
         and_i_refresh_the_page
         then_i_see_the_review_errors_page
@@ -519,8 +517,8 @@ feature "bulk add trainees" do
 
         when_i_attach_a_valid_file
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         when_the_background_job_is_run
         and_i_refresh_the_page
         then_i_see_the_review_errors_page
@@ -571,8 +569,8 @@ feature "bulk add trainees" do
 
         when_i_attach_a_file_with_an_unparseable_date
         and_i_click_the_upload_button
-        and_the_send_csv_processing_first_stage_email_has_been_sent
         and_i_click_on_continue_button
+        and_the_send_csv_processing_first_stage_email_has_been_sent
         when_the_background_job_is_run
         and_i_refresh_the_page
         then_i_see_the_review_errors_page


### PR DESCRIPTION
### Context

https://trello.com/c/oaBt1Fi3/8694-send-emails-for-the-first-stage-of-the-of-csv-bulk-create-trainees-process

### Changes proposed in this pull request

Moves when the mailer is activated to the next step in the process to cover csvs with errors.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
