### PR TITLE
[9519] - Fix error messages to reference the submitted field 

### DIFF
--- a/app/models/api/error_attribute_adapter.rb
+++ b/app/models/api/error_attribute_adapter.rb
@@ -48,6 +48,13 @@ module Api
       end
     end
 
+    # Rails' Error.generate_message calls read_attribute_for_validation before
+    # merging explicit value: options, raising NoMethodError for error attributes
+    # that don't correspond to model attributes (e.g. training_partner_urn).
+    def read_attribute_for_validation(attr)
+      respond_to?(attr) ? super : nil
+    end
+
     def errors
       model = self
 

--- a/app/models/api/v2026_0/trainee_attributes.rb
+++ b/app/models/api/v2026_0/trainee_attributes.rb
@@ -490,7 +490,8 @@ module Api
 
       def validate_training_partner
         if training_partner_id.is_a?(Api::HesaMapper::Attributes::InvalidValue)
-          errors.add(:training_partner_id, :invalid, value: training_partner_id.to_s)
+          field = training_partner_id.source_attribute || :training_partner_id
+          errors.add(field, :invalid, value: training_partner_id.to_s)
         end
       end
 

--- a/app/models/api/v2026_1/trainee_attributes.rb
+++ b/app/models/api/v2026_1/trainee_attributes.rb
@@ -502,7 +502,8 @@ module Api
 
       def validate_training_partner
         if training_partner_id.is_a?(Api::HesaMapper::Attributes::InvalidValue)
-          errors.add(:training_partner_id, :invalid, value: training_partner_id.to_s)
+          field = training_partner_id.source_attribute || :training_partner_id
+          errors.add(field, :invalid, value: training_partner_id.to_s)
         end
       end
 

--- a/app/services/api/hesa_mapper/attributes.rb
+++ b/app/services/api/hesa_mapper/attributes.rb
@@ -3,7 +3,9 @@
 module Api
   module HesaMapper
     module Attributes
-      InvalidValue = Struct.new(:original_value) do
+      # source_attribute tracks which input field (e.g. :training_partner_urn)
+      # produced the invalid value, so validation errors reference the right field.
+      InvalidValue = Struct.new(:original_value, :source_attribute) do
         delegate :to_s, to: :original_value
       end
     end

--- a/app/services/api/v2026_0/hesa_mapper/attributes.rb
+++ b/app/services/api/v2026_0/hesa_mapper/attributes.rb
@@ -250,7 +250,7 @@ module Api
         def training_partner_from_urn
           training_partner_id =
             if params[:training_partner_urn].present? && !NOT_APPLICABLE_SCHOOL_URNS.include?(params[:training_partner_urn])
