### PR TITLE
[8912] Add link to reference docs from api-docs index

### DIFF
--- a/tech_docs/source/api-docs/index.html.md.erb
+++ b/tech_docs/source/api-docs/index.html.md.erb
@@ -79,7 +79,7 @@ various sorts. For example, we record the nationality of trainees.
 This section provides guidance on how those attributes are serialised in the
 requests and responses processed by the API.
 
-For more around reference data you can visit the [reference data documentation](/reference-data/).
+For more information about reference data you can visit the [reference data documentation](/reference-data/).
 
 ### Dates
 All dates and datetimes in the API specification are intended to be [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)


### PR DESCRIPTION
### Context
The _Reference data and data encoding_ section of the API docs index page should have a link to the reference data root.

### Changes proposed in this pull request

- Add content and link to reference docs from api-docs index

<img width="1614" height="640" alt="image" src="https://github.com/user-attachments/assets/942cefa9-6de7-4fff-bdc7-804aecfd6e09" />

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
