### PR TITLE
[9578] New Qualtrics ids, better error handling

### DIFF
--- a/app/lib/qualtrics_api/client.rb
+++ b/app/lib/qualtrics_api/client.rb
@@ -15,9 +15,34 @@ module QualtricsApi
     def self.post(...)
       response = Request.post(...)
 
-      raise(HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}") unless response.success?
+      raise(http_error(response)) unless response.success?
 
       response
     end
+
+    def self.fetch_result(response, key)
+      parsed = JSON.parse(response.body)
+      value = parsed.dig("result", key)
+      return value if value.present?
+
+      raise(http_error(response, parsed:))
+    rescue JSON::ParserError
+      raise(HttpError, "status: #{response.code}, invalid JSON body: #{response.body}")
+    end
+
+    def self.http_error(response, parsed: nil)
+      parsed ||= JSON.parse(response.body)
+      error = parsed.dig("meta", "error") || parsed["error"]
+      detail = if error.is_a?(Hash)
+                 [error["errorCode"], error["errorMessage"]].compact.join(": ")
+               else
+                 parsed["result"].nil? ? "missing result in response" : "request failed"
+               end
+
+      HttpError.new("status: #{response.code}, #{detail}, body: #{response.body}")
+    rescue JSON::ParserError
+      HttpError.new("status: #{response.code}, body: #{response.body}, headers: #{response.headers}")
+    end
+    private_class_method :http_error
   end
 end

--- a/app/services/survey/base.rb
+++ b/app/services/survey/base.rb
@@ -25,10 +25,7 @@ module Survey
     def call
       return false unless should_send_survey?
 
-      unless response.success?
-        raise(StandardError, response.body)
-      end
-
+      create_distribution
       true
     end
 
@@ -38,19 +35,15 @@ module Survey
 
     delegate :first_names, :last_name, :email, :training_route, to: :trainee
 
-    def response
-      @response ||= create_distribution
-    end
-
     def contact_id
-      @contact_id ||= begin
-        response_body = create_contact_in_mailing_list_response.body
-        JSON.parse(response_body)["result"]["contactLookupId"]
-      end
+      @contact_id ||= QualtricsApi::Client.fetch_result(
+        create_contact_in_mailing_list_response,
+        "contactLookupId",
+      )
     end
 
     def create_contact_in_mailing_list_response
-      @create_contact_in_mailing_list_response ||= QualtricsApi::Client::Request.post(
+      @create_contact_in_mailing_list_response ||= QualtricsApi::Client.post(
         "/directories/#{directory_id}/mailinglists/#{mailing_list_id}/contacts",
         body: create_contact_in_mailing_list_body,
       )
@@ -66,7 +59,7 @@ module Survey
     end
 
     def create_distribution
-      QualtricsApi::Client::Request.post(
+      QualtricsApi::Client.post(
         "/distributions",
         body: create_distribution_body,
       )

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -39,12 +39,12 @@ google_tag_manager:
 qualtrics:
   directory_id: POOL_03wzmFoShC0dJRP
   base_url: https://fra1.qualtrics.com/API/v3/
-  library_id: UR_0qTPqmqVt86pGL4
+  library_id: UR_00Y1yoROVfab3Ei
   withdraw:
     survey_id: change_me
-    mailing_list_id: CG_2bZrlBdyq2DWcLV
-    message_id: MS_UaqTY612tQhJaZl
+    mailing_list_id: CG_3fCpfKT6HlLIKKa
+    message_id: MS_iGynzGf4Lcyb9AR
   award:
     survey_id: change_me
-    mailing_list_id: CG_2bZrlBdyq2DWcLV
-    message_id: MS_UaqTY612tQhJaZl
+    mailing_list_id: CG_3fCpfKT6HlLIKKa
+    message_id: MS_iGynzGf4Lcyb9AR

--- a/spec/support/shared_examples/survey_service_examples.rb
+++ b/spec/support/shared_examples/survey_service_examples.rb
@@ -81,16 +81,30 @@ RSpec.shared_examples "a survey service" do |date_field, email_subject|
   end
 
   context "when the API call fails" do
-    before do
-      allow(QualtricsApi::Client::Request).to receive(:post)
-        .and_raise(
-          QualtricsApi::Client::HttpError,
-          "status: 500, body: Internal Server Error",
-        )
+    let(:failure_response) do
+      instance_double(
+        HTTParty::Response,
+        code: 403,
+        body: {
+          meta: {
+            httpStatus: "403 - Forbidden",
+            error: { errorMessage: "Access denied to TA entity", errorCode: "TAG_0.4" },
+          },
+        }.to_json,
+        success?: false,
+        headers: {},
+      )
     end
 
-    it "raises an HttpError" do
-      expect { subject }.to raise_error(QualtricsApi::Client::HttpError)
+    before do
+      allow(QualtricsApi::Client::Request).to receive(:post).and_return(failure_response)
+    end
+
+    it "raises an HttpError with the Qualtrics error details" do
+      expect { subject }.to raise_error(
+        QualtricsApi::Client::HttpError,
+        /TAG_0\.4: Access denied to TA entity/,
+      )
     end
   end
 end


### PR DESCRIPTION
### Context

[Trello card](https://github.com/DFE-Digital/register-trainee-teachers/pull/6231)

Qualtrics survey sends have been erroring out for a few weeks

### Changes proposed in this pull request

* New qualtrics ids for message_id, mailing_list_id, and library_id have been added and tested
* new error handling has been added

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
