### PR TITLE
[9529] Bug - Some buttons and search fields are hidden when JS is enabled

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -117,8 +117,12 @@ $mobile-big-end: 501px;
 }
 
 // Display for js only
-:not(.js-enabled) .app-js-only {
+.app-js-only {
   display: none;
+
+  .js-enabled & {
+    display: revert;
+  }
 }
 
 // Display for no-js only

--- a/spec/features/cookie_preferences_spec.rb
+++ b/spec/features/cookie_preferences_spec.rb
@@ -12,7 +12,22 @@ feature "navigate to cookies preferences" do
     and_i_should_not_see_the_cookie_banner
   end
 
+  scenario "shows accept and reject buttons when JS is enabled", js: true do
+    given_i_am_on_the_start_page
+    then_i_should_see_the_cookie_banner
+    and_i_should_see_the_cookie_accept_button
+    and_i_should_see_the_cookie_reject_button
+  end
+
 private
+
+  def and_i_should_see_the_cookie_accept_button
+    expect(page).to have_button(t("cookies.accept"), visible: :visible)
+  end
+
+  def and_i_should_see_the_cookie_reject_button
+    expect(page).to have_button(t("cookies.reject"), visible: :visible)
+  end
 
   def given_i_am_on_the_start_page
     start_page.load

--- a/spec/features/system_admin/schools/list_schools_spec.rb
+++ b/spec/features/system_admin/schools/list_schools_spec.rb
@@ -15,6 +15,15 @@ feature "List schools" do
       when_i_visit_the_school_index_page
       then_i_see_the_school
     end
+
+    scenario "shows school search when JS is enabled", js: true do
+      when_i_visit_the_school_index_page
+      then_i_see_the_school_search
+    end
+  end
+
+  def then_i_see_the_school_search
+    expect(page).to have_field("Search for a school", visible: :visible)
   end
 
   def when_i_visit_the_school_index_page


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/0exDNBPu/9529-some-search-fields-are-hidden-when-js-is-enabled)

### Changes proposed in this pull request

* Changed SCSS for `app-js-only` class so it displays elements correctly again, whilst adhering to stylelint rules
* Added tests to check correct display for cookie banner and school search box

### Guidance to review

* Does cookie banner and school search box display correctly when JS is on and off?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
