### PR TITLE
[9590] - Handle trainees updates via api/UI (funding_method)

### DIFF
--- a/app/models/api/v2025_0/trainee_attributes.rb
+++ b/app/models/api/v2025_0/trainee_attributes.rb
@@ -283,6 +283,8 @@ module Api
         } || {}
         hesa_trainee_detail_attributes["fund_code"] ||=
           Api::V20250::HesaTraineeDetailSerializer::FUND_CODE_FROM_ELIGIBILITY[trainee.funding_eligibility]
+        hesa_trainee_detail_attributes["funding_method"] ||=
+          ::Trainees::MapFundingToHesaBursaryLevel.call(trainee:)
 
         degrees_attributes = trainee.degrees.map do |degree|
           degree.attributes.select { |k, _v| DegreeAttributes::ATTRIBUTES.include?(k.to_sym) }

--- a/app/models/api/v2026_0/trainee_attributes.rb
+++ b/app/models/api/v2026_0/trainee_attributes.rb
@@ -283,6 +283,8 @@ module Api
         } || {}
         hesa_trainee_detail_attributes["fund_code"] ||=
           Api::V20250::HesaTraineeDetailSerializer::FUND_CODE_FROM_ELIGIBILITY[trainee.funding_eligibility]
+        hesa_trainee_detail_attributes["funding_method"] ||=
+          ::Trainees::MapFundingToHesaBursaryLevel.call(trainee:)
 
         degrees_attributes = trainee.degrees.map do |degree|
           degree.attributes.select { |k, _v| DegreeAttributes::ATTRIBUTES.include?(k.to_sym) }

--- a/app/models/api/v2026_1/trainee_attributes.rb
+++ b/app/models/api/v2026_1/trainee_attributes.rb
@@ -285,6 +285,8 @@ module Api
         } || {}
         hesa_trainee_detail_attributes["fund_code"] ||=
           Api::V20250::HesaTraineeDetailSerializer::FUND_CODE_FROM_ELIGIBILITY[trainee.funding_eligibility]
+        hesa_trainee_detail_attributes["funding_method"] ||=
+          ::Trainees::MapFundingToHesaBursaryLevel.call(trainee:)
 
         degrees_attributes = trainee.degrees.map do |degree|
           degree.attributes.select { |k, _v| DegreeAttributes::ATTRIBUTES.include?(k.to_sym) }

--- a/app/models/training_partner.rb
+++ b/app/models/training_partner.rb
@@ -27,6 +27,8 @@
 # Foreign Keys
 #
 #  fk_rails_...  (provider_id => providers.id)
+#  fk_rails_...  (provider_id => providers.id)
+#  fk_rails_...  (school_id => schools.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 class TrainingPartner < ApplicationRecord

--- a/app/serializers/api/v2025_0/hesa_trainee_detail_serializer.rb
+++ b/app/serializers/api/v2025_0/hesa_trainee_detail_serializer.rb
@@ -8,6 +8,7 @@ module Api
         course_study_mode
         hesa_disabilities
         trainee_id
