### PR TITLE
[9639] Sync course_age_range in API and UI on POST/PUT

### DIFF
--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -4,6 +4,7 @@ module ApplyApplications
   class ConfirmCourseForm
     include ActiveModel::Model
     include CourseFormHelpers
+    include HesaCourseAgeRangeSync
 
     FIELDS = %i[
       uuid
@@ -29,6 +30,7 @@ module ApplyApplications
       update_trainee_attributes unless trainee_confirmed?
       trainee.progress.course_details = mark_as_reviewed
       clear_funding_information if clear_funding_information?
+      sync_hesa_course_age_range
 
       Trainees::Update.call(trainee:)
     end

--- a/app/forms/concerns/hesa_course_age_range_sync.rb
+++ b/app/forms/concerns/hesa_course_age_range_sync.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module HesaCourseAgeRangeSync
+private
+
+  def sync_hesa_course_age_range
+    return unless trainee.hesa_trainee_detail
+
+    trainee.hesa_trainee_detail.course_age_range = Trainees::MapCourseAgeRangeToHesa.call(trainee:)
+  end
+end

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -3,6 +3,7 @@
 class CourseDetailsForm < TraineeForm
   include CourseFormHelpers
   include DatesHelper
+  include HesaCourseAgeRangeSync
 
   FIELDS = %i[
     course_uuid
@@ -92,6 +93,7 @@ class CourseDetailsForm < TraineeForm
   def save!
     if valid?
       update_trainee_attributes
+      sync_hesa_course_age_range
       clear_funding_information if clear_funding_information?
       Trainees::Update.call(trainee:)
       clear_all_course_related_stashes

--- a/app/forms/course_education_phase_form.rb
+++ b/app/forms/course_education_phase_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CourseEducationPhaseForm < TraineeForm
+  include HesaCourseAgeRangeSync
+
   FIELDS = %i[
     course_education_phase
   ].freeze
@@ -13,6 +15,7 @@ class CourseEducationPhaseForm < TraineeForm
     if valid?
       trainee.assign_attributes(fields)
       clear_course_subjects if trainee.course_education_phase_changed?
+      sync_hesa_course_age_range
       Trainees::Update.call(trainee:)
       clear_stash
     else

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -2,6 +2,7 @@
 
 class PublishCourseDetailsForm < TraineeForm
   include CourseFormHelpers
+  include HesaCourseAgeRangeSync
 
   NOT_LISTED = "not_listed"
 
@@ -58,6 +59,7 @@ class PublishCourseDetailsForm < TraineeForm
     return false unless valid?
 
     update_trainee_attributes
+    sync_hesa_course_age_range
     clear_funding_information if clear_funding_information?
     Trainees::Update.call(trainee:)
     clear_all_course_related_stashes

--- a/app/services/api/v2025_0/create_hesa_trainee_detail_service.rb
+++ b/app/services/api/v2025_0/create_hesa_trainee_detail_service.rb
@@ -17,6 +17,7 @@ module Api
         attributes = extract_attributes_from_student_record
         attributes.merge!(extract_attributes_from_metadatum_record(attributes))
         attributes[:funding_method] = ::Trainees::MapFundingToHesa.call(trainee:) if attributes[:funding_method].blank?
+        attributes[:course_age_range] = ::Trainees::MapCourseAgeRangeToHesa.call(trainee:) if attributes[:course_age_range].blank?
         hesa_trainee_detail.assign_attributes(attributes)
 
         hesa_trainee_detail.save!

--- a/app/services/api/v2026_1/create_hesa_trainee_detail_service.rb
+++ b/app/services/api/v2026_1/create_hesa_trainee_detail_service.rb
@@ -17,6 +17,7 @@ module Api
         attributes = extract_attributes_from_student_record
         attributes.merge!(extract_attributes_from_metadatum_record(attributes))
         attributes[:funding_method] = ::Trainees::MapFundingToHesa.call(trainee:) if attributes[:funding_method].blank?
+        attributes[:course_age_range] = ::Trainees::MapCourseAgeRangeToHesa.call(trainee:) if attributes[:course_age_range].blank?
         hesa_trainee_detail.assign_attributes(attributes)
 
         hesa_trainee_detail.save!

--- a/app/services/trainees/map_course_age_range_to_hesa.rb
+++ b/app/services/trainees/map_course_age_range_to_hesa.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Trainees
+  class MapCourseAgeRangeToHesa
+    include ServicePattern
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      ::ReferenceData::COURSE_AGE_RANGES.find(trainee.course_age_range)&.hesa_code
+    end
+
+  private
+
+    attr_reader :trainee
+  end
+end

--- a/config/reference_data/course_age_range.yml
+++ b/config/reference_data/course_age_range.yml
@@ -134,10 +134,6 @@ data:
     name: nine_to_sixteen
     display_name: "Nine to sixteen"
     description: ""
-  - id: [11, 19]
-    name: eleven_to_nineteen
-    display_name: "Eleven to nineteen"
-    description: ""
   - id: [13, 18]
     name: thirteen_to_eighteen
     display_name: "Thirteen to eighteen"

--- a/spec/forms/apply_applications/confirm_course_form_spec.rb
+++ b/spec/forms/apply_applications/confirm_course_form_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ApplyApplications
+  describe ConfirmCourseForm, type: :model do
+    let(:trainee) { create(:trainee, :with_secondary_course_details, course_age_range:) }
+    let(:course_age_range) { [11, 16] }
+    let(:specialisms) { trainee.course_subjects }
+    let(:params) { {} }
+
+    subject(:form) { described_class.new(trainee, specialisms, params) }
+
+    describe "#save" do
+      context "when the trainee has a hesa_trainee_detail" do
+        before { trainee.create_hesa_trainee_detail!(course_age_range: existing_code) }
+
+        context "with a range that has a HESA code" do
+          let(:existing_code) { nil }
+
+          it "syncs the hesa course_age_range from the trainee's range" do
+            expect { form.save }
+              .to change { trainee.reload.hesa_trainee_detail.course_age_range }
+              .from(nil).to("13918")
+          end
+        end
+
+        context "without a HESA code for the range" do
+          let(:course_age_range) { [11, 18] }
+          let(:existing_code) { "13918" }
+
+          it "clears the stored code to nil" do
+            expect { form.save }
+              .to change { trainee.reload.hesa_trainee_detail.course_age_range }
+              .from("13918").to(nil)
+          end
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        it "does not create one" do
+          form.save
+
+          expect(trainee.reload.hesa_trainee_detail).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/concerns/hesa_course_age_range_sync_spec.rb
+++ b/spec/forms/concerns/hesa_course_age_range_sync_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HesaCourseAgeRangeSync do
+  let(:host_class) do
+    Class.new do
+      include HesaCourseAgeRangeSync
+
+      attr_accessor :trainee
+
+      def save!
+        sync_hesa_course_age_range
+      end
+    end
+  end
+
+  let(:instance) { host_class.new.tap { |i| i.trainee = trainee } }
+
+  describe "#save!" do
+    context "when the trainee has no hesa_trainee_detail" do
+      let(:trainee) { build(:trainee, course_min_age: 11, course_max_age: 16) }
+
+      it "is a no-op" do
+        expect { instance.save! }.not_to raise_error
+      end
+    end
+
+    context "when the trainee has a hesa_trainee_detail" do
+      before { trainee.create_hesa_trainee_detail!(course_age_range: existing_code) }
+
+      context "with a range that has a HESA code" do
+        let(:trainee) { create(:trainee, course_min_age: 11, course_max_age: 16) }
+        let(:existing_code) { nil }
+
+        it "assigns the HESA code for the range in memory using the mapper" do
+          expect { instance.save! }
+            .to change { trainee.hesa_trainee_detail.course_age_range }
+            .from(nil)
+            .to("13918")
+        end
+
+        it "does not persist the change on its own" do
+          instance.save!
+
+          expect(trainee.hesa_trainee_detail.reload.course_age_range).to be_nil
+        end
+      end
+
+      context "without a HESA code for the range" do
+        let(:trainee) { create(:trainee, course_min_age: 7, course_max_age: 16) }
+        let(:existing_code) { "13918" }
+
+        it "clears the stored code to nil" do
+          expect { instance.save! }
+            .to change { trainee.hesa_trainee_detail.course_age_range }
+            .from("13918")
+            .to(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -645,6 +645,45 @@ describe CourseDetailsForm, type: :model do
             .from(trainee.course_education_phase).to(COURSE_EDUCATION_PHASE_ENUMS[:primary])
         end
       end
+
+      context "when the trainee has a hesa_trainee_detail" do
+        before do
+          allocation_subject
+          trainee.create_hesa_trainee_detail!(course_age_range: existing_code)
+        end
+
+        context "with a range that has a HESA code" do
+          let(:existing_code) { nil }
+
+          it "syncs the HESA course_age_range code from the saved range" do
+            expect { subject.save! }
+              .to change { trainee.reload.hesa_trainee_detail.course_age_range }
+              .from(nil).to("13919")
+          end
+        end
+
+        context "without a HESA code for the saved range" do
+          let(:existing_code) { "13918" }
+          let(:min_age) { 7 }
+          let(:max_age) { 16 }
+
+          it "clears the stored code to nil" do
+            expect { subject.save! }
+              .to change { trainee.reload.hesa_trainee_detail.course_age_range }
+              .from("13918").to(nil)
+          end
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        before { allocation_subject }
+
+        it "does not create one" do
+          subject.save!
+
+          expect(trainee.reload.hesa_trainee_detail).to be_nil
+        end
+      end
     end
 
     describe "#stash" do

--- a/spec/forms/course_education_phase_form_spec.rb
+++ b/spec/forms/course_education_phase_form_spec.rb
@@ -48,5 +48,15 @@ describe CourseEducationPhaseForm, type: :model do
         expect(trainee.reload.course_subject_one).not_to be_nil
       end
     end
+
+    context "when the trainee has a hesa_trainee_detail" do
+      before { trainee.create_hesa_trainee_detail!(course_age_range: "13918") }
+
+      it "syncs the hesa course_age_range to match the cleared range" do
+        expect { subject.save! }
+          .to change { trainee.reload.hesa_trainee_detail.course_age_range }
+          .from("13918").to(nil)
+      end
+    end
   end
 end

--- a/spec/forms/publish_course_details_form_spec.rb
+++ b/spec/forms/publish_course_details_form_spec.rb
@@ -37,6 +37,8 @@ describe PublishCourseDetailsForm, type: :model do
         let(:course_uuid) { SecureRandom.uuid }
         let(:subject_name) { "Physical education" }
         let(:course_level) { "primary" }
+        let(:course_min_age) { 11 }
+        let(:course_max_age) { 16 }
         let(:subject_specialism_form) do
           SubjectSpecialismForm.new(trainee, params: { course_subject_one: subject_name })
         end
@@ -49,7 +51,9 @@ describe PublishCourseDetailsForm, type: :model do
                  uuid: course_uuid,
                  route: route,
                  accredited_body_code: trainee.provider.code,
-                 subject_names: [subject_name])
+                 subject_names: [subject_name],
+                 min_age: course_min_age,
+                 max_age: course_max_age)
 
           subject_specialism_form.stash_or_save!
         end
@@ -60,6 +64,29 @@ describe PublishCourseDetailsForm, type: :model do
 
           it "does not change the trainee's itt start date" do
             expect { subject.save! }.not_to(change { trainee.itt_start_date })
+          end
+        end
+
+        context "when the trainee has a hesa_trainee_detail" do
+          before { trainee.create_hesa_trainee_detail!(course_age_range: nil) }
+
+          it "syncs the hesa course_age_range from the course's age range" do
+            expect { subject.save! }
+              .to change { trainee.reload.hesa_trainee_detail.course_age_range }
+              .from(nil).to("13918")
+          end
+
+          context "without a HESA code for the course's age range" do
+            let(:course_min_age) { 7 }
+            let(:course_max_age) { 16 }
+
+            before { trainee.hesa_trainee_detail.update!(course_age_range: "13918") }
+
+            it "clears the stored code to nil" do
+              expect { subject.save! }
+                .to change { trainee.reload.hesa_trainee_detail.course_age_range }
+                .from("13918").to(nil)
+            end
           end
         end
       end

--- a/spec/requests/api/v2025_0/put_trainee_spec.rb
+++ b/spec/requests/api/v2025_0/put_trainee_spec.rb
@@ -2329,6 +2329,37 @@ describe "`PUT /api/v2025.0/trainees/:id` endpoint" do
         expect(trainee.reload.hesa_trainee_detail.funding_method).to eq(Hesa::CodeSets::BursaryLevels::NONE)
       end
     end
+
+    context "when the trainee has no hesa_trainee_detail, the hesa_student has no course_age_range and course_age_range is not in the update payload" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :in_progress,
+          trainee_route_trait,
+          hesa_id: "0310261553102",
+          funding_eligibility: :not_eligible,
+          applying_for_bursary: false,
+          applying_for_scholarship: false,
+          applying_for_grant: false,
+          bursary_tier: nil,
+          course_min_age: 11,
+          course_max_age: 16,
+        )
+      end
+      let(:data) { { course_year: "2015", itt_aim: "202", itt_qualification_aim: "001" } }
+
+      before do
+        create(:hesa_student, hesa_id: trainee.hesa_id, course_age_range: nil, fund_code: "7", bursary_level: nil)
+        create(:hesa_metadatum, trainee:)
+      end
+
+      it "falls back to Trainees::MapCourseAgeRangeToHesa for course_age_range" do
+        put(endpoint, params: params.to_json, headers: { Authorization: "Bearer #{token}", **json_headers })
+
+        expect(response).to have_http_status(:ok)
+        expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13918")
+      end
+    end
   end
 
   context "Updating a newly created trainee" do

