### PR TITLE
Add airbyte for review apps

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -86,6 +86,11 @@ runs:
         subscription-id: ${{ inputs.azure-subscription-id }}
         client-id: ${{ inputs.azure-client-id }}
 
+    - uses: google-github-actions/auth@v2
+      with:
+        project_id: rugged-abacus-218110
+        workload_identity_provider: projects/712009772377/locations/global/workloadIdentityPools/register-trainee-teachers/providers/register-trainee-teachers
+
     - name: Terraform init, plan & apply
       shell: bash
       run: make ${{ inputs.environment }} ci deploy

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -115,6 +115,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set Airbyte
+        if: (contains(github.event.pull_request.labels.*.name, 'airbyte'))
+        run: |
+          echo "TF_VAR_pg_airbyte_enabled=true" >> $GITHUB_ENV
+          echo "TF_VAR_airbyte_enabled=true" >> $GITHUB_ENV
+          echo "TF_VAR_connection_status=active" >> $GITHUB_ENV
+
       - name: Deploy App to Review
         id: deploy_review
         uses: ./.github/actions/deploy/

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -35,6 +35,13 @@ jobs:
         run: |
           echo "APP_NAME=pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}" >> $GITHUB_ENV
 
+      - name: Set Airbyte
+        if: (contains(github.event.pull_request.labels.*.name, 'airbyte'))
+        run: |
+          echo "TF_VAR_pg_airbyte_enabled=true" >> $GITHUB_ENV
+          echo "TF_VAR_airbyte_enabled=true" >> $GITHUB_ENV
+          echo "TF_VAR_connection_status=active" >> $GITHUB_ENV
+
       - uses: DFE-Digital/github-actions/delete-review-app@master
         with:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -47,3 +54,5 @@ jobs:
           tf-state-file: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}.tfstate
           terraform-base: terraform/aks
           tf-file: provider.tf
+          gcp-project-id: rugged-abacus-218110
+          gcp-wip: projects/712009772377/locations/global/workloadIdentityPools/register-trainee-teachers/providers/register-trainee-teachers

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ ci:	## Run in automation environment
 	$(eval export AUTO_APPROVE=-auto-approve)
 	$(eval SKIP_CONFIRM=true)
 
+airbyte: ## Add airbyte for review apps
+	$(if $(APP_NAME), , $(error Missing environment variable "APP_NAME", Please specify a pr number for your review app))
+	$(eval export TF_VAR_pg_airbyte_enabled=true)
+	$(eval export TF_VAR_airbyte_enabled=true)
+	$(eval export TF_VAR_connection_status=active)
+
 review:
 	$(if $(APP_NAME), , $(error Missing environment variable "APP_NAME", Please specify a pr number for your review app))
 	$(eval include global_config/review.sh)

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -53,4 +53,13 @@ DfE::Analytics.configure do |config|
   # instead of the BigQuery API JSON Key. Note that this also will also
   # use a new version of the BigQuery streaming APIs.
   config.azure_federated_auth = true
+
+  # Perform airbyte checks on startup and allow airbyte config generation
+  config.airbyte_enabled = true
+
+  # Path of airbyte stream config file relative to the App root (Rails.root)
+  config.airbyte_stream_config_path = "terraform/aks/workspace-variables/airbyte_stream_config.json"
+
+  # Set bigquery airbyte vars
+  config.bigquery_hidden_policy_tag = "projects/rugged-abacus-218110/locations/europe-west2/taxonomies/69524444121704657/policyTags/6523652585511281766"
 end

