### PR TITLE
[9574][9575] Remove International Relocation Payment (IRP) from Register (Training Initiatives)

### DIFF
--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 module FundingHelper
+  HIDDEN_TRAINING_INITIATIVES_BY_START_YEAR = {
+    2026 => %w[international_relocation_payment],
+  }.freeze
+
   def training_initiative_options(trainee)
-    Funding::AvailableTrainingInitiativesService.call(academic_cycle: trainee.start_academic_cycle).sort
+    cycle = trainee.start_academic_cycle
+    initiatives = Funding::AvailableTrainingInitiativesService.call(academic_cycle: cycle)
+    hidden = hidden_training_initiatives(cycle) - [trainee.training_initiative].compact
+    (initiatives - hidden).sort
   end
 
   def funding_options(trainee)
@@ -28,5 +35,9 @@ private
 
   def can_start_funding_section?(trainee)
     trainee.progress.course_details && trainee.start_academic_cycle.present?
+  end
+
+  def hidden_training_initiatives(academic_cycle)
+    HIDDEN_TRAINING_INITIATIVES_BY_START_YEAR.fetch(academic_cycle&.start_year, [])
   end
 end

--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -1,15 +1,8 @@
 # frozen_string_literal: true
 
 module FundingHelper
-  HIDDEN_TRAINING_INITIATIVES_BY_START_YEAR = {
-    2026 => %w[international_relocation_payment],
-  }.freeze
-
   def training_initiative_options(trainee)
-    cycle = trainee.start_academic_cycle
-    initiatives = Funding::AvailableTrainingInitiativesService.call(academic_cycle: cycle)
-    hidden = hidden_training_initiatives(cycle) - [trainee.training_initiative].compact
-    (initiatives - hidden).sort
+    Funding::AvailableTrainingInitiativesService.call(academic_cycle: trainee.start_academic_cycle).sort
   end
 
   def funding_options(trainee)
@@ -35,9 +28,5 @@ private
 
   def can_start_funding_section?(trainee)
     trainee.progress.course_details && trainee.start_academic_cycle.present?
-  end
-
-  def hidden_training_initiatives(academic_cycle)
-    HIDDEN_TRAINING_INITIATIVES_BY_START_YEAR.fetch(academic_cycle&.start_year, [])
   end
 end

