### PR TITLE
[9590] Improve handling of trainees updated via both API and UI - funding method - part 2

### DIFF
--- a/app/serializers/api/v2025_0/hesa_trainee_detail_serializer.rb
+++ b/app/serializers/api/v2025_0/hesa_trainee_detail_serializer.rb
@@ -6,6 +6,7 @@ module Api
       EXCLUDED_ATTRIBUTES = %w[
         id
         course_study_mode
+        funding_method
         hesa_disabilities
         trainee_id
       ].freeze

--- a/app/serializers/api/v2025_0/trainee_serializer.rb
+++ b/app/serializers/api/v2025_0/trainee_serializer.rb
@@ -58,6 +58,7 @@ module Api
             course_attributes,
             lead_partner_and_employing_school_attributes,
             hesa_trainee_attributes,
+            funding_method: funding_method,
             sex: sex,
             study_mode: course_study_mode,
             course_subject_one: course_subject_one,
@@ -197,6 +198,11 @@ module Api
         return {} unless @trainee.hesa_trainee_detail
 
         HesaTraineeDetailSerializer.new(@trainee.hesa_trainee_detail).as_hash
+      end
+
+      def funding_method
+        @trainee.hesa_trainee_detail&.funding_method.presence ||
+          ::Trainees::MapFundingToHesa.call(trainee: @trainee)
       end
 
       def nationality

--- a/app/serializers/api/v2026_0/trainee_serializer.rb
+++ b/app/serializers/api/v2026_0/trainee_serializer.rb
@@ -61,6 +61,7 @@ module Api
             course_attributes,
             training_partner_and_employing_school_attributes,
             hesa_trainee_attributes,
+            funding_method: funding_method,
             sex: sex,
             study_mode: course_study_mode,
             course_subject_1: course_subject_1,
@@ -200,6 +201,11 @@ module Api
         return {} unless @trainee.hesa_trainee_detail
 
         HesaTraineeDetailSerializer.new(@trainee.hesa_trainee_detail).as_hash
+      end
+
+      def funding_method
+        @trainee.hesa_trainee_detail&.funding_method.presence ||
+          ::Trainees::MapFundingToHesa.call(trainee: @trainee)
       end
 
       def nationality

--- a/app/serializers/api/v2026_1/trainee_serializer.rb
+++ b/app/serializers/api/v2026_1/trainee_serializer.rb
@@ -60,6 +60,7 @@ module Api
             course_attributes,
             training_partner_and_employing_school_attributes,
             hesa_trainee_attributes,
+            funding_method: funding_method,
             sex: sex,
             study_mode: course_study_mode,
             course_subject_1: course_subject_1,
@@ -200,6 +201,11 @@ module Api
         return {} unless @trainee.hesa_trainee_detail
 
         HesaTraineeDetailSerializer.new(@trainee.hesa_trainee_detail).as_hash
+      end
+
+      def funding_method
+        @trainee.hesa_trainee_detail&.funding_method.presence ||
+          ::Trainees::MapFundingToHesa.call(trainee: @trainee)
       end
 
       def nationality

--- a/spec/requests/api/v2025_0/get_trainee_spec.rb
+++ b/spec/requests/api/v2025_0/get_trainee_spec.rb
@@ -27,6 +27,54 @@ describe "`GET /api/v2025.0/trainees/:id` endpoint" do
     end
   end
 
