### PR TITLE
[8986, 8984, 8949] - Second Wednesday for census sign off and remove AO trainees

### DIFF
--- a/app/controllers/reports/censuses_controller.rb
+++ b/app/controllers/reports/censuses_controller.rb
@@ -97,7 +97,7 @@ module Reports
     end
 
     def itt_new_starter_trainees
-      @itt_new_starter_trainees ||= policy_scope(FindNewStarterTrainees.new(@current_academic_cycle.first_day_of_september).call)
+      @itt_new_starter_trainees ||= policy_scope(FindNewStarterTrainees.new(@current_academic_cycle.second_wednesday_of_october).call)
     end
 
     def itt_new_starter_filename

--- a/app/services/find_new_starter_trainees.rb
+++ b/app/services/find_new_starter_trainees.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class FindNewStarterTrainees
+  EXCLUDED_ROUTES = [
+    TRAINING_ROUTE_ENUMS[:assessment_only],
+    TRAINING_ROUTE_ENUMS[:early_years_assessment_only],
+  ].freeze
+
   attr_reader :census_date
 
   def initialize(census_date)
@@ -11,6 +16,7 @@ class FindNewStarterTrainees
     trainees = Trainee.where("itt_start_date <= :date or trainee_start_date <= :date", date: census_date)
                       .or(Trainee.where(trainee_start_date: nil))
                       .where(start_academic_cycle_id: AcademicCycle.current)
+                      .where.not(training_route: EXCLUDED_ROUTES)
                       .not_draft
 
     Trainees::Filter.call(trainees: trainees, filters: nil)

--- a/spec/controllers/reports/censuses_controller_spec.rb
+++ b/spec/controllers/reports/censuses_controller_spec.rb
@@ -4,9 +4,10 @@ require "rails_helper"
 
 describe Reports::CensusesController do
   let(:user) { build_current_user }
+  let(:academic_cycle) { create(:academic_cycle, previous_cycle: false) }
 
   before do
-    create(:academic_cycle, previous_cycle: false)
+    academic_cycle
     allow(controller).to receive(:current_user).and_return(user)
     allow(DetermineSignOffPeriod).to receive(:call).and_return(:census_period)
   end
@@ -25,6 +26,16 @@ describe Reports::CensusesController do
     it "renders a csv" do
       get :index, params: { format: :csv }
       expect(response.content_type).to eq("text/csv; charset=utf-8")
+    end
+
+    context "csv export" do
+      it "uses the second wednesday of october as the census date" do
+        expect(FindNewStarterTrainees).to receive(:new)
+          .with(academic_cycle.second_wednesday_of_october)
+          .and_call_original
+
+        get :index, params: { format: :csv }
+      end
     end
   end
 end

--- a/spec/services/find_new_starter_trainees_spec.rb
+++ b/spec/services/find_new_starter_trainees_spec.rb
@@ -18,10 +18,10 @@ describe FindNewStarterTrainees do
     end
   end
 
-  let(:valid_trainee) { create(:trainee, state: 1, itt_start_date: 2.months.ago, start_academic_cycle: AcademicCycle.current) }
-  let(:valid_trainee_with_no_trainee_start_date) { create(:trainee, state: 1, trainee_start_date: nil, start_academic_cycle: AcademicCycle.current) }
-  let(:valid_draft_trainee) { create(:trainee, state: 0, itt_start_date: 2.months.ago, start_academic_cycle: AcademicCycle.current) }
-  let(:valid_trainee_from_previous_academic_cycle) { create(:trainee, state: 0, itt_start_date: 2.months.ago, start_academic_cycle_id: 10) }
+  let(:valid_trainee) { create(:trainee, state: 1, itt_start_date: 2.months.ago, start_academic_cycle: AcademicCycle.current, training_route: :provider_led_postgrad) }
+  let(:valid_trainee_with_no_trainee_start_date) { create(:trainee, state: 1, trainee_start_date: nil, start_academic_cycle: AcademicCycle.current, training_route: :provider_led_postgrad) }
+  let(:valid_draft_trainee) { create(:trainee, state: 0, itt_start_date: 2.months.ago, start_academic_cycle: AcademicCycle.current, training_route: :provider_led_postgrad) }
+  let(:valid_trainee_from_previous_academic_cycle) { create(:trainee, state: 0, itt_start_date: 2.months.ago, start_academic_cycle_id: 10, training_route: :provider_led_postgrad) }
 
   it "to contain non draft current academic cycle trainees starting before the census date" do
     expect(subject).to include(valid_trainee)
@@ -47,9 +47,42 @@ describe FindNewStarterTrainees do
         itt_start_date: 2.months.ago,
         start_academic_cycle: AcademicCycle.current,
         record_source: Trainee::HESA_TRN_DATA_SOURCE,
+        training_route: :provider_led_postgrad,
       )
     end
 
     it { is_expected.to include(trainee) }
+  end
+
+  context "when trainee is on assessment only route" do
+    let(:assessment_only_trainee) do
+      create(
+        :trainee,
+        state: 1,
+        itt_start_date: 2.months.ago,
+        start_academic_cycle: AcademicCycle.current,
+        training_route: :assessment_only,
+      )
+    end
+
+    it "does not include assessment only trainees" do
+      expect(subject).not_to include(assessment_only_trainee)
+    end
+  end
+
+  context "when trainee is on early years assessment only route" do
+    let(:early_years_assessment_only_trainee) do
+      create(
+        :trainee,
+        state: 1,
+        itt_start_date: 2.months.ago,
+        start_academic_cycle: AcademicCycle.current,
+        training_route: :early_years_assessment_only,
+      )
+    end
+
+    it "does not include early years assessment only trainees" do
+      expect(subject).not_to include(early_years_assessment_only_trainee)
+    end
   end
 end


### PR DESCRIPTION
### Context

There are two support tickets with a similar issue around census sign off data:

[One](https://trello.com/c/jPv8m0ck/8984-chester-uni-sign-off-showing-125-out-of-400-new-starters) [Two](https://trello.com/c/JQohhoSK/8986-sign-off-issue)

Additionally, there we should be filtering out AO trainees according to this [support ticket](https://trello.com/c/dgt1c324/8949-cannot-add-age-range-to-trainees)

### Changes proposed in this pull request

* It looks like the CSV export is using a different date than the guidance. This changes the `itt_new_starter_trainees` range used to `second_wednesday_of_october` which matches the range used for the view.
* Filter out AO trainees

### Guidance to review

sanity check the change. This could be deployed to production data to verify the fix, a review app won't tell us much.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
