### PR TITLE
[8890] Missing TRN requests for trainees created via CSV bulk add trainees

### DIFF
--- a/app/services/api/create_trainee.rb
+++ b/app/services/api/create_trainee.rb
@@ -30,7 +30,10 @@ module Api
       validator = Submissions::ApiTrnValidator.new(trainee:)
 
       if validator.all_errors.empty? && trainee.save
-        ::Trainees::SubmitForTrn.call(trainee:) unless dry_run?
+        # ::Trainees::SubmitForTrn.call(trainee:) unless dry_run?
+
+        trainee.submit_for_trn!
+
         success_response(trainee)
       else
         save_errors_response(validator, trainee)

--- a/app/services/api/create_trainee.rb
+++ b/app/services/api/create_trainee.rb
@@ -8,13 +8,13 @@ module Api
 
     include ActiveModel::Model
 
-    attr_accessor :current_provider, :trainee_attributes, :version, :dry_run
+    attr_accessor :current_provider, :trainee_attributes, :version, :submit_for_trn
 
-    def initialize(current_provider:, trainee_attributes:, version:, dry_run: false)
+    def initialize(current_provider:, trainee_attributes:, version:, submit_for_trn: true)
       @current_provider = current_provider
       @trainee_attributes = trainee_attributes
       @version = version
-      @dry_run = dry_run
+      @submit_for_trn = submit_for_trn
     end
 
     def call
@@ -30,7 +30,8 @@ module Api
       validator = Submissions::ApiTrnValidator.new(trainee:)
 
       if validator.all_errors.empty? && trainee.save
-        ::Trainees::SubmitForTrn.call(trainee:) unless dry_run?
+        ::Trainees::SubmitForTrn.call(trainee:) if submit_for_trn
+
         success_response(trainee)
       else
         save_errors_response(validator, trainee)
@@ -75,7 +76,5 @@ module Api
     end
 
     def model = :trainee
-
-    alias_method :dry_run?, :dry_run
   end
 end

--- a/app/services/api/create_trainee.rb
+++ b/app/services/api/create_trainee.rb
@@ -30,10 +30,7 @@ module Api
       validator = Submissions::ApiTrnValidator.new(trainee:)
 
       if validator.all_errors.empty? && trainee.save
-        # ::Trainees::SubmitForTrn.call(trainee:) unless dry_run?
-
-        trainee.submit_for_trn!
-
+        ::Trainees::SubmitForTrn.call(trainee:) unless dry_run?
         success_response(trainee)
       else
         save_errors_response(validator, trainee)

--- a/app/services/bulk_update/add_trainees/import_rows.rb
+++ b/app/services/bulk_update/add_trainees/import_rows.rb
@@ -221,6 +221,7 @@ module BulkUpdate
           },
         )
         BulkUpdate::AddTrainees::ImportRow::Result.new(
+          nil,
           false,
           ["runtime failure: #{exception.message}"],
         )

--- a/spec/features/bulk_upload/bulk_add_trainees_spec.rb
+++ b/spec/features/bulk_upload/bulk_add_trainees_spec.rb
@@ -250,7 +250,7 @@ feature "bulk add trainees" do
         and_i_refresh_the_summary_page
         then_i_see_the_review_errors_page
         and_i_dont_see_the_submit_button
-        and_the_request_trn_jobs_have_been_queued
+        and_the_request_trn_job_has_not_been_queued
 
         when_i_click_the_upload_button
         then_i_see_the_review_errors_page
@@ -1221,7 +1221,6 @@ private
     BulkUpdate::AddTrainees::ImportRow.call(
       row: row,
       current_provider: BulkUpdate::TraineeUpload.last.provider,
-      dry_run: false,
     )
   end
 
@@ -1301,7 +1300,7 @@ private
   end
 
   def and_the_request_trn_jobs_have_been_queued
-    expect(Trainees::SubmitForTrn).to have_received(:call).at_least(5).times
+    expect(Trainees::SubmitForTrn).to have_received(:call).exactly(5).times
   end
 
   alias_method :and_i_attach_a_valid_file, :when_i_attach_a_valid_file