--- a/spec/requests/api/v2026_1/put_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/put_trainee_spec.rb
@@ -2844,6 +2844,37 @@ describe "`PUT /api/v2026.1/trainees/:id` endpoint" do
         expect(trainee.reload.hesa_trainee_detail.funding_method).to eq(Hesa::CodeSets::BursaryLevels::NONE)
       end
     end
+
+    context "when the trainee has no hesa_trainee_detail, the hesa_student has no course_age_range and course_age_range is not in the update payload" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :in_progress,
+          trainee_route_trait,
+          hesa_id: "0310261553102",
+          funding_eligibility: :not_eligible,
+          applying_for_bursary: false,
+          applying_for_scholarship: false,
+          applying_for_grant: false,
+          bursary_tier: nil,
+          course_min_age: 11,
+          course_max_age: 16,
+        )
+      end
+      let(:data) { { course_year: "2015", itt_aim: "202", itt_qualification_aim: "001" } }
+
+      before do
+        create(:hesa_student, hesa_id: trainee.hesa_id, course_age_range: nil, fund_code: "7", bursary_level: nil)
+        create(:hesa_metadatum, trainee:)
+      end
+
+      it "falls back to Trainees::MapCourseAgeRangeToHesa for course_age_range" do
+        put(endpoint, params: params.to_json, headers: { Authorization: "Bearer #{token}", **json_headers })
+
+        expect(response).to have_http_status(:ok)
+        expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13918")
+      end
+    end
   end
 
   context "Updating a newly created trainee" do