--- a/terraform/aks/airbyte.tf
+++ b/terraform/aks/airbyte.tf
@@ -1,0 +1,84 @@
+provider "google" {
+  project = "rugged-abacus-218110"
+}
+
+data "azurerm_key_vault_secret" "airbyte_client_id" {
+  count = var.airbyte_enabled ? 1 : 0
+
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "AIRBYTE-CLIENT-ID"
+}
+
+data "azurerm_key_vault_secret" "airbyte_client_secret" {
+  count = var.airbyte_enabled ? 1 : 0
+
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "AIRBYTE-CLIENT-SECRET"
+}
+
+data "azurerm_key_vault_secret" "airbyte_workspace_id" {
+  count = var.airbyte_enabled ? 1 : 0
+
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "AIRBYTE-WORKSPACE-ID"
+}
+
+# change this to a random password?
+data "azurerm_key_vault_secret" "airbyte_replication_password" {
+  count = var.airbyte_enabled ? 1 : 0
+
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "AIRBYTE-REPLICATION-PASSWORD"
+}
+
+module "airbyte" {
+  source = "./vendor/modules/aks//aks/airbyte"
+
+  count = var.airbyte_enabled ? 1 : 0
+
+  environment           = local.app_name_suffix
+  azure_resource_prefix = var.azure_resource_prefix
+  service_short         = var.service_short
+  service_name          = var.service_name
+  docker_image          = var.app_docker_image
+  postgres_version      = var.postgres_version
+  postgres_url          = module.postgres.url
+
+  host_name          = module.postgres.host
+  database_name      = module.postgres.name
+  workspace_id       = data.azurerm_key_vault_secret.airbyte_workspace_id[0].value
+  client_id          = data.azurerm_key_vault_secret.airbyte_client_id[0].value
+  client_secret      = data.azurerm_key_vault_secret.airbyte_client_secret[0].value
+  repl_password      = data.azurerm_key_vault_secret.airbyte_replication_password[0].value
+  server_url         = "https://airbyte-${var.namespace}.${module.cluster_data.ingress_domain}"
+  connection_status  = var.connection_status
+  connection_streams = local.connection_streams
+
+  cluster           = var.cluster
+  namespace         = var.namespace
+  gcp_taxonomy_id   = "69524444121704657"
+  gcp_policy_tag_id = "6523652585511281766"
+  gcp_keyring       = "bat-key-ring"
+  gcp_key           = "bat-key"
+
+  config_map_ref = module.application_configuration.kubernetes_config_map_name
+  secret_ref     = module.application_configuration.kubernetes_secret_name
+  cpu            = module.cluster_data.configuration_map.cpu_min
+
+  use_azure = var.deploy_azure_backing_services
+}
+
+## Airbyte module variables
+
+variable "airbyte_enabled" { default = false }
+
+variable "connection_status" {
+  type = string
+  default = "inactive"
+  description = "Connectin status, either active or inactive"
+}
+
+locals {
+  connection_streams = var.airbyte_enabled ? file("workspace-variables/airbyte_stream_config.json") : null
+  gcp_dataset_name   = replace("${var.service_short}_airbyte_${local.app_name_suffix}", "-", "_")
+}

--- a/terraform/aks/provider.tf
+++ b/terraform/aks/provider.tf
@@ -13,6 +13,10 @@ terraform {
       source = "hashicorp/kubernetes"
       version = "2.32.0"
     }
+    airbyte = {
+      source  = "airbytehq/airbyte"
+      version = "0.10.0"
+    }
   }
   backend "azurerm" {
   }
@@ -37,4 +41,11 @@ provider "kubernetes" {
       command     = "kubelogin"
       args        = module.cluster_data.kubelogin_args
   }
