### PR TITLE
[9554]  Eager loading for withdrawals and memoize 

### DIFF
--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -57,6 +57,7 @@ module Api
       succeeded, validation = update_trainee_service_class.call(trainee:, attributes:)
 
       if succeeded
+        trainee.reload
         render(json: { data: serializer_klass.new(trainee).as_hash })
       else
         render(

--- a/app/serializers/api/v2025_0/trainee_serializer.rb
+++ b/app/serializers/api/v2025_0/trainee_serializer.rb
@@ -66,12 +66,12 @@ module Api
             training_route: training_route,
             nationality: nationality,
             training_initiative: training_initiative,
-            withdraw_date: @trainee.current_withdrawal&.date&.iso8601,
+            withdraw_date: current_withdrawal&.date&.iso8601,
             withdraw_reasons: withdraw_reasons,
-            withdrawal_trigger: @trainee.current_withdrawal&.trigger,
-            withdrawal_future_interest: @trainee.current_withdrawal&.future_interest,
-            withdrawal_another_reason: @trainee.current_withdrawal&.another_reason,
-            withdrawal_safeguarding_concern_reasons: @trainee.current_withdrawal&.safeguarding_concern_reasons,
+            withdrawal_trigger: current_withdrawal&.trigger,
+            withdrawal_future_interest: current_withdrawal&.future_interest,
+            withdrawal_another_reason: current_withdrawal&.another_reason,
+            withdrawal_safeguarding_concern_reasons: current_withdrawal&.safeguarding_concern_reasons,
             placements: placements,
             degrees: degrees,
             state: @trainee.state,
@@ -88,7 +88,7 @@ module Api
       end
 
       def placements
-        @placements ||= @trainee.placements.includes(:school).map do |placement|
+        @placements ||= @trainee.placements.map do |placement|
           PlacementSerializer.new(placement).as_hash
         end
       end
@@ -200,7 +200,7 @@ module Api
       end
 
       def nationality
-        return if @trainee.nationalities.reload.blank?
+        return if @trainee.nationalities.blank?
 
         RecruitsApi::CodeSets::Nationalities::APPLY_MAPPING[
           @trainee.nationalities.first.name,
@@ -220,7 +220,11 @@ module Api
       end
 
       def withdraw_reasons
-        @trainee.current_withdrawal_reasons&.map(&:name)
+        current_withdrawal&.withdrawal_reasons&.map(&:name)
+      end
+
+      def current_withdrawal
+        @current_withdrawal ||= @trainee.current_withdrawal
       end
 
       delegate :ethnic_group, :disability_disclosure, :course_education_phase, :trainee_start_date, to: :@trainee

--- a/app/serializers/api/v2026_0/trainee_serializer.rb
+++ b/app/serializers/api/v2026_0/trainee_serializer.rb
@@ -69,12 +69,12 @@ module Api
             training_route: training_route,
             nationality: nationality,
             training_initiative: training_initiative,
-            withdrawal_date: @trainee.current_withdrawal&.date&.iso8601,
+            withdrawal_date: current_withdrawal&.date&.iso8601,
             withdrawal_reasons: withdrawal_reasons,
-            withdrawal_trigger: @trainee.current_withdrawal&.trigger,
-            withdrawal_future_interest: @trainee.current_withdrawal&.future_interest,
-            withdrawal_another_reason: @trainee.current_withdrawal&.another_reason,
-            withdrawal_safeguarding_concern_reasons: @trainee.current_withdrawal&.safeguarding_concern_reasons,
+            withdrawal_trigger: current_withdrawal&.trigger,
+            withdrawal_future_interest: current_withdrawal&.future_interest,
+            withdrawal_another_reason: current_withdrawal&.another_reason,
+            withdrawal_safeguarding_concern_reasons: current_withdrawal&.safeguarding_concern_reasons,
             placements: placements,
             degrees: degrees,
             state: @trainee.state,
@@ -91,7 +91,7 @@ module Api
       end
 
       def placements
-        @placements ||= @trainee.placements.includes(:school).map do |placement|
+        @placements ||= @trainee.placements.map do |placement|
           PlacementSerializer.new(placement).as_hash
         end
       end
@@ -203,7 +203,7 @@ module Api
       end
 
       def nationality
-        return if @trainee.nationalities.reload.blank?
+        return if @trainee.nationalities.blank?
 
         RecruitsApi::CodeSets::Nationalities::APPLY_MAPPING[
           @trainee.nationalities.first.name,
@@ -223,7 +223,11 @@ module Api
       end
 
       def withdrawal_reasons
-        @trainee.current_withdrawal_reasons&.map(&:name)
+        current_withdrawal&.withdrawal_reasons&.map(&:name)
+      end
+
+      def current_withdrawal
+        @current_withdrawal ||= @trainee.current_withdrawal
       end
 
       delegate :ethnic_group, :disability_disclosure, :course_education_phase, :trainee_start_date, to: :@trainee

--- a/app/serializers/api/v2026_1/trainee_serializer.rb
+++ b/app/serializers/api/v2026_1/trainee_serializer.rb
@@ -69,12 +69,12 @@ module Api
             iqts_country: iqts_country,
             nationality: nationality,
             training_initiative: training_initiative,
-            withdrawal_date: @trainee.current_withdrawal&.date&.iso8601,
+            withdrawal_date: current_withdrawal&.date&.iso8601,
             withdrawal_reasons: withdrawal_reasons,
-            withdrawal_trigger: @trainee.current_withdrawal&.trigger,
-            withdrawal_future_interest: @trainee.current_withdrawal&.future_interest,
-            withdrawal_another_reason: @trainee.current_withdrawal&.another_reason,
-            withdrawal_safeguarding_concern_reasons: @trainee.current_withdrawal&.safeguarding_concern_reasons,
+            withdrawal_trigger: current_withdrawal&.trigger,
+            withdrawal_future_interest: current_withdrawal&.future_interest,
+            withdrawal_another_reason: current_withdrawal&.another_reason,
+            withdrawal_safeguarding_concern_reasons: current_withdrawal&.safeguarding_concern_reasons,
             placements: placements,
             degrees: degrees,
             state: @trainee.state,
@@ -91,7 +91,7 @@ module Api
       end
 
       def placements
-        @placements ||= @trainee.placements.includes(:school).map do |placement|
+        @placements ||= @trainee.placements.map do |placement|
           PlacementSerializer.new(placement).as_hash
         end
       end
@@ -203,7 +203,7 @@ module Api
       end
 
       def nationality
-        return if @trainee.nationalities.reload.blank?
+        return if @trainee.nationalities.blank?
 
         RecruitsApi::CodeSets::Nationalities::APPLY_MAPPING[
           @trainee.nationalities.first.name,
@@ -227,7 +227,11 @@ module Api
       end
 
       def withdrawal_reasons
-        @trainee.current_withdrawal_reasons&.map(&:name)
+        current_withdrawal&.withdrawal_reasons&.map(&:name)
+      end
+
+      def current_withdrawal
+        @current_withdrawal ||= @trainee.current_withdrawal
       end
 
       delegate :ethnic_group, :disability_disclosure, :course_education_phase, :trainee_start_date, to: :@trainee

--- a/app/services/api/get_trainees_service.rb
+++ b/app/services/api/get_trainees_service.rb
@@ -14,7 +14,16 @@ module Api
 
       [
         ::Trainees::Filter.call(trainees:, filters:)
-          .includes(%i[published_course employing_school training_partner placements degrees hesa_trainee_detail]),
+          .includes(
+            :published_course,
+            :employing_school,
+            :training_partner,
+            :degrees,
+            :hesa_trainee_detail,
+            :nationalities,
+            { placements: :school },
+            { trainee_withdrawals: :withdrawal_reasons },
+          ),
         nil,
       ]
     end
@@ -27,7 +36,11 @@ module Api
       @trainees ||= provider.trainees
         .not_draft
         .joins(:start_academic_cycle)
-        .includes(%i[nationalities withdrawal_reasons])
+        .includes(
+          :nationalities,
+          { placements: :school },
+          { trainee_withdrawals: :withdrawal_reasons },
+        )
         .where(academic_cycles: { id: academic_cycle.id })
         .where(trainees: { updated_at: since.. })
         .order("trainees.updated_at #{sort_order}")


### PR DESCRIPTION
### Context

[Trello ticket](https://trello.com/c/tRrVsja3/9554-n1-issue-via-sentry)

N+1 issue [found via sentry](https://dfe-teacher-services.sentry.io/issues/7016578136/?project=5552118). 

### Changes proposed in this pull request

* broadened eager loading for index:
    * `placements: :school`
    * `trainee_withdrawals: :withdrawal_reasons` 
* memoize `current_withdrawal` inside serialiser and reuse it
* stop forcing `nationalities.reload` (causing per-trainee reload queries)
* stop doing `@trainee.placements.includes(:school)` per trainee
* use `current_withdrawal&.withdrawal_reasons` instead of calling `current_withdrawal_reasons` path repeatedly

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