--- a/spec/services/api/v2025_0/create_hesa_trainee_detail_service_spec.rb
+++ b/spec/services/api/v2025_0/create_hesa_trainee_detail_service_spec.rb
@@ -166,6 +166,30 @@ RSpec.describe Api::V20250::CreateHesaTraineeDetailService do
             .to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
         end
       end
+
+      context "when the course_age_range is missing" do
+        let(:trainee) { create(:trainee, course_min_age: 11, course_max_age: 16) }
+
+        it "derives course_age_range from the trainee's range via Trainees::MapCourseAgeRangeToHesa" do
+          subject.call(trainee:)
+
+          expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13918")
+        end
+      end
+
+      context "when a hesa_student course_age_range is present" do
+        let(:trainee) { create(:trainee, course_min_age: 11, course_max_age: 16) }
+
+        before do
+          create(:hesa_student, course_age_range: "13915", trainee: trainee)
+        end
+
+        it "prefers the student record's course_age_range over the fallback" do
+          subject.call(trainee:)
+
+          expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13915")
+        end
+      end
     end
   end
 end

--- a/spec/services/api/v2026_1/create_hesa_trainee_detail_service_spec.rb
+++ b/spec/services/api/v2026_1/create_hesa_trainee_detail_service_spec.rb
@@ -166,6 +166,30 @@ RSpec.describe Api::V20261::CreateHesaTraineeDetailService do
             .to eq(Hesa::CodeSets::BursaryLevels::POSTGRADUATE_BURSARY)
         end
       end
