### PR TITLE
allow nil values for course_subject_two and course_subject_three

### DIFF
--- a/app/services/api/v2025_0/hesa_mapper/attributes.rb
+++ b/app/services/api/v2025_0/hesa_mapper/attributes.rb
@@ -17,6 +17,11 @@ module Api
           application_id
         ].freeze
 
+        ALLOWED_NIL_PARAMS = %w[
+          course_subject_two
+          course_subject_three
+        ].freeze
+
         NOT_APPLICABLE_SCHOOL_URNS = %w[900000 900010 900020 900030].freeze
         VETERAN_TEACHING_UNDERGRADUATE_BURSARY_LEVEL = "C"
         DISABILITY_PARAM_REGEX = /\Adisability\d+\z/
@@ -61,6 +66,7 @@ module Api
           .merge(lead_partner_attributes)
           .merge(employing_school_attributes)
           .compact
+          .merge(allowed_nil_values)
 
           if update && !disabilities?
             mapped_params = mapped_params.except(:hesa_disabilities, :disability_disclosure, :disabilities)
@@ -287,6 +293,10 @@ module Api
 
         def application_choice_id
           params[:application_id]
+        end
+
+        def allowed_nil_values
+          (ALLOWED_NIL_PARAMS & params.compact_blank.keys).index_with { |_key| nil }
         end
       end
     end

--- a/spec/requests/api/v2025_0/put_trainee_spec.rb
+++ b/spec/requests/api/v2025_0/put_trainee_spec.rb
@@ -1047,6 +1047,68 @@ describe "`PUT /api/v2025.0/trainees/:id` endpoint" do
         end
       end
 
+      context "when course_subject_two or course_subject_three are being unset" do
+        before do
+          trainee.update(course_subject_one: "biology",
+                         course_subject_two: "historical linguistics",
+                         course_subject_three: "computer science")
+
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        context "via null values" do
+          let(:params) do
+            {
+              data: {
+                course_subject_one: "100511",
+                course_subject_two: nil,
+                course_subject_three: nil,
+              },
+            }
+          end
+
+          it "sets the correct subjects" do
+            trainee.reload
+
+            expect(trainee.course_subject_one).to eq("primary teaching")
+            expect(trainee.course_subject_two).to be_nil
+            expect(trainee.course_subject_three).to be_nil
+
+            expect(response.parsed_body[:data][:course_subject_one]).to eq("100511")
+            expect(response.parsed_body[:data][:course_subject_two]).to be_nil
+            expect(response.parsed_body[:data][:course_subject_three]).to be_nil
+          end
+        end
+
+        context "via blank values" do
+          let(:params) do
+            {
+              data: {
+                course_subject_one: "100511",
+                course_subject_two: "",
+                course_subject_three: "",
+              },
+            }
+          end
+
+          it "sets the correct subjects" do
+            trainee.reload
+
+            expect(trainee.course_subject_one).to eq("primary teaching")
+            expect(trainee.course_subject_two).to be_nil
+            expect(trainee.course_subject_three).to be_nil
+
+            expect(response.parsed_body[:data][:course_subject_one]).to eq("100511")
+            expect(response.parsed_body[:data][:course_subject_two]).to be_nil
+            expect(response.parsed_body[:data][:course_subject_three]).to be_nil
+          end
+        end
+      end
+
       context "when HasCourseAttributes#primary_education_phase? is false" do
         let(:params) do
           {


### PR DESCRIPTION
### Context

https://trello.com/c/asb5xO6T/8932-allow-api-fields-to-be-set-to-empty-values

### Changes proposed in this pull request

Allow nil values for `course_subject_two` and `course_subject_three` via api requests

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
