### PR TITLE
[9577] Reduce noisy errors for `SchoolData::ImportJob`

### DIFF
--- a/app/jobs/school_data/import_job.rb
+++ b/app/jobs/school_data/import_job.rb
@@ -20,9 +20,9 @@ module SchoolData
       )
 
       download_record
-    rescue StandardError
+    rescue StandardError => e
       download_record&.update(status: :failed, completed_at: Time.current)
-      raise if executions > 14 # Raise if the job is still failing on the next day
+      raise if executions > 14 || !e.is_a?(Net::HTTPClientException) # Raise immediately unless it's a retryable client error. Raise those after 14 attempts.
     end
   end
 end

--- a/app/jobs/school_data/import_job.rb
+++ b/app/jobs/school_data/import_job.rb
@@ -22,7 +22,7 @@ module SchoolData
       download_record
     rescue StandardError
       download_record&.update(status: :failed, completed_at: Time.current)
-      raise
+      raise if executions > 14 # Raise if the job is still failing on the next day
     end
   end
 end

--- a/spec/jobs/school_data/import_job_spec.rb
+++ b/spec/jobs/school_data/import_job_spec.rb
@@ -73,25 +73,38 @@ RSpec.describe SchoolData::ImportJob do
         end
 
         it "updates download record status to failed" do
-          job.perform
+          begin
+            job.perform
+          rescue StandardError
+            nil
+          end
 
           download_record.reload
           expect(download_record.status).to eq("failed")
           expect(download_record.completed_at).to be_present
         end
 
-        it "does not re-raise the error before the retry limit" do
-          expect { job.perform }.not_to raise_error
-        end
-
-        it "re-raises the error once the retry limit is exceeded" do
-          job.executions = 15
+        it "re-raises the error immediately for non-HTTPClientException errors" do
           expect { job.perform }.to raise_error(error)
         end
 
-        it "does not re-raise the error at exactly the retry limit" do
-          job.executions = 14
-          expect { job.perform }.not_to raise_error
+        context "when the error is a Net::HTTPClientException" do
+          let(:response) { Net::HTTPBadRequest.new("1.1", 404, "Not Found") }
+          let(:error) { Net::HTTPClientException.new("Not Found", response) }
+
+          it "does not re-raise the error before the retry limit" do
+            expect { job.perform }.not_to raise_error
+          end
+
+          it "re-raises the error once the retry limit is exceeded" do
+            job.executions = 15
+            expect { job.perform }.to raise_error(error)
+          end
+
+          it "does not re-raise the error at exactly the retry limit" do
+            job.executions = 14
+            expect { job.perform }.not_to raise_error
+          end
         end
 
         context "when download record is nil" do
@@ -100,7 +113,7 @@ RSpec.describe SchoolData::ImportJob do
           end
 
           it "does not crash when trying to update nil download record" do
-            expect { job.perform }.not_to raise_error
+            expect { job.perform }.to raise_error(error)
           end
         end
       end

--- a/spec/jobs/school_data/import_job_spec.rb
+++ b/spec/jobs/school_data/import_job_spec.rb
@@ -73,15 +73,25 @@ RSpec.describe SchoolData::ImportJob do
         end
 
         it "updates download record status to failed" do
-          expect { job.perform }.to raise_error(error)
+          job.perform
 
           download_record.reload
           expect(download_record.status).to eq("failed")
           expect(download_record.completed_at).to be_present
         end
 
-        it "re-raises the error" do
+        it "does not re-raise the error before the retry limit" do
+          expect { job.perform }.not_to raise_error
+        end
+
+        it "re-raises the error once the retry limit is exceeded" do
+          job.executions = 15
           expect { job.perform }.to raise_error(error)
+        end
+
+        it "does not re-raise the error at exactly the retry limit" do
+          job.executions = 14
+          expect { job.perform }.not_to raise_error
         end
 
         context "when download record is nil" do
@@ -90,7 +100,7 @@ RSpec.describe SchoolData::ImportJob do
           end
 
           it "does not crash when trying to update nil download record" do
-            expect { job.perform }.to raise_error(error)
+            expect { job.perform }.not_to raise_error
           end
         end
       end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/RZ3avfXy/9577-investigate-school-data-download-failures)

The `SchoolData::ImportJob` fails fairly regularly due to unknown issues on the GIAS side. We keep retrying it and it always seems to succeed on the 15th run.

We want to stop the errors being raised while it's retrying and likely to succeed, so only raise them if the 15th try fails. This is to reduce to error noise being reported to us via Sentry.

### Changes proposed in this pull request

* Don't raise an error unless 15 tries have failed
* Update tests

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