--- a/config/initializers/training_routes/funding/2026_2027/training_initiatives.rb
+++ b/config/initializers/training_routes/funding/2026_2027/training_initiatives.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 TRAINING_INITIATIVES_2026_TO_2027 = %w[
-  international_relocation_payment
   now_teach
   veterans_teaching_undergraduate_bursary
   primary_mathematics_specialist

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -57,12 +57,6 @@ feature "edit training initiative" do
       when_i_visit_the_training_initiative_page
       then_the_international_relocation_payment_option_is_not_shown
     end
-
-    scenario "international relocation payment is still offered if the trainee already has it set" do
-      given_a_2026_to_2027_trainee_exists(training_initiative: "international_relocation_payment")
-      when_i_visit_the_training_initiative_page
-      then_the_international_relocation_payment_option_is_shown
-    end
   end
 
   context "when a trainee is in 2025/26 academic cycle" do

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -51,6 +51,28 @@ feature "edit training initiative" do
     then_i_see_error_messages
   end
 
+  context "when a trainee is in 2026/27 academic cycle" do
+    scenario "international relocation payment is not offered as an option" do
+      given_a_2026_to_2027_trainee_exists
+      when_i_visit_the_training_initiative_page
+      then_the_international_relocation_payment_option_is_not_shown
+    end
+
+    scenario "international relocation payment is still offered if the trainee already has it set" do
+      given_a_2026_to_2027_trainee_exists(training_initiative: "international_relocation_payment")
+      when_i_visit_the_training_initiative_page
+      then_the_international_relocation_payment_option_is_shown
+    end
+  end
+
+  context "when a trainee is in 2025/26 academic cycle" do
+    scenario "international relocation payment is still offered as an option" do
+      given_a_2025_to_2026_trainee_exists
+      when_i_visit_the_training_initiative_page
+      then_the_international_relocation_payment_option_is_shown
+    end
+  end
+
 private
 
   def given_a_provider_led_postgrad_trainee_exists
@@ -98,5 +120,27 @@ private
   def then_the_trainee_has_the_correct_initiative(initiative)
     trainee.reload
     expect(trainee.training_initiative).to eq(initiative)
+  end
+
+  def given_a_2026_to_2027_trainee_exists(**attrs)
+    given_a_trainee_exists(:provider_led_postgrad,
+                           itt_start_date: Date.new(2026, 9, 1),
+                           start_academic_cycle: AcademicCycle.for_year(2026),
+                           **attrs)
+  end
+
+  def given_a_2025_to_2026_trainee_exists(**attrs)
+    given_a_trainee_exists(:provider_led_postgrad,
+                           itt_start_date: Date.new(2025, 9, 1),
+                           start_academic_cycle: AcademicCycle.for_year(2025),
+                           **attrs)
+  end
+
+  def then_the_international_relocation_payment_option_is_not_shown
+    expect(training_initiative_page).not_to have_field("International Relocation Payment", type: "radio")
+  end
+
+  def then_the_international_relocation_payment_option_is_shown
+    expect(training_initiative_page).to have_field("International Relocation Payment", type: "radio")
   end
 end

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -12,7 +12,7 @@ feature "edit training initiative" do
       given_a_provider_led_postgrad_trainee_exists
       and_a_bursary_exists_for_their_subject
       when_i_visit_the_training_initiative_page
-      and_i_update_the_training_initiative("international_relocation_payment")
+      and_i_update_the_training_initiative("now_teach")
       and_i_submit_the_form
       then_i_am_redirected_to_the_bursary_page
     end
@@ -20,7 +20,7 @@ feature "edit training initiative" do
     scenario "without bursary redirects to funding confirmation page" do
       given_a_trainee_exists(:assessment_only)
       when_i_visit_the_training_initiative_page
-      and_i_update_the_training_initiative("international_relocation_payment")
+      and_i_update_the_training_initiative("now_teach")
       and_i_submit_the_form
       then_i_am_redirected_to_the_funding_confirmation_page
     end
@@ -28,7 +28,7 @@ feature "edit training initiative" do
     scenario "on the early_years_postgrad route redirects to bursary page" do
       given_a_trainee_exists(:early_years_postgrad, :with_valid_itt_start_date)
       when_i_visit_the_training_initiative_page
-      and_i_update_the_training_initiative("international_relocation_payment")
+      and_i_update_the_training_initiative("now_teach")
       and_i_submit_the_form
       then_i_am_redirected_to_the_bursary_page
     end
@@ -39,9 +39,9 @@ feature "edit training initiative" do
   scenario "can select an initiative and save it to the trainee record" do
     given_a_trainee_exists(:provider_led_postgrad)
     when_i_visit_the_training_initiative_page
-    and_i_update_the_training_initiative("international_relocation_payment")
+    and_i_update_the_training_initiative("now_teach")
     and_i_submit_the_form
-    then_the_trainee_has_the_correct_initiative("international_relocation_payment")
+    then_the_trainee_has_the_correct_initiative("now_teach")
   end
 
   scenario "submitting with invalid parameters shows error messages" do
@@ -87,7 +87,7 @@ private
     training_initiative_page.load(id: trainee.slug)
   end
 
-  def and_i_update_the_training_initiative(initiative = "international_relocation_payment")
+  def and_i_update_the_training_initiative(initiative = "now_teach")
     radio_button = training_initiative_page.find("input[value='#{initiative}']", visible: :all)
     radio_button.presence&.click
   end

--- a/spec/helpers/funding_helper_spec.rb
+++ b/spec/helpers/funding_helper_spec.rb
@@ -70,32 +70,13 @@ describe FundingHelper do
     context "when looking for 2026 initiatives" do
       let(:year) { 2026 }
 
-      it "returns 2026-2027 initiatives excluding international_relocation_payment" do
+      it "returns 2026-2027 initiatives" do
         expected_initiatives = %w[
           now_teach
           veterans_teaching_undergraduate_bursary
           primary_mathematics_specialist
         ]
         expect(training_initiative_options(trainee)).to match_array(expected_initiatives)
-      end
-
-      context "when the trainee already has international_relocation_payment set" do
-        let(:trainee) do
-          create(:trainee,
-                 itt_start_date: Date.new(year, 9, 1),
-                 start_academic_cycle: academic_cycle,
-                 training_initiative: ROUTE_INITIATIVES_ENUMS[:international_relocation_payment])
-        end
-
-        it "keeps international_relocation_payment in the list so it can stay selected" do
-          expected_initiatives = %w[
-            international_relocation_payment
-            now_teach
-            veterans_teaching_undergraduate_bursary
-            primary_mathematics_specialist
-          ]
-          expect(training_initiative_options(trainee)).to match_array(expected_initiatives)
-        end
       end
     end
 

--- a/spec/helpers/funding_helper_spec.rb
+++ b/spec/helpers/funding_helper_spec.rb
@@ -67,6 +67,38 @@ describe FundingHelper do
       end
     end
 
+    context "when looking for 2026 initiatives" do
+      let(:year) { 2026 }
+
+      it "returns 2026-2027 initiatives excluding international_relocation_payment" do
+        expected_initiatives = %w[
+          now_teach
+          veterans_teaching_undergraduate_bursary
+          primary_mathematics_specialist
+        ]
+        expect(training_initiative_options(trainee)).to match_array(expected_initiatives)
+      end
+
+      context "when the trainee already has international_relocation_payment set" do
+        let(:trainee) do
+          create(:trainee,
+                 itt_start_date: Date.new(year, 9, 1),
+                 start_academic_cycle: academic_cycle,
+                 training_initiative: ROUTE_INITIATIVES_ENUMS[:international_relocation_payment])
+        end
+
+        it "keeps international_relocation_payment in the list so it can stay selected" do
+          expected_initiatives = %w[
+            international_relocation_payment
+            now_teach
+            veterans_teaching_undergraduate_bursary
+            primary_mathematics_specialist
+          ]
+          expect(training_initiative_options(trainee)).to match_array(expected_initiatives)
+        end
+      end
+    end
+
     context "when constant doesn't exist for the year" do
       let(:year) { 1999 }
 

--- a/spec/validators/api/v2026_0/hesa_trainee_detail_attributes/rules/additional_training_initiative_spec.rb
+++ b/spec/validators/api/v2026_0/hesa_trainee_detail_attributes/rules/additional_training_initiative_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Api::V20260::HesaTraineeDetailAttributes::Rules::AdditionalTraini
     end
 
     context "when `additional_training_initiative` is a valid HESA code and available in the given year" do
-      let(:additional_training_initiative) { "036" }
+      let(:additional_training_initiative) { "026" }
 
       it "returns true" do
         expect(subject.call(hesa_trainee_detail_attributes).valid?).to be(true)

--- a/spec/validators/api/v2026_0/hesa_trainee_detail_attributes/rules/training_initiative_spec.rb
+++ b/spec/validators/api/v2026_0/hesa_trainee_detail_attributes/rules/training_initiative_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Api::V20260::HesaTraineeDetailAttributes::Rules::TrainingInitiati
     end
 
     context "when the `training_initiative` is a valid HESA code and available in the given year" do
-      let(:training_initiative) { "international_relocation_payment" }
+      let(:training_initiative) { "now_teach" }
 
       it "returns true" do
         expect(subject.call(hesa_trainee_detail_attributes).valid?).to be(true)
@@ -75,7 +75,7 @@ RSpec.describe Api::V20260::HesaTraineeDetailAttributes::Rules::TrainingInitiati
     end
 
     context "when the `training_initiative` is a valid HESA code but not available in the given year" do
-      let(:training_initiative) { "future_teaching_scholars" }
+      let(:training_initiative) { "international_relocation_payment" }
 
       it "returns false" do
         expect(subject.call(hesa_trainee_detail_attributes).valid?).to be(false)
@@ -83,7 +83,7 @@ RSpec.describe Api::V20260::HesaTraineeDetailAttributes::Rules::TrainingInitiati
 
       it "returns error details including the given value and allowed values" do
         expect(subject.call(hesa_trainee_detail_attributes).error_details).to eq(
-          { academic_cycle: "2026 to 2027", training_initiative: "future_teaching_scholars" },
+          { academic_cycle: "2026 to 2027", training_initiative: "international_relocation_payment" },
         )
       end
     end


### PR DESCRIPTION
### Context

[9574-remove-international-relocation-payment-irp-from-register-frontend-training-initiatives
](https://trello.com/c/Ghs6QFIe/9574-remove-international-relocation-payment-irp-from-register-frontend-training-initiatives)

[9575-remove-international-relocation-payment-irp-from-2026-api-csv-training-initiatives](https://trello.com/c/8wEig4HU/9575-remove-international-relocation-payment-irp-from-2026-api-csv-training-initiatives)

### Changes proposed in this pull request

* Hide `international_relocation_payment` for `26/27` academic cycle from training initiatives UI for trainees
* Existing trainees with `international_relocation_payment` will have the option available unless they select and save another training initiative

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