+
+      context "when the course_age_range is missing" do
+        let(:trainee) { create(:trainee, course_min_age: 11, course_max_age: 16) }
+
+        it "derives course_age_range from the trainee's range via Trainees::MapCourseAgeRangeToHesa" do
+          subject.call(trainee:)
+
+          expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13918")
+        end
+      end
+
+      context "when a hesa_student course_age_range is present" do
+        let(:trainee) { create(:trainee, course_min_age: 11, course_max_age: 16) }
+
+        before do
+          create(:hesa_student, course_age_range: "13915", trainee: trainee)
+        end
+
+        it "prefers the student record's course_age_range over the fallback" do
+          subject.call(trainee:)
+
+          expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13915")
+        end
+      end
     end
   end
 end

--- a/spec/services/trainees/map_course_age_range_to_hesa_spec.rb
+++ b/spec/services/trainees/map_course_age_range_to_hesa_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe MapCourseAgeRangeToHesa do
+    describe "::call" do
+      subject(:result) { described_class.call(trainee:) }
+
+      context "when the age range has a HESA code" do
+        let(:trainee) { build(:trainee, course_min_age: 11, course_max_age: 16) }
+
+        it { is_expected.to eq("13918") }
+      end
+
+      context "when the age range is one that maps to a single HESA code" do
+        let(:trainee) { build(:trainee, course_min_age: 11, course_max_age: 19) }
+
+        it { is_expected.to eq("13919") }
+      end
+
+      context "when the age range has no HESA code" do
+        let(:trainee) { build(:trainee, course_min_age: 7, course_max_age: 16) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when the trainee has no age range" do
+        let(:trainee) { build(:trainee, course_min_age: nil, course_max_age: nil) }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Sync course_age_range in API and UI on POST/PUT](https://trello.com/c/54Cx5jlj/9639-sync-courseagerange-in-api-and-ui-on-post-put)

### Changes proposed in this pull request

* Remove duplicate `[11, 19]` from `course_age_range.yml`
* Add `Trainees::MapCourseAgeRangeToHesa`
* Sync `course_age_range` to hesa_trainee_detail in course forms
* Sync course_age_range in POST/PUT in API

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