+  context "when the trainee has a hesa_trainee_detail" do
+    let!(:trainee) do
+      create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, slug: "12345", provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2025.0/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    context "with a funding_method" do
+      it "returns the stored funding_method" do
+        expect(response.parsed_body["funding_method"]).to eq(trainee.hesa_trainee_detail.funding_method)
+      end
+    end
+
+    context "without a funding_method" do
+      let!(:trainee) do
+        create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, slug: "12345", provider: auth_token.provider).tap do |trainee|
+          trainee.hesa_trainee_detail.update!(funding_method: nil)
+        end
+      end
+
+      it "returns the funding_method mapped from the trainee funding attributes" do
+        expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+      end
+    end
+  end
+
+  context "when the trainee has no hesa_trainee_detail" do
+    let!(:trainee) do
+      create(:trainee, :with_tiered_bursary, slug: "12345", provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2025.0/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the funding_method mapped from the trainee funding attributes" do
+      expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+    end
+  end
+
   context "when the trainee does not exist" do
     before do
       get(

--- a/spec/requests/api/v2025_0/get_trainees_spec.rb
+++ b/spec/requests/api/v2025_0/get_trainees_spec.rb
@@ -11,6 +11,33 @@ describe "`GET /trainees` endpoint" do
 
   it_behaves_like "a register API endpoint", "/api/v2025.0/trainees"
 
+  context "when trainees are missing a funding_method" do
+    let!(:trainee_without_stored_funding_method) do
+      create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.hesa_trainee_detail.update!(funding_method: nil)
+      end
+    end
+
+    let!(:trainee_without_hesa_trainee_detail) do
+      create(:trainee, :with_tiered_bursary, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle)
+    end
+
+    before do
+      get(
+        "/api/v2025.0/trainees",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the funding_method mapped from the trainee funding attributes" do
+      [trainee_without_stored_funding_method, trainee_without_hesa_trainee_detail].each do |trainee|
+        serialized_trainee = response.parsed_body["data"].find { |data| data["trainee_id"] == trainee.slug }
+
+        expect(serialized_trainee["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+      end
+    end
+  end
+
   context "filtering out draft trainees" do
     let!(:draft_trainee) { create(:trainee, :draft, :with_hesa_trainee_detail) }
 

--- a/spec/requests/api/v2026_0/get_trainee_spec.rb
+++ b/spec/requests/api/v2026_0/get_trainee_spec.rb
@@ -27,6 +27,54 @@ describe "`GET /api/v2026.0/trainees/:id` endpoint" do
     end
   end
 
+  context "when the trainee has a hesa_trainee_detail" do
+    let!(:trainee) do
+      create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, slug: "12345", provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2026.0/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    context "with a funding_method" do
+      it "returns the stored funding_method" do
+        expect(response.parsed_body["funding_method"]).to eq(trainee.hesa_trainee_detail.funding_method)
+      end
+    end
+
+    context "without a funding_method" do
+      let!(:trainee) do
+        create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, slug: "12345", provider: auth_token.provider).tap do |trainee|
+          trainee.hesa_trainee_detail.update!(funding_method: nil)
+        end
+      end
+
+      it "returns the funding_method mapped from the trainee funding attributes" do
+        expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+      end
+    end
+  end
+
+  context "when the trainee has no hesa_trainee_detail" do
+    let!(:trainee) do
+      create(:trainee, :with_tiered_bursary, slug: "12345", provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2026.0/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the funding_method mapped from the trainee funding attributes" do
+      expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+    end
+  end
+
   context "when the trainee does not exist" do
     before do
       get(

--- a/spec/requests/api/v2026_0/get_trainees_spec.rb
+++ b/spec/requests/api/v2026_0/get_trainees_spec.rb
@@ -11,6 +11,33 @@ describe "`GET /trainees` endpoint" do
 
   it_behaves_like "a register API endpoint", "/api/v2026.0/trainees"
 
+  context "when trainees are missing a funding_method" do
+    let!(:trainee_without_stored_funding_method) do
+      create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.hesa_trainee_detail.update!(funding_method: nil)
+      end
+    end
+
+    let!(:trainee_without_hesa_trainee_detail) do
+      create(:trainee, :with_tiered_bursary, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle)
+    end
+
+    before do
+      get(
+        "/api/v2026.0/trainees",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the funding_method mapped from the trainee funding attributes" do
+      [trainee_without_stored_funding_method, trainee_without_hesa_trainee_detail].each do |trainee|
+        serialized_trainee = response.parsed_body["data"].find { |data| data["trainee_id"] == trainee.slug }
+
+        expect(serialized_trainee["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+      end
+    end
+  end
+
   context "filtering out draft trainees" do
     let!(:draft_trainee) { create(:trainee, :draft, :with_hesa_trainee_detail) }
 

--- a/spec/requests/api/v2026_1/get_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/get_trainee_spec.rb
@@ -27,6 +27,54 @@ describe "`GET /api/v2026.1/trainees/:id` endpoint" do
     end
   end
 
+  context "when the trainee has a hesa_trainee_detail" do
+    let!(:trainee) do
+      create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, slug: "12345", provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2026.1/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    context "with a funding_method" do
+      it "returns the stored funding_method" do
+        expect(response.parsed_body["funding_method"]).to eq(trainee.hesa_trainee_detail.funding_method)
+      end
+    end
+
+    context "without a funding_method" do
+      let!(:trainee) do
+        create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, slug: "12345", provider: auth_token.provider).tap do |trainee|
+          trainee.hesa_trainee_detail.update!(funding_method: nil)
+        end
+      end
+
+      it "returns the funding_method mapped from the trainee funding attributes" do
+        expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+      end
+    end
+  end
+
+  context "when the trainee has no hesa_trainee_detail" do
+    let!(:trainee) do
+      create(:trainee, :with_tiered_bursary, slug: "12345", provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2026.1/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the funding_method mapped from the trainee funding attributes" do
+      expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+    end
+  end
+
   context "when the trainee does not exist" do
     before do
       get(

--- a/spec/requests/api/v2026_1/get_trainees_spec.rb
+++ b/spec/requests/api/v2026_1/get_trainees_spec.rb
@@ -11,6 +11,33 @@ describe "`GET /trainees` endpoint" do
 
   it_behaves_like "a register API endpoint", "/api/v2026.1/trainees"
 
+  context "when trainees are missing a funding_method" do
+    let!(:trainee_without_stored_funding_method) do
+      create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.hesa_trainee_detail.update!(funding_method: nil)
+      end
+    end
+
+    let!(:trainee_without_hesa_trainee_detail) do
+      create(:trainee, :with_tiered_bursary, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle)
+    end
+
+    before do
+      get(
+        "/api/v2026.1/trainees",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the funding_method mapped from the trainee funding attributes" do
+      [trainee_without_stored_funding_method, trainee_without_hesa_trainee_detail].each do |trainee|
+        serialized_trainee = response.parsed_body["data"].find { |data| data["trainee_id"] == trainee.slug }
+
+        expect(serialized_trainee["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+      end
+    end
+  end
+
   context "filtering out draft trainees" do
     let!(:draft_trainee) { create(:trainee, :draft, :with_hesa_trainee_detail) }
 

--- a/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
@@ -125,6 +125,34 @@ RSpec.describe Api::V20250::TraineeSerializer do
       end
     end
 
+    describe "funding_method" do
+      context "when the hesa_trainee_detail has a funding_method" do
+        it "serializes the stored funding_method" do
+          expect(json["funding_method"]).to eq(trainee.hesa_trainee_detail.funding_method)
+        end
+      end
+
+      context "when the hesa_trainee_detail has no funding_method" do
+        let(:trainee) do
+          create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary).tap do |trainee|
+            trainee.hesa_trainee_detail.update!(funding_method: nil)
+          end
+        end
+
+        it "serializes the funding_method mapped from the trainee funding attributes" do
+          expect(json["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, :with_tiered_bursary) }
+
+        it "serializes the funding_method mapped from the trainee funding attributes" do
+          expect(json["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+        end
+      end
+    end
+
     describe "nationality" do
       it "serializes nationality to HESA code" do
         expect(json[:nationality]).to eq("FR")

--- a/spec/serializers/api/v2026_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_0/trainee_serializer_spec.rb
@@ -125,6 +125,34 @@ RSpec.describe Api::V20260::TraineeSerializer do
       end
     end
 
+    describe "funding_method" do
+      context "when the hesa_trainee_detail has a funding_method" do
+        it "serializes the stored funding_method" do
+          expect(json["funding_method"]).to eq(trainee.hesa_trainee_detail.funding_method)
+        end
+      end
+
+      context "when the hesa_trainee_detail has no funding_method" do
+        let(:trainee) do
+          create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary).tap do |trainee|
+            trainee.hesa_trainee_detail.update!(funding_method: nil)
+          end
+        end
+
+        it "serializes the funding_method mapped from the trainee funding attributes" do
+          expect(json["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, :with_tiered_bursary) }
+
+        it "serializes the funding_method mapped from the trainee funding attributes" do
+          expect(json["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+        end
+      end
+    end
+
     describe "nationality" do
       it "serializes nationality to HESA code" do
         expect(json[:nationality]).to eq("FR")

--- a/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
@@ -126,6 +126,34 @@ RSpec.describe Api::V20261::TraineeSerializer do
       end
     end
 
+    describe "funding_method" do
+      context "when the hesa_trainee_detail has a funding_method" do
+        it "serializes the stored funding_method" do
+          expect(json["funding_method"]).to eq(trainee.hesa_trainee_detail.funding_method)
+        end
+      end
+
+      context "when the hesa_trainee_detail has no funding_method" do
+        let(:trainee) do
+          create(:trainee, :with_hesa_trainee_detail, :with_tiered_bursary).tap do |trainee|
+            trainee.hesa_trainee_detail.update!(funding_method: nil)
+          end
+        end
+
+        it "serializes the funding_method mapped from the trainee funding attributes" do
+          expect(json["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, :with_tiered_bursary) }
+
+        it "serializes the funding_method mapped from the trainee funding attributes" do
+          expect(json["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+        end
+      end
+    end
+
     describe "nationality" do
       it "serializes nationality to HESA code" do
         expect(json[:nationality]).to eq("FR")


### PR DESCRIPTION
### Context

[9590-improve-handling-of-trainees-updated-via-both-api-and-ui-funding-method-part-2](https://trello.com/c/ql0zBrWx/9590-improve-handling-of-trainees-updated-via-both-api-and-ui-funding-method-part-2)

### Changes proposed in this pull request

* Serialise `funding_method` in `TraineeSerializer`
* Fallback to `Trainees::MapFundingToHesa` if the `hesa_trainee_detail` is missing or the `hesa_trainee_detail#funding_method` is `nil`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
