### PR TITLE
[9621] Fix incorrect dates returned by the API for some trainees

### DIFF
--- a/app/serializers/api/v2025_0/hesa_trainee_detail_serializer.rb
+++ b/app/serializers/api/v2025_0/hesa_trainee_detail_serializer.rb
@@ -9,6 +9,8 @@ module Api
         funding_method
         hesa_disabilities
         trainee_id
+        created_at
+        updated_at
       ].freeze
 
       FUND_CODE_FROM_ELIGIBILITY = {

--- a/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
@@ -109,6 +109,15 @@ RSpec.describe Api::V20250::TraineeSerializer do
       end
     end
 
+    describe "created_at and updated_at" do
+      it "uses the trainee timestamps, not hesa_trainee_detail" do
+        expect(json["created_at"]).to eq(trainee.created_at)
+        expect(json["updated_at"]).to eq(trainee.updated_at)
+        expect(json["created_at"]).not_to eq(trainee.hesa_trainee_detail.created_at)
+        expect(json["updated_at"]).not_to eq(trainee.hesa_trainee_detail.updated_at)
+      end
+    end
+
     describe "HESA trainee details" do
       let(:serialized) do
         Api::V20250::HesaTraineeDetailSerializer.new(trainee.hesa_trainee_detail).as_hash.with_indifferent_access

--- a/spec/serializers/api/v2026_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_0/trainee_serializer_spec.rb
@@ -109,6 +109,15 @@ RSpec.describe Api::V20260::TraineeSerializer do
       end
     end
 
+    describe "created_at and updated_at" do
+      it "uses the trainee timestamps, not hesa_trainee_detail" do
+        expect(json["created_at"]).to eq(trainee.created_at)
+        expect(json["updated_at"]).to eq(trainee.updated_at)
+        expect(json["created_at"]).not_to eq(trainee.hesa_trainee_detail.created_at)
+        expect(json["updated_at"]).not_to eq(trainee.hesa_trainee_detail.updated_at)
+      end
+    end
+
     describe "HESA trainee details" do
       let(:serialized) do
         Api::V20260::HesaTraineeDetailSerializer.new(trainee.hesa_trainee_detail).as_hash.with_indifferent_access

--- a/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
@@ -110,6 +110,15 @@ RSpec.describe Api::V20261::TraineeSerializer do
       end
     end
 
+    describe "created_at and updated_at" do
+      it "uses the trainee timestamps, not hesa_trainee_detail" do
+        expect(json["created_at"]).to eq(trainee.created_at)
+        expect(json["updated_at"]).to eq(trainee.updated_at)
+        expect(json["created_at"]).not_to eq(trainee.hesa_trainee_detail.created_at)
+        expect(json["updated_at"]).not_to eq(trainee.hesa_trainee_detail.updated_at)
+      end
+    end
+
     describe "HESA trainee details" do
       let(:serialized) do
         Api::V20261::HesaTraineeDetailSerializer.new(trainee.hesa_trainee_detail).as_hash.with_indifferent_access


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/AmIb3R0a/9621-fix-incorrect-dates-returned-by-the-api-for-some-trainees)

### Changes proposed in this pull request

* Exclude the `HesaTraineeDetailSerializer` dates so that the correct `created_at` and `updated_at` dates are returned for all trainees from the API.
* Add a test for this

### Guidance to review

* Are the correct dates now returned?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
