### PR TITLE
[8839] Redirect to the trailing slash path from infrastructure

### DIFF
--- a/app/middleware/tech_docs/trailing_slash_redirect.rb
+++ b/app/middleware/tech_docs/trailing_slash_redirect.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module TechDocs
+  class TrailingSlashRedirect
+    PATHS = %w[/api-docs /csv-docs /reference-data].freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      path = env["PATH_INFO"]
+
+      return [301, { "Location" => "#{path}/" }, []] if PATHS.include?(path)
+
+      @app.call(env)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,10 @@ require "sprockets/railtie"
 require "rails/test_unit/railtie"
 require "govuk/components"
 
+Dir[File.expand_path("../app/middleware/**/*.rb", __dir__)].each do |file|
+  require file
+end
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -37,6 +41,8 @@ module RegisterTraineeTeachers
     config.view_component.show_previews = !Rails.env.production?
 
     config.middleware.use(Rack::Deflater)
+    config.middleware.insert_before(ActionDispatch::Static, TechDocs::TrailingSlashRedirect)
+
     config.active_job.queue_adapter = :sidekiq
 
     # Configure session store to use ActiveRecord.

--- a/spec/requests/tech_docs_redirects_spec.rb
+++ b/spec/requests/tech_docs_redirects_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Tech Docs redirects" do
+  %w[api-docs csv-docs reference-data].each do |path|
+    describe "/#{path}/" do
+      context "when the path is '/#{path}'" do
+        before do
+          get "/#{path}"
+        end
+
+        it "redirects to '/#{path}/'" do
+          expect(response).to have_http_status(:moved_permanently)
+          expect(response).to redirect_to("/#{path}/")
+        end
+      end
+
+      context "when the path is '/#{path}/'" do
+        before do
+          get "/#{path}/"
+        end
+
+        it "does not redirect" do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Redirect to the trailing slash path from infrastructure](https://trello.com/c/NHhwTYpf/8839-%F0%9F%91%B9-redirect-to-the-trailing-slash-path-from-infrastructure)

Add `TechDocs::TrailingSlashRedirect` middleware

### Changes proposed in this pull request

* Redirect `/api-docs` to `/api-docs/`
* Redirect `/csv-docs` to `/csv-docs/`
* Redirect `/reference-data` to `/reference-data/`


### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
