### PR TITLE
[9538] - Add toc active link override JS

### DIFF
--- a/tech_docs/source/javascripts/_toc_active_item_fix.js
+++ b/tech_docs/source/javascripts/_toc_active_item_fix.js
@@ -1,0 +1,51 @@
+/* eslint-disable */
+
+(function () {
+  'use strict'
+
+  function getActiveTocLink () {
+    var explicitCurrent = document.querySelector('.app-pane__toc a[aria-current="page"]')
+    if (explicitCurrent) return explicitCurrent
+
+    var links = document.querySelectorAll('.app-pane__toc .js-toc-list a[href]')
+    var currentPath = window.location.pathname
+    for (var i = 0; i < links.length; i++) {
+      var href = links[i].getAttribute('href')
+      if (!href) continue
+
+      var url = new URL(href, window.location.href)
+      if (url.pathname === currentPath) {
+        return links[i]
+      }
+    }
+
+    return null
+  }
+
+  function scrollActiveLinkIntoView () {
+    var activeLink = getActiveTocLink()
+    if (!activeLink || typeof activeLink.scrollIntoView !== 'function') return false
+
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    return true
+  }
+
+  function runWithRetries () {
+    var attempts = 0
+    var maxAttempts = 6
+
+    function attempt () {
+      attempts += 1
+      var didScroll = scrollActiveLinkIntoView()
+
+      if (!didScroll || attempts < maxAttempts) {
+        window.setTimeout(attempt, 120)
+      }
+    }
+
+    window.requestAnimationFrame(attempt)
+  }
+
+  document.addEventListener('DOMContentLoaded', runWithRetries)
+  window.addEventListener('pageshow', runWithRetries)
+})()

--- a/tech_docs/source/javascripts/application.js
+++ b/tech_docs/source/javascripts/application.js
@@ -1,2 +1,3 @@
 //= require govuk_tech_docs
 //= require _search
+//= require _toc_active_item_fix


### PR DESCRIPTION
### Context

[Trello ticket](https://trello.com/c/JENE1URe/9538-spike-05-days-investigate-left-hand-navigation-no-showing-current-page-in-view)

Sometimes you have to scroll to see the current page in the left-hand navigation in the tech docs.

### Changes proposed in this pull request

Small JS to focus the current TOC active link 

### Guidance to review

* Sanity check JS
* advise if this should be a PR to the tech docs repo instead

### Previews

#### Before

https://github.com/user-attachments/assets/15aca9b0-7e4e-4cee-9e5f-62b7a335e56e

#### After

https://github.com/user-attachments/assets/c0e0f76e-4e94-4711-b079-04d85a376d48

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
