### PR TITLE
Add workflow to fix Airbyte replication slot

### DIFF
--- a/.github/workflows/fix-airbyte-replication.yml
+++ b/.github/workflows/fix-airbyte-replication.yml
@@ -1,0 +1,63 @@
+name: Fix Airbyte Replication
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to fix
+        required: true
+        default: qa
+        type: choice
+        options:
+          - qa
+          - staging
+          - production
+      dry-run:
+        description: Check slot status only do not create slot
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+  schedule: # hourly every Sunday midnight until 9am
+    - cron: '0 0-9 * * 0'
+
+permissions:
+  id-token: write
+
+env:
+  SERVICE_NAME: register
+  SERVICE_SHORT: rtt
+  TF_VARS_PATH: terraform/aks/workspace-variables
+
+jobs:
+  fix-replication:
+    name: Fix Airbyte replication slot
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment || 'production' }}
+    env:
+      DEPLOY_ENV: ${{ inputs.environment || 'production' }}
+      DRY_RUN: ${{ inputs.dry-run || 'false' }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Set environment variables
+      run: |
+        tf_vars_file=${TF_VARS_PATH}/${DEPLOY_ENV}.tfvars.json
+        echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "NAMESPACE=$(jq -r '.namespace' ${tf_vars_file})" >> $GITHUB_ENV
+
+    - name: Fix Airbyte replication slot
+      uses: DFE-Digital/github-actions/fix-airbyte-replication-slot@master
+      with:
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        app-name: ${{ env.SERVICE_NAME }}-${{ env.DEPLOY_ENV }}
+        namespace: ${{ env.NAMESPACE }}
+        cluster: ${{ env.CLUSTER }}
+        dry-run: ${{ env.DRY_RUN }}


### PR DESCRIPTION
### Context
Airbyte can lose its Postgres replication slot, requiring a manual process to fix. This workflow provides a self-service way to either recreate the replication slot if it doesn't exist, or fix an LSN error by dropping and recreating the slot. This is based on the SD Airbyte Operations Runbook.

### Changes proposed in this pull request

Added .github/workflows/fix-airbyte-replication.yml which provides two actions triggered manually via workflow_dispatch:

**recreate-slot** : checks if the airbyte_slot replication slot exists and recreates it if missing
**fix-lsn-error** : drops the replication slot using the existing bin/stop-replication.psql script to fix LSN mismatch errors

### Guidance to review
The workflow follows the same patterns as existing workflows in this repo, OIDC authentication, konduit for database tunnelling, and environment variables read from tfvars. The bin/stop-replication.psql script already existed in the repo and is reused here. Review that the konduit commands match the existing patterns in database-backup.yml.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql? **No**
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events? **No, it does not change the DB Schema**
- [ ] Do we need to send any updates to TRS as part of the work in this PR? **No**
- [ ] Does this PR need an ADR? **No**

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
