### PR TITLE
[9536] Investigate differences between 2026 reference data documentation pages and CSV download

### DIFF
--- a/app/lib/hesa/reference_data/v2026_0.rb
+++ b/app/lib/hesa/reference_data/v2026_0.rb
@@ -23,25 +23,22 @@ module Hesa
           study_mode: ::ReferenceData::STUDY_MODES,
           training_route: ::ReferenceData::TRAINING_ROUTES,
           training_initiative: ::ReferenceData::TRAINING_INITIATIVES,
-        }.transform_values do |type|
-          Hesa::ReferenceData::V20260.values_for(type)
+        }.each_with_object({}) do |(name, type), hash|
+          hash[name] = Hesa::ReferenceData::V20260.values_for(name, type)
         end.freeze
       end
 
       # rubocop:disable Style/HashEachMethods
-      def self.values_for(type)
-        transformed_values = []
+      def self.values_for(type_name, type)
+        rows = []
         type.values.each do |value|
-          hesa_codes = value.hesa_codes || []
-          if hesa_codes.present?
-            hesa_codes.each do |code|
-              transformed_values << [code, value.display_name]
-            end
-          else
-            transformed_values << ["-", value.display_name]
+          Array(value.hesa_codes).each do |code|
+            next if code.blank?
+
+            rows << [code, I18n.t("#{type_name}.#{code}", default: value.display_name)]
           end
-        end.flatten
-        transformed_values
+        end
+        rows.sort_by(&:first)
       end
       # rubocop:enable Style/HashEachMethods
     end

--- a/app/lib/hesa/reference_data/v2026_1.rb
+++ b/app/lib/hesa/reference_data/v2026_1.rb
@@ -24,8 +24,8 @@ module Hesa
           training_route: ::ReferenceData::TRAINING_ROUTES,
           training_initiative: ::ReferenceData::TRAINING_INITIATIVES,
           iqts_country: ::ReferenceData::COUNTRIES,
-        }.transform_values do |type|
-          Hesa::ReferenceData::V20261.values_for(type)
+        }.each_with_object({}) do |(name, type), hash|
+          hash[name] = Hesa::ReferenceData::V20261.values_for(name, type)
         end.freeze
       end
     end

--- a/spec/fixtures/files/reference_data/v2026_0/course_age_range.csv
+++ b/spec/fixtures/files/reference_data/v2026_0/course_age_range.csv
@@ -1,30 +1,11 @@
 Code,Label
-13912,Three to eleven
-13914,Five to eleven
-13918,Eleven to sixteen
--,Eleven to eighteen
-13919,Eleven to nineteen
--,Zero to five
--,Two to seven
--,Two to eleven
--,Two to nineteen
-13909,Three to seven
--,Three to eight
-13911,Three to nine
--,Three to sixteen
--,Four to eleven
--,Four to nineteen
-13913,Five to nine
--,Five to fourteen
--,Five to eighteen
-13915,Seven to eleven
-13916,Seven to fourteen
--,Seven to sixteen
--,Seven to eighteen
--,Nine to thirteen
-13917,Nine to fourteen
--,Nine to sixteen
--,Eleven to nineteen
--,Thirteen to eighteen
--,Fourteen to eighteen
--,Fourteen to nineteen
+13909,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 3-7
+13911,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 3-9
+13912,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 3-11
+13913,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 5-9
+13914,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 5-11
+13915,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 7-11
+13916,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 7-14
+13917,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 9-14
+13918,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 11-16
+13919,Accredited by the Department for Education (DfE) for the purpose of delivering initial teacher training programmes to achieve Qualified Teacher Status (QTS): Ages 11-19

--- a/spec/lib/hesa/reference_data/v20260_spec.rb
+++ b/spec/lib/hesa/reference_data/v20260_spec.rb
@@ -13,5 +13,58 @@ RSpec.describe Hesa::ReferenceData::V20260 do
         CSV.parse(file_content("reference_data/v2026_0/course_age_range.csv")),
       )
     end
+
+    describe "training_initiative" do
+      let(:rows) { CSV.parse(described_class.find(:training_initiative).as_csv, headers: true) }
+
+      it "excludes entries that have no hesa code" do
+        expect(rows.map { |r| r["Code"] }).to all(be_present)
+        expect(rows.map { |r| r["Label"] }).not_to include(
+          "Future Teaching Scholars",
+          "Troops to Teachers",
+          "Not on a training initiative",
+          "Veteran teaching undergraduate bursary",
+          "Abridged ITT course",
+          "Additional ITT place for PE with a priority subject",
+        )
+      end
+
+      it "uses the locale label when one exists for the hesa code" do
+        labels = rows.to_h { |r| [r["Code"], r["Label"]] }
+        expect(labels["009"]).to eq("Maths and Physics Chairs Programme")
+      end
+
+      it "falls back to display_name when the locale has no entry for the hesa code" do
+        labels = rows.to_h { |r| [r["Code"], r["Label"]] }
+        expect(labels["011"]).to eq("Primary mathematics specialist")
+      end
+    end
+
+    describe "institution" do
+      let(:rows) { CSV.parse(described_class.find(:institution).as_csv, headers: true) }
+
+      it "excludes entries with a blank hesa code" do
+        expect(rows.map { |r| r["Code"] }).to all(be_present)
+        expect(rows.map { |r| r["Label"] }).not_to include(
+          "Non EU countries",
+          "Other EU countries",
+          "Other UK (Northern Ireland)",
+        )
+      end
+
+      it "renders duplicate hesa codes as separate rows sharing the locale label" do
+        rows_for_0115 = rows.select { |r| r["Code"] == "0115" }
+        rows_for_0204 = rows.select { |r| r["Code"] == "0204" }
+        expect(rows_for_0115.size).to eq(2)
+        expect(rows_for_0204.size).to eq(2)
+        expect(rows_for_0115.map { |r| r["Label"] }).to all(eq("City, University of London"))
+        expect(rows_for_0204.map { |r| r["Label"] }).to all(eq("The University of Manchester"))
+      end
+
+      it "uses locale label rather than YAML display_name" do
+        winchester = rows.select { |r| r["Code"] == "0021" }
+        expect(winchester.map { |r| r["Label"] }).to all(eq("The University of Winchester"))
+      end
+    end
   end
 end

--- a/tech_docs/Rakefile
+++ b/tech_docs/Rakefile
@@ -335,6 +335,8 @@ class ReferenceDataHelper
           hesa_codes = value.fetch("hesa_codes", [])
           if hesa_codes.present?
             hesa_codes.each do |code|
+              next if code.blank?
+
               reference_data_type.type_values << ReferenceDataValue.new(
                 hesa_code: code,
                 id: value.fetch("id"),


### PR DESCRIPTION
### Context

[9536-spike-1-day-investigate-differences-between-2026-reference-data-documentation-pages-and-csv-download](https://trello.com/c/O014p6CH/9536-spike-1-day-investigate-differences-between-2026-reference-data-documentation-pages-and-csv-download)

The reference-data CSV download and docs page for `v2026` drew from the same yaml files but applied different filters and label sources, so they showed different rows and labels.

### Changes proposed in this pull request

- Aligns the CSV with the docs: skip blank/missing hesa_codes, use the canonical locale label (falling back to YAML display_name), and render duplicate codes the same way the docs do.
- Adds a matching blank code guard to the docs Rakefile so empty Code cells stop rendering.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
