### PR TITLE
[xxxx] Fix old trainee withdrawal path

### DIFF
--- a/app/controllers/trainees/forbidden_deletes_controller.rb
+++ b/app/controllers/trainees/forbidden_deletes_controller.rb
@@ -14,7 +14,7 @@ module Trainees
         if @trainee_forbidden_deletes_form.defer?
           redirect_to(trainee_deferral_path(trainee))
         elsif @trainee_forbidden_deletes_form.withdraw?
-          redirect_to(trainee_withdrawal_path(trainee))
+          redirect_to(trainee_withdrawal_start_path(trainee))
         else
           redirect_to(trainee_path(trainee))
         end


### PR DESCRIPTION
### Context

An old path had not been updated since the new withdrawal journey was put in place. [Reported by Sentry](https://dfe-teacher-services.sentry.io/issues/6888332646/events/c96c01b36ec5413097ba679acd146505/)

### Changes proposed in this pull request

* Update the path

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
