### PR TITLE
[xxxx] Make sure expected start year is tested

### DIFF
--- a/spec/forms/funding/eligibility_form_spec.rb
+++ b/spec/forms/funding/eligibility_form_spec.rb
@@ -109,7 +109,7 @@ module Funding
           create(:trainee,
                  funding_eligibility: "eligible",
                  course_allocation_subject: allocation_subject,
-                 start_academic_cycle: academic_cycle,
+                 itt_start_date: academic_cycle.start_date,
                  applying_for_bursary: true,
                  bursary_tier: :tier_one)
         end


### PR DESCRIPTION
### Context

Running one test on 1 July has highlighted an academic year-related issue due to the `DEFAULT_CYCLE_OFFSET = 1.month`.

### Changes proposed in this pull request

* Create a trainee with an `itt_start_date` rather than `start_academic_cycle` to get the expected academic year when `SetAcademicCycles` is called on trainee save.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
