### PR TITLE
[8694] Set correct template statuses for first stage

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -169,8 +169,8 @@ govuk_notify:
     succeeded_template_id: 8ff06d35-8960-462e-aa6e-9942a7fd713d
     failed_template_id: 3344fd46-7f33-4762-a350-d02a88f863b0
   csv_submitted_for_processing_first_stage:
-    in_progress_template_id: 8d856c2c-1e5f-4bd9-bbba-c8633422bcec
-    succeeded_template_id: 7cae2078-784c-445d-b251-7bc3a901ef73
+    pending_template_id: 8d856c2c-1e5f-4bd9-bbba-c8633422bcec
+    validated_template_id: 7cae2078-784c-445d-b251-7bc3a901ef73
     failed_template_id: 716e14d1-7157-41b2-bdac-9ab94adc7934
   performance_profile_submitted_email_template_id: 21879652-3975-4a0a-b0b4-9fe6a5353090
   census_submitted_email_template_id: 5a610b43-a36e-4e4c-8ab0-e7e9d158f440

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -31,6 +31,6 @@ govuk_notify:
     succeeded_template_id: succeeded-uuid
     failed_template_id: failed-uuid
   csv_submitted_for_processing_first_stage:
-    in_progress_template_id: in-progress-uuid
-    succeeded_template_id: succeeded-uuid
+    pending_template_id: pending-uuid
+    validated_template_id: validated-uuid
     failed_template_id: failed-uuid

--- a/spec/mailers/csv_submitted_for_processing_first_stage_email_mailer_spec.rb
+++ b/spec/mailers/csv_submitted_for_processing_first_stage_email_mailer_spec.rb
@@ -16,12 +16,12 @@ describe CsvSubmittedForProcessingFirstStageEmailMailer do
     let(:template_ids) do
       {
         in_progress: "in-progress-uuid",
-        succeeded: "succeeded-uuid",
+        validated: "validated-uuid",
         failed: "failed-uuid",
       }
     end
 
-    %i[in_progress succeeded failed].each do |status|
+    %i[in_progress validated failed].each do |status|
       context "when the upload status is #{status}" do
         let(:upload) { create(:bulk_update_trainee_upload, status) }
 

--- a/spec/mailers/csv_submitted_for_processing_first_stage_email_mailer_spec.rb
+++ b/spec/mailers/csv_submitted_for_processing_first_stage_email_mailer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe CsvSubmittedForProcessingFirstStageEmailMailer do
   context "sending an email to a user" do
-    let(:upload) { create(:bulk_update_trainee_upload, :in_progress) }
+    let(:upload) { create(:bulk_update_trainee_upload, :pending) }
     let(:user) { upload.provider.users.first }
     let(:mail) do
       described_class.generate(

--- a/spec/mailers/csv_submitted_for_processing_first_stage_email_mailer_spec.rb
+++ b/spec/mailers/csv_submitted_for_processing_first_stage_email_mailer_spec.rb
@@ -15,7 +15,7 @@ describe CsvSubmittedForProcessingFirstStageEmailMailer do
 
     let(:template_ids) do
       {
-        in_progress: "in-progress-uuid",
+        pending: "pending-uuid",
         validated: "validated-uuid",
         failed: "failed-uuid",
       }

--- a/spec/mailers/csv_submitted_for_processing_first_stage_email_mailer_spec.rb
+++ b/spec/mailers/csv_submitted_for_processing_first_stage_email_mailer_spec.rb
@@ -21,7 +21,7 @@ describe CsvSubmittedForProcessingFirstStageEmailMailer do
       }
     end
 
-    %i[in_progress validated failed].each do |status|
+    %i[pending validated failed].each do |status|
       context "when the upload status is #{status}" do
         let(:upload) { create(:bulk_update_trainee_upload, status) }
 


### PR DESCRIPTION
### Context

https://trello.com/c/oaBt1Fi3/8694-send-emails-for-the-first-stage-of-the-of-csv-bulk-create-trainees-process

### Changes proposed in this pull request

Set templates for correct statuses for first stage of bulk upload process

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
