### PR TITLE
[9516] Remove version pinning from yarn packages in GitHub workflows for tests and linting

### DIFF
--- a/.github/actions/coverage-tests/action.yml
+++ b/.github/actions/coverage-tests/action.yml
@@ -36,7 +36,7 @@ runs:
       run: |
         docker compose exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
         docker compose exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
-        docker compose exec -T web /bin/sh -c "yarn add jest@30.0.0"
+        docker compose exec -T web /bin/sh -c "yarn install --immutable"
         docker compose exec -T web /bin/sh -c "RAILS_ENV=test bundle exec rails assets:precompile"
         docker compose exec -T web /bin/sh -c 'apk add chromium chromium-chromedriver'
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -56,9 +56,7 @@ jobs:
             command: docker compose exec -T web /bin/sh -c 'bundle exec rubocop app config db lib spec Gemfile --format clang'
           - linter-type: scss
             command: |
-              docker compose exec -T web /bin/sh -c "yarn add stylelint@15.11.0"
-              docker compose exec -T web /bin/sh -c "yarn add stylelint-scss@5.3.1"
-              docker compose exec -T web /bin/sh -c "yarn add stylelint-config-gds@1.1.0"
+              docker compose exec -T web /bin/sh -c "yarn install --immutable"
               docker compose exec -T web /bin/sh -c "yarn run scss:lint"
           - linter-type: dfe_analytics
             command: |
@@ -66,7 +64,7 @@ jobs:
               docker compose exec -T web /bin/sh -c 'bundle exec rake dfe:analytics:check'
           - linter-type: javascript_lint_and_test
             command: |
-              docker compose exec -T web /bin/sh -c "yarn add jest@30.0.0"
+              docker compose exec -T web /bin/sh -c "yarn install --immutable"
               docker compose exec -T web /bin/sh -c "yarn run standard $(git ls-files '**.js' | tr '\n' ' ')"
               docker compose exec -T web /bin/sh -c 'yarn run test'
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -36,7 +36,7 @@ jobs:
         uses: DFE-Digital/github-actions/build-docker-image@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          teams-webhook: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
           context: ""
 
   coverage_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           docker compose exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
           docker compose exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
-          docker compose exec -T web /bin/sh -c "yarn add jest@30.0.0"
+          docker compose exec -T web /bin/sh -c "yarn install --immutable"
           docker compose exec -T web /bin/sh -c "RAILS_ENV=test bundle exec rails assets:precompile"
           docker compose exec -T web /bin/sh -c 'apk add chromium chromium-chromedriver'
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -117,7 +117,7 @@ $mobile-big-end: 501px;
 }
 
 // Display for js only
-body:not(.js-enabled) .app-js-only {
+:not(.js-enabled) .app-js-only {
   display: none;
 }
 

--- a/app/assets/stylesheets/trainee_list.scss
+++ b/app/assets/stylesheets/trainee_list.scss
@@ -1,5 +1,5 @@
 .app-records-actions {
-  margin: 0 0 govuk-spacing(3) 0;
+  margin: 0 0 govuk-spacing(3);
   border-bottom: 1px solid govuk-colour("mid-grey");
 
   @include govuk-clearfix;


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/dTWrus6r/9516-remove-version-pinning-from-yarn-packages-in-github-workflows-for-tests-and-linting)

### Changes proposed in this pull request

* Removed pinned versions from GH workflows that were out of date
* Installed JS dependencies using versions from package.js
* Fixed SCSS linting issues

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