+}
+
+provider "airbyte" {
+  # Configuration options
+  server_url = var.airbyte_enabled ? "https://airbyte-${var.namespace}.${module.cluster_data.ingress_domain}/api/public/v1" : ""
+  client_id = var.airbyte_enabled ? data.azurerm_key_vault_secret.airbyte_client_id[0].value : ""
+  client_secret = var.airbyte_enabled ? data.azurerm_key_vault_secret.airbyte_client_secret[0].value: ""
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -111,6 +111,7 @@ locals {
     {
       DB_SSLMODE                                  = var.db_sslmode
       SETTINGS__AZURE__STORAGE__TEMP_DATA_ACCOUNT = local.azure_tempdata_storage_account_name
+      BIGQUERY_AIRBYTE_DATASET                    = var.airbyte_enabled ? local.gcp_dataset_name : null
     }
   )
 

--- a/terraform/aks/workspace-variables/airbyte_stream_config.json
+++ b/terraform/aks/workspace-variables/airbyte_stream_config.json
@@ -1,0 +1,2582 @@
+{
+  "configurations": {
+    "streams": [
+      {
+        "name": "academic_cycles",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "end_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "start_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "activities",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "action_name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "controller_name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "metadata"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "user_id"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "allocation_subjects",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "apply_applications",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "accredited_body_code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "apply_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "recruitment_cycle_year"
+            ]
+          },
+          {
+            "fieldPath": [
+              "state"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "bulk_update_row_errors",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "errored_on_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "errored_on_type"
+            ]
+          },
+          {
+            "fieldPath": [
+              "error_type"
+            ]
+          },
+          {
+            "fieldPath": [
+              "message"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "bulk_update_trainee_uploads",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "provider_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "status"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "submitted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "submitted_by_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "number_of_trainees"
+            ]
+          },
+          {
+            "fieldPath": [
+              "version"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "course_subjects",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "subject_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "courses",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "accredited_body_code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_length"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "duration_in_years"
+            ]
+          },
+          {
+            "fieldPath": [
+              "full_time_end_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "full_time_start_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "level"
+            ]
+          },
+          {
+            "fieldPath": [
+              "max_age"
+            ]
+          },
+          {
+            "fieldPath": [
+              "min_age"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "part_time_end_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "part_time_start_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "published_start_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "qualification"
+            ]
+          },
+          {
+            "fieldPath": [
+              "recruitment_cycle_year"
+            ]
+          },
+          {
+            "fieldPath": [
+              "route"
+            ]
+          },
+          {
+            "fieldPath": [
+              "study_mode"
+            ]
+          },
+          {
+            "fieldPath": [
+              "summary"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "degrees",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "country"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dttp_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "grade"
+            ]
+          },
+          {
+            "fieldPath": [
+              "grade_uuid"
+            ]
+          },
+          {
+            "fieldPath": [
+              "graduation_year"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "institution"
+            ]
+          },
+          {
+            "fieldPath": [
+              "institution_uuid"
+            ]
+          },
+          {
+            "fieldPath": [
+              "locale_code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "non_uk_degree"
+            ]
+          },
+          {
+            "fieldPath": [
+              "other_grade"
+            ]
+          },
+          {
+            "fieldPath": [
+              "slug"
+            ]
+          },
+          {
+            "fieldPath": [
+              "subject"
+            ]
+          },
+          {
+            "fieldPath": [
+              "subject_uuid"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "uk_degree"
+            ]
+          },
+          {
+            "fieldPath": [
+              "uk_degree_uuid"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "disabilities",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "dqt_trn_requests",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "request_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "response"
+            ]
+          },
+          {
+            "fieldPath": [
+              "state"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "dttp_providers",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dttp_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "ukprn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "dttp_schools",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dttp_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "status_code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "urn"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "funding_method_subjects",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "allocation_subject_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "funding_method_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "funding_methods",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "academic_cycle_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "amount"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "funding_type"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "training_route"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "hesa_metadata",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_programme_title"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "fundability"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "itt_aim"
+            ]
+          },
+          {
+            "fieldPath": [
+              "itt_qualification_aim"
+            ]
+          },
+          {
+            "fieldPath": [
+              "pg_apprenticeship_start_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "placement_school_urn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "service_leaver"
+            ]
+          },
+          {
+            "fieldPath": [
+              "study_length"
+            ]
+          },
+          {
+            "fieldPath": [
+              "study_length_unit"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "year_of_course"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "hesa_trn_submissions",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "submitted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "lead_partner_users",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "lead_partner_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "user_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "lead_partners",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "urn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "record_type"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "ukprn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "school_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "provider_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "discarded_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "nationalities",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "nationalisations",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "nationality_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "placements",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "school_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "urn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "address"
+            ]
+          },
+          {
+            "fieldPath": [
+              "postcode"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "slug"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "potential_duplicate_trainees",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "group_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "provider_users",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "provider_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "user_id"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "providers",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "accreditation_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "apply_sync_enabled"
+            ]
+          },
+          {
+            "fieldPath": [
+              "code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dttp_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "ukprn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "accredited"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "discarded_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "schools",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "close_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "open_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "postcode"
+            ]
+          },
+          {
+            "fieldPath": [
+              "town"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "urn"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "sign_offs",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "provider_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "academic_cycle_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "user_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "sign_off_type"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "subject_specialisms",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "allocation_subject_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "hecos_code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "subjects",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "trainee_withdrawal_reasons",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "withdrawal_reason_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_withdrawal_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "trainee_withdrawals",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trigger"
+            ]
+          },
+          {
+            "fieldPath": [
+              "another_reason"
+            ]
+          },
+          {
+            "fieldPath": [
+              "future_interest"
+            ]
+          },
+          {
+            "fieldPath": [
+              "discarded_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "trainees",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "apply_application_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "applying_for_bursary"
+            ]
+          },
+          {
+            "fieldPath": [
+              "applying_for_grant"
+            ]
+          },
+          {
+            "fieldPath": [
+              "applying_for_scholarship"
+            ]
+          },
+          {
+            "fieldPath": [
+              "awarded_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "bursary_tier"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trainee_start_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "commencement_status"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_allocation_subject_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_education_phase"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_max_age"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_min_age"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_subject_one"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_subject_three"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_subject_two"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_uuid"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_from_dttp"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_from_hesa"
+            ]
+          },
+          {
+            "fieldPath": [
+              "date_of_birth"
+            ]
+          },
+          {
+            "fieldPath": [
+              "defer_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "defer_reason"
+            ]
+          },
+          {
+            "fieldPath": [
+              "disability_disclosure"
+            ]
+          },
+          {
+            "fieldPath": [
+              "discarded_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "diversity_disclosure"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dormancy_dttp_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dttp_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dttp_update_sha"
+            ]
+          },
+          {
+            "fieldPath": [
+              "ebacc"
+            ]
+          },
+          {
+            "fieldPath": [
+              "email"
+            ]
+          },
+          {
+            "fieldPath": [
+              "employing_school_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "employing_school_not_applicable"
+            ]
+          },
+          {
+            "fieldPath": [
+              "end_academic_cycle_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "first_names"
+            ]
+          },
+          {
+            "fieldPath": [
+              "sex"
+            ]
+          },
+          {
+            "fieldPath": [
+              "hesa_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "hesa_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "iqts_country"
+            ]
+          },
+          {
+            "fieldPath": [
+              "itt_end_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "itt_start_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "last_name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "lead_partner_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "placement_detail"
+            ]
+          },
+          {
+            "fieldPath": [
+              "lead_partner_not_applicable"
+            ]
+          },
+          {
+            "fieldPath": [
+              "outcome_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "placement_assignment_dttp_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "progress"
+            ]
+          },
+          {
+            "fieldPath": [
+              "provider_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "recommended_for_award_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "record_source"
+            ]
+          },
+          {
+            "fieldPath": [
+              "region"
+            ]
+          },
+          {
+            "fieldPath": [
+              "reinstate_date"
+            ]
+          },
+          {
+            "fieldPath": [
+              "slug"
+            ]
+          },
+          {
+            "fieldPath": [
+              "start_academic_cycle_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "state"
+            ]
+          },
+          {
+            "fieldPath": [
+              "study_mode"
+            ]
+          },
+          {
+            "fieldPath": [
+              "submission_ready"
+            ]
+          },
+          {
+            "fieldPath": [
+              "submitted_for_trn_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "training_initiative"
+            ]
+          },
+          {
+            "fieldPath": [
+              "training_route"
+            ]
+          },
+          {
+            "fieldPath": [
+              "trn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "hesa_trn_submission_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "hesa_editable"
+            ]
+          },
+          {
+            "fieldPath": [
+              "slug_sent_to_dqt_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "application_choice_id"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "users",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dfe_sign_in_uid"
+            ]
+          },
+          {
+            "fieldPath": [
+              "discarded_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "dttp_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "email"
+            ]
+          },
+          {
+            "fieldPath": [
+              "first_name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "last_name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "last_signed_in_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "system_admin"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "welcome_email_sent_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "withdrawal_reasons",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Context

Add airbyte to review apps

### Changes proposed in this pull request

Airbyte configuration files
Airbyte resources will be created for a PR if the airbyte label is added alongside the deploy label

### Guidance to review

Add deploy and airbyte labels
check delete-review-app with airbyte label workflow https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/18537567228 

register should be updated to DFE-Analytics v1.15.9 before merge, and remove v1.15.9 from this PR

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