--- a/spec/services/bulk_update/add_trainees/import_rows_spec.rb
+++ b/spec/services/bulk_update/add_trainees/import_rows_spec.rb
@@ -155,7 +155,6 @@ module BulkUpdate
             context "when the upload status is pending" do
               let(:trainee_upload) { create(:bulk_update_trainee_upload, :with_mixed_case_headers, :pending) }
 
-
               it "does not create any trainee records" do
                 allow(ImportRow).to receive(:call).and_call_original
 

--- a/spec/services/bulk_update/add_trainees/import_rows_spec.rb
+++ b/spec/services/bulk_update/add_trainees/import_rows_spec.rb
@@ -13,8 +13,11 @@ module BulkUpdate
           let(:trainee_upload) { create(:bulk_update_trainee_upload) }
 
           it "does not call the `ImportRow` service" do
-            expect(ImportRow).not_to receive(:call)
+            allow(ImportRow).to receive(:call)
+
             described_class.call(trainee_upload)
+
+            expect(ImportRow).not_to have_received(:call)
           end
         end
 
@@ -25,15 +28,11 @@ module BulkUpdate
             context "when the upload status is pending" do
               let(:trainee_upload) { create(:bulk_update_trainee_upload, :pending) }
 
-              before do
-                allow(ImportRow).to receive(:call).and_return(
-                  BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
-                )
-              end
-
               it "does not create any trainee records" do
-                expect(ImportRow).to receive(:call).exactly(5).times.and_call_original
+                allow(ImportRow).to receive(:call).and_call_original
+
                 expect(described_class.call(trainee_upload)).to be(true)
+                expect(ImportRow).to have_received(:call).exactly(5).times
               end
 
               it "creates bulk_update_trainee_upload_rows records" do
@@ -44,15 +43,28 @@ module BulkUpdate
 
               it "sets the status to `validated`" do
                 described_class.call(trainee_upload)
+
                 expect(trainee_upload.reload).to be_validated
               end
 
+              it "does not submit for TRN" do
+                allow(Trainees::SubmitForTrn).to receive(:call)
+
+                described_class.call(trainee_upload)
+
+                expect(Trainees::SubmitForTrn).not_to have_received(:call)
+              end
+
               context "when there is a database error" do
-                before { allow(BulkUpdate::TraineeUploadRow).to receive(:create!).and_raise(ActiveRecord::ActiveRecordError) }
+                before do
+                  allow(BulkUpdate::TraineeUploadRow).to receive(:create!).and_raise(ActiveRecord::ActiveRecordError)
+                  allow(Trainees::SubmitForTrn).to receive(:call)
+                end
 
                 it "raises the exception and sets the status to `failed`" do
                   expect { described_class.call(trainee_upload) }.to raise_error(ActiveRecord::ActiveRecordError)
                   expect(trainee_upload.reload).to be_failed
+                  expect(Trainees::SubmitForTrn).not_to have_received(:call)
                 end
               end
             end
@@ -60,15 +72,14 @@ module BulkUpdate
             context "when the upload status is in progress" do
               let(:trainee_upload) { create(:bulk_update_trainee_upload, :with_rows, status: :in_progress) }
 
-              before do
-                allow(ImportRow).to receive(:call).and_return(
-                  BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
-                )
-              end
-
               it "creates 5 trainee records" do
-                expect(ImportRow).to receive(:call).exactly(5).times.and_call_original
+                allow(ImportRow).to receive(:call).and_call_original
+                allow(Trainees::SubmitForTrn).to receive(:call).and_call_original
+
                 expect(described_class.call(trainee_upload)).to be(true)
+
+                expect(ImportRow).to have_received(:call).exactly(5).times
+                expect(Trainees::SubmitForTrn).to have_received(:call).exactly(5).times
               end
 
               it "sets the status to `succeeded`" do
@@ -77,22 +88,30 @@ module BulkUpdate
               end
 
               context "when there is a database error" do
-                before { allow(BulkUpdate::AddTrainees::ImportRow).to receive(:call).and_raise(ActiveRecord::ActiveRecordError) }
+                before do
+                  allow(Trainees::SubmitForTrn).to receive(:call).and_call_original
+                  allow(BulkUpdate::AddTrainees::ImportRow).to receive(:call).and_raise(ActiveRecord::ActiveRecordError)
+                end
 
                 it "sets the status to `failed`" do
                   described_class.call(trainee_upload)
+
                   expect(trainee_upload.reload).to be_failed
