### PR TITLE
Update postgres sku to v5 for non-production

### DIFF
--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -72,7 +72,7 @@ variable "main_app" {
 
 variable "azure_maintenance_window" { default = null }
 variable "postgres_flexible_server_sku" { default = "B_Standard_B1ms" }
-variable "snapshot_flexible_server_sku" { default = "GP_Standard_D2ds_v4" }
+variable "snapshot_flexible_server_sku" { default = "GP_Standard_D2ds_v5" }
 variable "postgres_enable_high_availability" { default = false }
 variable "azure_enable_backup_storage" { default = true }
 variable "enable_container_monitoring" { default = false }

--- a/terraform/aks/workspace-variables/productiondata.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata.tfvars.json
@@ -26,7 +26,7 @@
     "start_hour": 2,
     "start_minute": 0
   },
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
   "azure_enable_backup_storage": false,
   "azure_tempdata_storage_account_name": "s189p01registerpdttmp",
   "azure_resource_group_name": "s189p01-rtt-pdt-rg",

--- a/terraform/aks/workspace-variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace-variables/sandbox.tfvars.json
@@ -26,7 +26,7 @@
     "start_hour": 2,
     "start_minute": 0
   },
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
   "azure_enable_backup_storage": false,
   "azure_tempdata_storage_account_name": "s189p01registersbxtmp",
   "azure_resource_group_name": "s189p01-rtt-sbx-rg",

--- a/terraform/aks/workspace-variables/staging.tfvars.json
+++ b/terraform/aks/workspace-variables/staging.tfvars.json
@@ -6,7 +6,7 @@
   "namespace": "bat-production",
   "db_sslmode": "prefer",
   "postgres_version": 16,
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
   "main_app": {
     "main": {
       "startup_command": ["/bin/sh", "-c", "STATEMENT_TIMEOUT=90s bundle exec rails db:migrate && unset STATEMENT_TIMEOUT && bundle exec rails server -b 0.0.0.0"],


### PR DESCRIPTION
### Context

Upgrade the following non-prod postgres servers to v5

s189p01-rtt-pd-pg-analysis
s189p01-rtt-pdt-pg
s189p01-rtt-sbx-pg
s189p01-rtt-stg-pg

This will cause a 10-20 minute downtime for each server.
Register have confirmed this can be run after 5pm with a maintenance page raised for sandbox. 

### Changes proposed in this pull request

Replace v4 sku with the v5 version
This will give a performance improvement without any price increase

### Guidance to review

make env deploy-plan

All willl be updated in-place

<img width="647" height="154" alt="image" src="https://github.com/user-attachments/assets/056dcfd4-5658-4b95-848c-ba54c202d7ae" />

<img width="637" height="137" alt="image" src="https://github.com/user-attachments/assets/53db02ff-a382-4a5f-bba5-588146a885a3" />

<img width="639" height="200" alt="image" src="https://github.com/user-attachments/assets/a06a6c27-eb86-422d-a0d4-bdfd66458197" />

<img width="633" height="208" alt="image" src="https://github.com/user-attachments/assets/589bb420-cc86-4ad6-b4e3-4086723e91a5" />


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
