### PR TITLE
[9571] Trainee training partners display bug

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -38,13 +38,9 @@ module RecordDetails
 
     def record_detail_rows
       rows = [provider_row]
-      if trainee.requires_training_partner?
-        rows += [
-          training_partner_row,
-          employing_school_row,
-        ]
-      end
       rows += [
+        training_partner_row(not_applicable: training_partner_not_applicable?),
+        employing_school_row(not_applicable: employing_school_not_applicable?),
         record_source_row,
         trainee_id_row,
         region,

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -6,12 +6,13 @@ class TraineesController < BaseTraineeController
   include MissingFieldsCheckable
 
   before_action :redirect_to_not_found, if: -> { trainee.discarded? }, only: :show
-  before_action :ensure_trainee_is_not_draft!, :load_missing_data_view, only: :show
+  before_action :ensure_trainee_is_not_draft!, only: :show
   before_action :clear_page_tracker, only: :show
 
   def show
     authorize(trainee)
     clear_form_stash(trainee)
+    load_missing_data_view
     page_tracker.save_as_origin!
     @timeline_events = Trainees::CreateTimeline.call(trainee:, current_user:)
   end

--- a/app/helpers/training_partner_helper.rb
+++ b/app/helpers/training_partner_helper.rb
@@ -9,6 +9,8 @@ module TrainingPartnerHelper
   end
 
   def training_partner_row(not_applicable: false)
+    return unless trainee.requires_training_partner?
+
     mappable_field(
       not_applicable ? t(:not_applicable) : training_partner_detail(training_partner),
       t("components.training_partner_and_employing_school_details.training_partner_key"),

--- a/spec/components/school_details/view_spec.rb
+++ b/spec/components/school_details/view_spec.rb
@@ -48,7 +48,7 @@ module SchoolDetails
     end
 
     context "when urn not provided from hesa import" do
-      let(:trainee) { create(:trainee, :imported_from_hesa) }
+      let(:trainee) { create(:trainee, :imported_from_hesa, :with_training_route) }
 
       before do
         render_inline(View.new(trainee: trainee, editable: true))


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/3iYJIlmK/9571-trainee-training-partners-updated-bug)

If the trainee's training partner was set to 'not applicable' the trainee record was still saying it was missing information, which is not right.

### Changes proposed in this pull request

* Pass through `training_partner_not_applicable` status so correct text is displayed on the record
* Fix flaky test so it always uses a training partner route

### Guidance to review

1. Find a trainee on a training route which 'requires' a training partner
2. Set the training partner to 'not applicable'
3. Look at the trainee record. It should look like this: 

<img width="991" height="359" alt="image" src="https://github.com/user-attachments/assets/db76674c-0968-40cc-bae6-6e8ba503eae5" />


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