+                  expect(Trainees::SubmitForTrn).not_to have_received(:call)
                 end
 
                 it "sends the exception to Sentry" do
-                  expect(Sentry).to receive(:capture_exception).at_least(5).times.with(
+                  allow(Sentry).to receive(:capture_exception)
+
+                  described_class.call(trainee_upload)
+
+                  expect(Sentry).to have_received(:capture_exception).exactly(5).times.with(
                     an_instance_of(ActiveRecord::ActiveRecordError),
                     extra: {
                       provider_id: trainee_upload.provider_id,
                       user_id: trainee_upload.submitted_by_id,
                     },
                   )
-                  described_class.call(trainee_upload)
                 end
               end
             end
@@ -102,15 +121,12 @@ module BulkUpdate
             context "when the upload status is pending" do
               let(:trainee_upload) { create(:bulk_update_trainee_upload, :with_blank_rows, :pending) }
 
-              before do
-                allow(ImportRow).to receive(:call).and_return(
-                  BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
-                )
-              end
-
               it "does not create any trainee records" do
-                expect(ImportRow).to receive(:call).exactly(3).times.and_call_original
+                allow(ImportRow).to receive(:call).and_call_original
+
                 expect(described_class.call(trainee_upload)).to be(true)
+
+                expect(ImportRow).to have_received(:call).exactly(3).times
               end
 
               it "creates bulk_update_trainee_upload_rows records" do
@@ -121,7 +137,16 @@ module BulkUpdate
 
               it "sets the status to `validated`" do
                 described_class.call(trainee_upload)
+
                 expect(trainee_upload.reload).to be_validated
+              end
+
+              it "does not submit for TRN" do
+                allow(Trainees::SubmitForTrn).to receive(:call)
+
+                described_class.call(trainee_upload)
+
+                expect(Trainees::SubmitForTrn).not_to have_received(:call)
               end
             end
           end
@@ -130,15 +155,13 @@ module BulkUpdate
             context "when the upload status is pending" do
               let(:trainee_upload) { create(:bulk_update_trainee_upload, :with_mixed_case_headers, :pending) }
 
-              before do
-                allow(ImportRow).to receive(:call).and_return(
-                  BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
-                )
-              end
 
               it "does not create any trainee records" do
-                expect(ImportRow).to receive(:call).exactly(5).times.and_call_original
+                allow(ImportRow).to receive(:call).and_call_original
+
                 expect(described_class.call(trainee_upload)).to be(true)
+
+                expect(ImportRow).to have_received(:call).exactly(5).times
               end
 
               it "creates bulk_update_trainee_upload_rows records" do
@@ -169,14 +192,16 @@ module BulkUpdate
               trainee_upload.import!
 
               allow(ImportRow).to receive(:call).and_return(
-                BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
-                BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
+                BulkUpdate::AddTrainees::ImportRow::Result.new({}, true, []),
+                BulkUpdate::AddTrainees::ImportRow::Result.new({}, true, []),
                 BulkUpdate::AddTrainees::ImportRow::Result.new(
+                  nil,
                   false,
                   { errors: { funding: ["Funding type is required"], email: "Enter an email address" } },
                 ),
-                BulkUpdate::AddTrainees::ImportRow::Result.new(true, []),
+                BulkUpdate::AddTrainees::ImportRow::Result.new({}, true, []),
                 BulkUpdate::AddTrainees::ImportRow::Result.new(
+                  nil,
                   false,
                   ["Add at least one degree"],
                 ),
@@ -184,9 +209,9 @@ module BulkUpdate
             end
 
             it "does not create any trainee records" do
-              expect(ImportRow).to receive(:call).exactly(5).times.and_call_original
               expect(described_class.call(trainee_upload)).to be(false)
               expect(Trainee.count).to eq(@original_trainee_count)
+              expect(ImportRow).to have_received(:call).exactly(5).times
             end
 
             it "sets the status to `failed`" do


### PR DESCRIPTION
### Context

[8890-missing-trn-requests-for-trainees-created-via-csv-bulk-add-trainees
](https://trello.com/c/t07UAvf6/8890-missing-trn-requests-for-trainees-created-via-csv-bulk-add-trainees)

### Changes proposed in this pull request

* Ensure request for TRN occurs after the trainees have been created

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
