### PR TITLE
[8836] Update docs to say _Provider Trainee ID_ is optional

### DIFF
--- a/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
+++ b/app/views/bulk_update/add_trainees/reference_docs/fields.yaml
@@ -5,7 +5,7 @@
   description: Provider’s own internal identifier for the student.
   format: 50 character max length
   example: "`99157234`"
-  validation: Mandatory
+  validation: Optional
   validation_notes: https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/forms/training_details_form.rb#L7
 - field_name: Application ID
   technical: application_id


### PR DESCRIPTION
### Context
Currently the CSV docs state that `Provider Trainee ID` is mandatory. It isn't.

### Changes proposed in this pull request
Change the docs to reflect the implementation (`Provider Trainee ID` is optional). We may change this in future.

<img width="1374" height="1096" alt="image" src="https://github.com/user-attachments/assets/bda4e246-498e-4b8b-b6b9-d5e92004fb84" />


### Guidance to review
Is this documented elsewhere? 

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
