### PR TITLE
[9500] Check bulk processes for TRN duplicate matching issue

### DIFF
--- a/app/services/bulk_update/placements/import_rows.rb
+++ b/app/services/bulk_update/placements/import_rows.rb
@@ -35,7 +35,7 @@ module BulkUpdate
       end
 
       def find_trainees(trn)
-        provider.trainees.where(trn:)
+        provider.trainees.kept.where(trn:)
       end
 
       def valid_trainee?(trainees, trn, rows)

--- a/spec/services/api/find_duplicate_trainees_spec.rb
+++ b/spec/services/api/find_duplicate_trainees_spec.rb
@@ -127,6 +127,26 @@ describe Api::FindDuplicateTrainees do
     ).to eq([Api::V20250::TraineeSerializer.new(trainee).as_hash])
   end
 
+  it "does not return discarded trainees as duplicates" do
+    trainee.discard
+
+    attributes = trainee_attributes.new(
+      first_names: "Bob",
+      last_name: "Roberts",
+      date_of_birth: trainee.date_of_birth,
+      training_route: trainee.training_route,
+      itt_start_date: trainee.itt_start_date,
+    )
+
+    expect(
+      described_class.call(
+        current_provider: trainee.provider,
+        trainee_attributes: attributes,
+        serializer_klass: serializer_klass,
+      ),
+    ).to be_empty
+  end
+
   it "doesn't return trainees that are have a different first name and email" do
     attributes = trainee_attributes.new(
       first_names: "Bobbie",

--- a/spec/services/bulk_update/placements/import_rows_spec.rb
+++ b/spec/services/bulk_update/placements/import_rows_spec.rb
@@ -227,6 +227,45 @@ module BulkUpdate
           end
         end
 
+        context "when a discarded trainee exists with the same TRN as an active trainee" do
+          let(:trainee) { create(:trainee, :trn_received, provider:) }
+          let(:trns) { [trainee.trn] }
+          let(:rows) { bulk_update_placement.rows }
+
+          before do
+            create(:trainee, :discarded, trn: trainee.trn, provider: provider)
+            create_rows_for_bulk_placement(trns)
+          end
+
+          it "ignores the discarded trainee and imports successfully" do
+            described_class.call(bulk_update_placement)
+
+            expect(trainee.placements.count).to eq(1)
+            rows.each { |row| expect(row.state).to eql "imported" }
+          end
+        end
+
+        context "when only a discarded trainee exists for a TRN" do
+          let(:trn) { "1234567" }
+          let(:trns) { [trn] }
+          let(:rows) { bulk_update_placement.rows }
+
+          before do
+            create(:trainee, :discarded, trn:, provider:)
+            create_rows_for_bulk_placement(trns)
+
+            allow(ImportRow).to receive(:call)
+          end
+
+          it "marks rows as failed with no trainee found error" do
+            described_class.call(bulk_update_placement)
+
+            expect(ImportRow).to have_received(:call).exactly(0).times
+
+            check_rows_for_errors("No trainee was found for TRN:", "failed")
+          end
+        end
+
         context "when there are multiple trainees for a TRN" do
           let(:trns) { %w[1234567 1234567] }
           let(:rows) { bulk_update_placement.rows }

--- a/spec/services/bulk_update/recommendations_uploads/trainee_lookup_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/trainee_lookup_spec.rb
@@ -37,6 +37,17 @@ module BulkUpdate
       it "returns the trainees with matching Trainee ID" do
         expect(subject[trainee.provider_trainee_id]).to eq([trainee])
       end
+
+      context "when a discarded trainee exists with the same TRN" do
+        let!(:discarded_trainee) do
+          create(:trainee, :discarded, trn: trainee.trn, provider: trainee.provider)
+        end
+
+        it "excludes the discarded trainee from results" do
+          expect(subject[trainee.trn]).to eq([trainee])
+          expect(subject[trainee.trn]).not_to include(discarded_trainee)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

[9500-check-bulk-processes-for-trn-duplicate-matching-issue
](https://trello.com/c/obUcmiR5/9500-check-bulk-processes-for-trn-duplicate-matching-issue)

### Changes proposed in this pull request

* Added `.kept` to `BulkUpdate::Placements::ImportRows#find_trainees` to exclude discarded trainees from TRN lookup

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