-              TrainingPartner.find_by(urn: params[:training_partner_urn])&.id || InvalidValue.new(params[:training_partner_urn])
+              TrainingPartner.find_by(urn: params[:training_partner_urn])&.id || InvalidValue.new(params[:training_partner_urn], :training_partner_urn)
             end
 
           {
@@ -262,7 +262,7 @@ module Api
         def training_partner_from_ukprn
           training_partner_id =
             if params[:training_partner_ukprn].present?
-              TrainingPartner.find_by(ukprn: params[:training_partner_ukprn])&.id || InvalidValue.new(params[:training_partner_ukprn])
+              TrainingPartner.find_by(ukprn: params[:training_partner_ukprn])&.id || InvalidValue.new(params[:training_partner_ukprn], :training_partner_ukprn)
             end
 
           {

--- a/app/services/api/v2026_1/hesa_mapper/attributes.rb
+++ b/app/services/api/v2026_1/hesa_mapper/attributes.rb
@@ -260,7 +260,7 @@ module Api
         def training_partner_from_urn
           training_partner_id =
             if params[:training_partner_urn].present? && !NOT_APPLICABLE_SCHOOL_URNS.include?(params[:training_partner_urn])
-              TrainingPartner.find_by(urn: params[:training_partner_urn])&.id || InvalidValue.new(params[:training_partner_urn])
+              TrainingPartner.find_by(urn: params[:training_partner_urn])&.id || InvalidValue.new(params[:training_partner_urn], :training_partner_urn)
             end
 
           {
@@ -272,7 +272,7 @@ module Api
         def training_partner_from_ukprn
           training_partner_id =
             if params[:training_partner_ukprn].present?
-              TrainingPartner.find_by(ukprn: params[:training_partner_ukprn])&.id || InvalidValue.new(params[:training_partner_ukprn])
+              TrainingPartner.find_by(ukprn: params[:training_partner_ukprn])&.id || InvalidValue.new(params[:training_partner_ukprn], :training_partner_ukprn)
             end
 
           {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2250,6 +2250,10 @@ en:
               invalid: is invalid. The URN '%{value}' does not match any known training partners
               csv:
                 invalid: Training Partner URN is invalid. The URN '%{value}' does not match any known training partners
+            training_partner_urn:
+              invalid: is invalid. The URN '%{value}' does not match any known training partners
+            training_partner_ukprn:
+              invalid: is invalid. The UKPRN '%{value}' does not match any known training partners
             employing_school_id:
               invalid: is invalid. The URN '%{value}' does not match any known schools
               csv:
@@ -2345,6 +2349,10 @@ en:
               invalid: is invalid. The URN '%{value}' does not match any known training partners
               csv:
                 invalid: Training Partner URN is invalid. The URN '%{value}' does not match any known training partners
+            training_partner_urn:
+              invalid: is invalid. The URN '%{value}' does not match any known training partners
+            training_partner_ukprn:
+              invalid: is invalid. The UKPRN '%{value}' does not match any known training partners
             iqts_country:
               inclusion: is not a valid iQTS country
             employing_school_id:

--- a/spec/requests/api/v2026_0/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v2026_0/post_hesa_trainees_spec.rb
@@ -489,7 +489,7 @@ describe "`POST /api/v2026.0/trainees` endpoint" do
 
           response.parsed_body[:data]
           expect(response.parsed_body["errors"]).to include(
-            "training_partner_id is invalid. The URN '99999999' does not match any known training partners",
+            "training_partner_ukprn is invalid. The UKPRN '99999999' does not match any known training partners",
           )
         end
       end
@@ -532,7 +532,7 @@ describe "`POST /api/v2026.0/trainees` endpoint" do
 
             response.parsed_body[:data]
             expect(response.parsed_body["errors"]).to include(
-              "training_partner_id is invalid. The URN '123456' does not match any known training partners",
+              "training_partner_urn is invalid. The URN '123456' does not match any known training partners",
             )
           end
         end
@@ -568,7 +568,7 @@ describe "`POST /api/v2026.0/trainees` endpoint" do
             it "returns unprocessible entity HTTP code and a validation error message" do
               expect(response).to have_http_status(:unprocessable_entity)
               expect(response.parsed_body["errors"]).to include(
-                "training_partner_id is invalid. The URN '#{training_partner.urn}' does not match any known training partners",
+                "training_partner_urn is invalid. The URN '#{training_partner.urn}' does not match any known training partners",
               )
             end
           end

--- a/spec/requests/api/v2026_0/put_trainee_spec.rb
+++ b/spec/requests/api/v2026_0/put_trainee_spec.rb
@@ -1029,7 +1029,7 @@ describe "`PUT /api/v2026.0/trainees/:id` endpoint" do
               it "returns an error" do
                 expect(response).to have_http_status(:unprocessable_entity)
                 expect(response.parsed_body["errors"]).to include(
-                  "training_partner_id is invalid. The URN '#{new_training_partner.urn}' does not match any known training partners",
+                  "training_partner_urn is invalid. The URN '#{new_training_partner.urn}' does not match any known training partners",
                 )
               end
             end

--- a/spec/requests/api/v2026_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v2026_1/post_hesa_trainees_spec.rb
@@ -489,7 +489,7 @@ describe "`POST /api/v2026.1/trainees` endpoint" do
 
           response.parsed_body[:data]
           expect(response.parsed_body["errors"]).to include(
-            "training_partner_id is invalid. The URN '99999999' does not match any known training partners",
+            "training_partner_ukprn is invalid. The UKPRN '99999999' does not match any known training partners",
           )
         end
       end
@@ -532,7 +532,7 @@ describe "`POST /api/v2026.1/trainees` endpoint" do
 
             response.parsed_body[:data]
             expect(response.parsed_body["errors"]).to include(
-              "training_partner_id is invalid. The URN '123456' does not match any known training partners",
+              "training_partner_urn is invalid. The URN '123456' does not match any known training partners",
             )
           end
         end
@@ -568,7 +568,7 @@ describe "`POST /api/v2026.1/trainees` endpoint" do
             it "returns unprocessible entity HTTP code and a validation error message" do
               expect(response).to have_http_status(:unprocessable_entity)
               expect(response.parsed_body["errors"]).to include(
-                "training_partner_id is invalid. The URN '#{training_partner.urn}' does not match any known training partners",
+                "training_partner_urn is invalid. The URN '#{training_partner.urn}' does not match any known training partners",
               )
             end
           end

--- a/spec/requests/api/v2026_1/put_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/put_trainee_spec.rb
@@ -1066,7 +1066,7 @@ describe "`PUT /api/v2026.1/trainees/:id` endpoint" do
               it "returns an error" do
                 expect(response).to have_http_status(:unprocessable_entity)
                 expect(response.parsed_body["errors"]).to include(
-                  "training_partner_id is invalid. The URN '#{new_training_partner.urn}' does not match any known training partners",
+                  "training_partner_urn is invalid. The URN '#{new_training_partner.urn}' does not match any known training partners",
                 )
               end
             end


### PR DESCRIPTION
### Context

[Trello ticket](https://trello.com/c/q9TyULmf/9519-training-partner-error-messages-are-not-accurate)

Error messages returned by the API for training partner are not always accurate.

The error messages always reference `training_partner_id` which is not a field that gets submitted, and always says `The URN '%{value}' does not match any known lead partners` even when a UKRPN was actually submitted.

### Changes proposed in this pull request

* `Api::HesaMapper::Attributes` allows `:source_attribute` to be passed in for later retrieval
* validation uses `:source_attribute` to properly retrieve locale for the correct attribute
* `read_attribute_for_validation` override is needed as Rails tries to call `send(:training_partner_ukprn/urn)` on the model during error message generation

### Guidance to review


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
