### PR TITLE
[8936] Fix missing `outcome_date` in recommend for award API

### DIFF
--- a/app/services/api/trainees/award_recommendation_service.rb
+++ b/app/services/api/trainees/award_recommendation_service.rb
@@ -33,8 +33,8 @@ module Api
       def call
         return false, errors unless valid?
 
-        trainee.recommend_for_award!
         trainee.attributes = trainee_attributes
+        trainee.recommend_for_award!
 
         ::Trainees::UpdateIttDataInTra.call(trainee:)
 

--- a/spec/services/api/trainees/award_recommendation_service_spec.rb
+++ b/spec/services/api/trainees/award_recommendation_service_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
         expect(Dqt::RecommendForAwardJob).to have_received(:perform_later).with(trainee)
         expect(trainee.recommended_for_award?).to be(true)
       end
+
+      it "sets the outcome_date", feature_integrate_with_dqt: false, feature_integrate_with_trs: false do
+        expect(trainee.outcome_date).to be_nil
+
+        success, errors = subject.call(params, trainee)
+
+        expect(success).to be(true)
+        expect(errors).to be_blank
+
+        expect(trainee.reload.outcome_date).to be_present
+      end
     end
 
     describe "failure" do


### PR DESCRIPTION
### Context
We have seen errors from TRS when recommending for award. This was traced back to a missing `outcome_date` on trainee records created via the API despite there being validations to ensure that this value is set.

https://trello.com/c/hpJ48007/8936-still-getting-hesa-imported-trainees-stuck-at-recommended-for-award-state

### Changes proposed in this pull request

It seems that we were only setting the outcome date _after_ the state change so the `outcome_date` was set in the API response but not actually saved to the database.

### Guidance to review

Anything missing? Is this tested properly?

We also need to check records in production.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