+        funding_method
       ].freeze
 
       FUND_CODE_FROM_ELIGIBILITY = {
@@ -21,13 +22,23 @@ module Api
 
       def as_hash
         attrs = @trainee_details&.attributes&.except(*EXCLUDED_ATTRIBUTES) || {}
-        attrs.merge("fund_code" => fund_code_from_trainee)
+        attrs.merge(
+          "fund_code" => fund_code_from_trainee,
+          "funding_method" => funding_method_from_trainee,
+        )
       end
 
     private
 
       def fund_code_from_trainee
         FUND_CODE_FROM_ELIGIBILITY[@trainee_details&.trainee&.funding_eligibility]
+      end
+
+      def funding_method_from_trainee
+        trainee = @trainee_details&.trainee
+        return if trainee.nil?
+
+        ::Trainees::MapFundingToHesaBursaryLevel.call(trainee:)
       end
     end
   end

--- a/app/serializers/api/v2025_0/hesa_trainee_detail_serializer.rb
+++ b/app/serializers/api/v2025_0/hesa_trainee_detail_serializer.rb
@@ -8,7 +8,6 @@ module Api
         course_study_mode
         hesa_disabilities
         trainee_id
-        funding_method
       ].freeze
 
       FUND_CODE_FROM_ELIGIBILITY = {
@@ -24,7 +23,7 @@ module Api
         attrs = @trainee_details&.attributes&.except(*EXCLUDED_ATTRIBUTES) || {}
         attrs.merge(
           "fund_code" => fund_code_from_trainee,
-          "funding_method" => funding_method_from_trainee,
+          "funding_method" => attrs["funding_method"].presence || funding_method_from_trainee,
         )
       end
 

--- a/app/serializers/api/v2025_0/trainee_serializer.rb
+++ b/app/serializers/api/v2025_0/trainee_serializer.rb
@@ -194,9 +194,13 @@ module Api
       end
 
       def hesa_trainee_attributes
-        return {} unless @trainee.hesa_trainee_detail
+        return { "funding_method" => funding_method } unless @trainee.hesa_trainee_detail
 
         HesaTraineeDetailSerializer.new(@trainee.hesa_trainee_detail).as_hash
+      end
+
+      def funding_method
+        ::Trainees::MapFundingToHesaBursaryLevel.call(trainee: @trainee)
       end
 
       def nationality

--- a/app/serializers/api/v2026_0/trainee_serializer.rb
+++ b/app/serializers/api/v2026_0/trainee_serializer.rb
@@ -197,9 +197,13 @@ module Api
       end
 
       def hesa_trainee_attributes
-        return {} unless @trainee.hesa_trainee_detail
+        return { "funding_method" => funding_method } unless @trainee.hesa_trainee_detail
 
         HesaTraineeDetailSerializer.new(@trainee.hesa_trainee_detail).as_hash
+      end
+
+      def funding_method
+        ::Trainees::MapFundingToHesaBursaryLevel.call(trainee: @trainee)
       end
 
       def nationality

--- a/app/serializers/api/v2026_1/trainee_serializer.rb
+++ b/app/serializers/api/v2026_1/trainee_serializer.rb
@@ -197,9 +197,13 @@ module Api
       end
 
       def hesa_trainee_attributes
-        return {} unless @trainee.hesa_trainee_detail
+        return { "funding_method" => funding_method } unless @trainee.hesa_trainee_detail
 
         HesaTraineeDetailSerializer.new(@trainee.hesa_trainee_detail).as_hash
+      end
+
+      def funding_method
+        ::Trainees::MapFundingToHesaBursaryLevel.call(trainee: @trainee)
       end
 
       def nationality

--- a/app/services/trainees/map_funding_to_hesa_bursary_level.rb
+++ b/app/services/trainees/map_funding_to_hesa_bursary_level.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Trainees
+  class MapFundingToHesaBursaryLevel
+    include ServicePattern
+
+    BURSARY_TIER_TO_HESA_CODE = {
+      BURSARY_TIER_ENUMS[:tier_one] => ::Hesa::CodeSets::BursaryLevels::TIER_ONE,
+      BURSARY_TIER_ENUMS[:tier_two] => ::Hesa::CodeSets::BursaryLevels::TIER_TWO,
+      BURSARY_TIER_ENUMS[:tier_three] => ::Hesa::CodeSets::BursaryLevels::TIER_THREE,
+    }.freeze
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      return if funding_not_set?
+
+      return ::Hesa::CodeSets::BursaryLevels::SCHOLARSHIP if trainee.applying_for_scholarship?
+
+      if trainee.applying_for_bursary?
+        return BURSARY_TIER_TO_HESA_CODE[trainee.bursary_tier] if trainee.bursary_tier.present?
+        return ::Hesa::CodeSets::BursaryLevels::VETERAN_TEACHING_UNDERGRADUATE_BURSARY if veteran_bursary?
+        return ::Hesa::CodeSets::BursaryLevels::UNDERGRADUATE_BURSARY if trainee.undergrad_route?
+
+        return ::Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY
+      end
+
+      return ::Hesa::CodeSets::BursaryLevels::GRANT if trainee.applying_for_grant?
+
+      ::Hesa::CodeSets::BursaryLevels::NONE
+    end
+
+  private
+
+    attr_reader :trainee
+
+    def funding_not_set?
+      trainee.applying_for_bursary.nil? &&
+        trainee.applying_for_grant.nil? &&
+        trainee.applying_for_scholarship.nil?
+    end
+
+    def veteran_bursary?
+      trainee.training_initiative == ROUTE_INITIATIVES_ENUMS[:veterans_teaching_undergraduate_bursary]
+    end
+  end
+end

--- a/spec/requests/api/v2026_0/get_trainee_spec.rb
+++ b/spec/requests/api/v2026_0/get_trainee_spec.rb
@@ -27,6 +27,29 @@ describe "`GET /api/v2026.0/trainees/:id` endpoint" do
     end
   end
 
+  context "when the trainee was created in the UI without a HESA trainee detail record" do
+    let!(:trainee) do
+      create(
+        :trainee,
+        :created_manually,
+        provider: auth_token.provider,
+        applying_for_bursary: true,
+      )
+    end
+
+    before do
+      get(
+        "/api/v2026.0/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns funding_method derived from the trainee funding fields" do
+      expect(trainee.hesa_trainee_detail).to be_nil
+      expect(response.parsed_body[:funding_method]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
+    end
+  end
+
   context "when the trainee does not exist" do
     before do
       get(

--- a/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
@@ -123,6 +123,30 @@ RSpec.describe Api::V20250::TraineeSerializer do
         trainee.update!(funding_eligibility: :eligible)
         expect(serialized["fund_code"]).to eq(Hesa::CodeSets::FundCodes::ELIGIBLE)
       end
+
+      it "includes funding_method derived from trainee funding fields" do
+        trainee.update!(applying_for_bursary: true, training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative])
+        expect(serialized["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
+      end
+    end
+
+    describe "when the trainee has no HESA trainee detail record" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :created_manually,
+          :with_diversity_information,
+          :in_progress,
+          :with_french_nationality,
+          applying_for_bursary: true,
+          training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative],
+        )
+      end
+
+      it "derives funding_method from the trainee funding fields" do
+        expect(trainee.hesa_trainee_detail).to be_nil
+        expect(json[:funding_method]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
+      end
     end
 
     describe "nationality" do

--- a/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Api::V20250::TraineeSerializer do
       end
 
       it "serializes model attributes" do
-        model_attrs = trainee.hesa_trainee_detail.attributes.except(*Api::V20250::HesaTraineeDetailSerializer::EXCLUDED_ATTRIBUTES)
+        model_attrs = trainee.hesa_trainee_detail.attributes.except(*Api::V20250::HesaTraineeDetailSerializer::EXCLUDED_ATTRIBUTES, "funding_method")
         expect(serialized).to include(model_attrs)
       end
 
@@ -124,7 +124,8 @@ RSpec.describe Api::V20250::TraineeSerializer do
         expect(serialized["fund_code"]).to eq(Hesa::CodeSets::FundCodes::ELIGIBLE)
       end
 
-      it "includes funding_method derived from trainee funding fields" do
+      it "falls back to deriving funding_method from trainee funding fields when the stored value is nil" do
+        trainee.hesa_trainee_detail.update!(funding_method: nil)
         trainee.update!(applying_for_bursary: true, training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative])
         expect(serialized["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
       end

--- a/spec/serializers/api/v2026_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_0/trainee_serializer_spec.rb
@@ -123,6 +123,30 @@ RSpec.describe Api::V20260::TraineeSerializer do
         trainee.update!(funding_eligibility: :eligible)
         expect(serialized["fund_code"]).to eq(Hesa::CodeSets::FundCodes::ELIGIBLE)
       end
+
+      it "includes funding_method derived from trainee funding fields" do
+        trainee.update!(applying_for_bursary: true, training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative])
+        expect(serialized["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
+      end
+    end
+
+    describe "when the trainee has no HESA trainee detail record" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :created_manually,
+          :with_diversity_information,
+          :in_progress,
+          :with_french_nationality,
+          applying_for_bursary: true,
+          training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative],
+        )
+      end
+
+      it "derives funding_method from the trainee funding fields" do
+        expect(trainee.hesa_trainee_detail).to be_nil
+        expect(json[:funding_method]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
+      end
     end
 
     describe "nationality" do

--- a/spec/serializers/api/v2026_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_0/trainee_serializer_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Api::V20260::TraineeSerializer do
       end
 
       it "serializes model attributes" do
-        model_attrs = trainee.hesa_trainee_detail.attributes.except(*Api::V20260::HesaTraineeDetailSerializer::EXCLUDED_ATTRIBUTES)
+        model_attrs = trainee.hesa_trainee_detail.attributes.except(*Api::V20260::HesaTraineeDetailSerializer::EXCLUDED_ATTRIBUTES, "funding_method")
         expect(serialized).to include(model_attrs)
       end
 
@@ -124,7 +124,8 @@ RSpec.describe Api::V20260::TraineeSerializer do
         expect(serialized["fund_code"]).to eq(Hesa::CodeSets::FundCodes::ELIGIBLE)
       end
 
-      it "includes funding_method derived from trainee funding fields" do
+      it "falls back to deriving funding_method from trainee funding fields when the stored value is nil" do
+        trainee.hesa_trainee_detail.update!(funding_method: nil)
         trainee.update!(applying_for_bursary: true, training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative])
         expect(serialized["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
       end

--- a/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
@@ -124,6 +124,30 @@ RSpec.describe Api::V20261::TraineeSerializer do
         trainee.update!(funding_eligibility: :eligible)
         expect(serialized["fund_code"]).to eq(Hesa::CodeSets::FundCodes::ELIGIBLE)
       end
+
+      it "includes funding_method derived from trainee funding fields" do
+        trainee.update!(applying_for_bursary: true, training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative])
+        expect(serialized["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
+      end
+    end
+
+    describe "when the trainee has no HESA trainee detail record" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :created_manually,
+          :with_diversity_information,
+          :in_progress,
+          :with_french_nationality,
+          applying_for_bursary: true,
+          training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative],
+        )
+      end
+
+      it "derives funding_method from the trainee funding fields" do
+        expect(trainee.hesa_trainee_detail).to be_nil
+        expect(json[:funding_method]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
+      end
     end
 
     describe "nationality" do

--- a/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Api::V20261::TraineeSerializer do
       end
 
       it "serializes model attributes" do
-        model_attrs = trainee.hesa_trainee_detail.attributes.except(*Api::V20261::HesaTraineeDetailSerializer::EXCLUDED_ATTRIBUTES, "fund_code")
+        model_attrs = trainee.hesa_trainee_detail.attributes.except(*Api::V20261::HesaTraineeDetailSerializer::EXCLUDED_ATTRIBUTES, "fund_code", "funding_method")
         expect(serialized).to include(model_attrs)
       end
 
@@ -125,7 +125,8 @@ RSpec.describe Api::V20261::TraineeSerializer do
         expect(serialized["fund_code"]).to eq(Hesa::CodeSets::FundCodes::ELIGIBLE)
       end
 
-      it "includes funding_method derived from trainee funding fields" do
+      it "falls back to deriving funding_method from trainee funding fields when the stored value is nil" do
+        trainee.hesa_trainee_detail.update!(funding_method: nil)
         trainee.update!(applying_for_bursary: true, training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative])
         expect(serialized["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
       end

--- a/spec/services/trainees/map_funding_to_hesa_bursary_level_spec.rb
+++ b/spec/services/trainees/map_funding_to_hesa_bursary_level_spec.rb
@@ -29,10 +29,10 @@ module Trainees
       it { is_expected.to be_nil }
     end
 
-    # The following codes can't be recovered from the funding fields alone -
-    # the inbound mapper collapses undergrad/postgrad/veteran bursaries to a
-    # plain applying_for_bursary, so we disambiguate via training_route and
-    # training_initiative. These are asserted explicitly rather than round-tripped.
+    # We can't work out these codes using *only* the funding fields.
+    # The inbound mapping squashes undergrad, postgrad, and veteran bursaries into a
+    # basic "applying_for_bursary" flag. We need to use the training_route and
+    # training_initiative to tell them apart, hence direct testing, instead of round-trips.
     context "when applying for a bursary on the veteran teaching initiative" do
       let(:applying_for_bursary) { true }
       let(:training_initiative) { ROUTE_INITIATIVES_ENUMS[:veterans_teaching_undergraduate_bursary] }

--- a/spec/services/trainees/map_funding_to_hesa_bursary_level_spec.rb
+++ b/spec/services/trainees/map_funding_to_hesa_bursary_level_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe MapFundingToHesaBursaryLevel do
+    subject { described_class.call(trainee:) }
+
+    let(:trainee) do
+      build(
+        :trainee,
+        training_route:,
+        applying_for_bursary:,
+        applying_for_grant:,
+        applying_for_scholarship:,
+        bursary_tier:,
+        training_initiative:,
+      )
+    end
+
+    let(:training_route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
+    let(:applying_for_bursary) { nil }
+    let(:applying_for_grant) { nil }
+    let(:applying_for_scholarship) { nil }
+    let(:bursary_tier) { nil }
+    let(:training_initiative) { ROUTE_INITIATIVES_ENUMS[:no_initiative] }
+
+    context "when no funding has been set" do
+      it { is_expected.to be_nil }
+    end
+
+    # The following codes can't be recovered from the funding fields alone -
+    # the inbound mapper collapses undergrad/postgrad/veteran bursaries to a
+    # plain applying_for_bursary, so we disambiguate via training_route and
+    # training_initiative. These are asserted explicitly rather than round-tripped.
+    context "when applying for a bursary on the veteran teaching initiative" do
+      let(:applying_for_bursary) { true }
+      let(:training_initiative) { ROUTE_INITIATIVES_ENUMS[:veterans_teaching_undergraduate_bursary] }
+
+      it { is_expected.to eq(::Hesa::CodeSets::BursaryLevels::VETERAN_TEACHING_UNDERGRADUATE_BURSARY) }
+    end
+
+    context "when applying for a bursary on an undergraduate route" do
+      let(:training_route) { TRAINING_ROUTE_ENUMS[:provider_led_undergrad] }
+      let(:applying_for_bursary) { true }
+
+      it { is_expected.to eq(::Hesa::CodeSets::BursaryLevels::UNDERGRADUATE_BURSARY) }
+    end
+
+    context "when applying for a bursary on a postgraduate route" do
+      let(:applying_for_bursary) { true }
+
+      it { is_expected.to eq(::Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY) }
+    end
+
+    # HESA bursary level has no single code for grant + tier, so we pick the tier.
+    # See PR questions - this is a product/HESA decision, not a code one.
+    context "when applying for both a grant and a tiered bursary" do
+      let(:applying_for_bursary) { true }
+      let(:applying_for_grant) { true }
+      let(:bursary_tier) { BURSARY_TIER_ENUMS[:tier_two] }
+
+      it "the tier takes precedence" do
+        expect(subject).to eq(::Hesa::CodeSets::BursaryLevels::TIER_TWO)
+      end
+    end
+
+    # Drift protection: for codes whose Trainee state is fully captured by the
+    # funding fields (not route/initiative dependent), feeding them through the
+    # inbound mapper and back out again must return the original code. This will
+    # fault if MapFundingFromDttpEntityId or the bursary level mappings change.
+    describe "round trip with MapFundingFromDttpEntityId" do
+      [
+        ::Hesa::CodeSets::BursaryLevels::SCHOLARSHIP,
+        ::Hesa::CodeSets::BursaryLevels::NONE,
+        ::Hesa::CodeSets::BursaryLevels::TIER_ONE,
+        ::Hesa::CodeSets::BursaryLevels::TIER_TWO,
+        ::Hesa::CodeSets::BursaryLevels::TIER_THREE,
+        ::Hesa::CodeSets::BursaryLevels::GRANT,
+      ].each do |hesa_code|
+        context "for HESA bursary level #{hesa_code}" do
+          let(:funding_fields) do
+            entity_id = ::Hesa::CodeSets::BursaryLevels::MAPPING[hesa_code]
+            MapFundingFromDttpEntityId.call(funding_entity_id: entity_id)
+          end
+
+          let(:trainee) do
+            build(:trainee, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad], **funding_fields)
+          end
+
+          it "maps the Trainee funding fields back to #{hesa_code}" do
+            expect(described_class.call(trainee:)).to eq(hesa_code)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/ql0zBrWx/9590-improve-handling-of-trainees-updated-via-both-api-and-ui-funding-method-part-2)

There are some issues with data for trainees who are HESA-created or manually-created when accessed and updated via the API, or vice versa.

We want to fix this by implementing proposals from https://dfedigital.atlassian.net/wiki/spaces/Register/pages/5724504068/Investigate+how+to+refactor+Hesa+TraineeDetail (which is the output from https://trello.com/c/jYoKmYX1/61-what-does-the-api-return-for-manually-added-or-api-added-and-manually-modified-trainees).

There is one field on Hesa::TraineeDetail that is 2-way mappable (as per https://dfedigital.atlassian.net/wiki/spaces/Register/pages/5724504068/Investigate+how+to+refactor+Hesa+TraineeDetail):

`funding_method`

This is a follow-on from https://trello.com/c/olpj05ZN/9560-improve-handling-of-trainees-updated-via-both-api-and-ui-funding-method

### Changes proposed in this pull request

* mapper for `MapFundingToHesaBursaryLevel ` - this is essentially the inverse of `MapFundingFromDttpEntityId`
* serialisers updated
* a spec to error on any drift between the two `spec/services/trainees/map_funding_to_hesa_bursary_level_spec.rb`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
