### PR TITLE
[9641] Sync course_study_mode in API and UI on POST/PUT

### DIFF
--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -5,6 +5,7 @@ module ApplyApplications
     include ActiveModel::Model
     include CourseFormHelpers
     include HesaCourseAgeRangeSync
+    include HesaCourseStudyModeSync
 
     FIELDS = %i[
       uuid
@@ -31,6 +32,7 @@ module ApplyApplications
       trainee.progress.course_details = mark_as_reviewed
       clear_funding_information if clear_funding_information?
       sync_hesa_course_age_range
+      sync_hesa_course_study_mode
 
       Trainees::Update.call(trainee:)
     end

--- a/app/forms/concerns/hesa_course_study_mode_sync.rb
+++ b/app/forms/concerns/hesa_course_study_mode_sync.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module HesaCourseStudyModeSync
+private
+
+  def sync_hesa_course_study_mode
+    return unless trainee.hesa_trainee_detail
+
+    trainee.hesa_trainee_detail.course_study_mode = Trainees::MapStudyModeToHesa.call(trainee:)
+  end
+end

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -4,6 +4,7 @@ class CourseDetailsForm < TraineeForm
   include CourseFormHelpers
   include DatesHelper
   include HesaCourseAgeRangeSync
+  include HesaCourseStudyModeSync
 
   FIELDS = %i[
     course_uuid
@@ -94,6 +95,7 @@ class CourseDetailsForm < TraineeForm
     if valid?
       update_trainee_attributes
       sync_hesa_course_age_range
+      sync_hesa_course_study_mode
       clear_funding_information if clear_funding_information?
       Trainees::Update.call(trainee:)
       clear_all_course_related_stashes

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -3,6 +3,7 @@
 class PublishCourseDetailsForm < TraineeForm
   include CourseFormHelpers
   include HesaCourseAgeRangeSync
+  include HesaCourseStudyModeSync
 
   NOT_LISTED = "not_listed"
 
@@ -60,6 +61,7 @@ class PublishCourseDetailsForm < TraineeForm
 
     update_trainee_attributes
     sync_hesa_course_age_range
+    sync_hesa_course_study_mode
     clear_funding_information if clear_funding_information?
     Trainees::Update.call(trainee:)
     clear_all_course_related_stashes

--- a/app/models/api/v2025_0/trainee_attributes.rb
+++ b/app/models/api/v2025_0/trainee_attributes.rb
@@ -283,6 +283,8 @@ module Api
         } || {}
         hesa_trainee_detail_attributes["fund_code"] ||=
           Api::V20250::HesaTraineeDetailSerializer::FUND_CODE_FROM_ELIGIBILITY[trainee.funding_eligibility]
+        hesa_trainee_detail_attributes["course_study_mode"] ||=
+          ::Trainees::MapStudyModeToHesa.call(trainee:)
 
         degrees_attributes = trainee.degrees.map do |degree|
           degree.attributes.select { |k, _v| DegreeAttributes::ATTRIBUTES.include?(k.to_sym) }

--- a/app/models/api/v2026_1/trainee_attributes.rb
+++ b/app/models/api/v2026_1/trainee_attributes.rb
@@ -285,6 +285,8 @@ module Api
         } || {}
         hesa_trainee_detail_attributes["fund_code"] ||=
           Api::V20250::HesaTraineeDetailSerializer::FUND_CODE_FROM_ELIGIBILITY[trainee.funding_eligibility]
+        hesa_trainee_detail_attributes["course_study_mode"] ||=
+          ::Trainees::MapStudyModeToHesa.call(trainee:)
 
         degrees_attributes = trainee.degrees.map do |degree|
           degree.attributes.select { |k, _v| DegreeAttributes::ATTRIBUTES.include?(k.to_sym) }

--- a/app/services/trainees/map_study_mode_to_hesa.rb
+++ b/app/services/trainees/map_study_mode_to_hesa.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Trainees
+  class MapStudyModeToHesa
+    include ServicePattern
+
+    STUDY_MODE_TO_HESA = {
+      COURSE_STUDY_MODES[:full_time] => "01",
+      COURSE_STUDY_MODES[:part_time] => "31",
+    }.freeze
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      return stored_code if selected_mode_value.nil?
+      return stored_code if ::Hesa::CodeSets::StudyModes::MAPPING[stored_code] == selected_mode_value
+
+      STUDY_MODE_TO_HESA[trainee.study_mode]
+    end
+
+  private
+
+    attr_reader :trainee
+
+    def stored_code
+      trainee.hesa_trainee_detail&.course_study_mode
+    end
+
+    def selected_mode_value
+      Trainee.study_modes[trainee.study_mode]
+    end
+  end
+end

--- a/spec/forms/apply_applications/confirm_course_form_spec.rb
+++ b/spec/forms/apply_applications/confirm_course_form_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 
 module ApplyApplications
   describe ConfirmCourseForm, type: :model do
+    subject(:form) { described_class.new(trainee, specialisms, params) }
+
     let(:trainee) { create(:trainee, :with_secondary_course_details, course_age_range:) }
     let(:course_age_range) { [11, 16] }
     let(:specialisms) { trainee.course_subjects }
     let(:params) { {} }
-
-    subject(:form) { described_class.new(trainee, specialisms, params) }
 
     describe "#save" do
       context "when the trainee has a hesa_trainee_detail" do
@@ -42,6 +42,24 @@ module ApplyApplications
           form.save
 
           expect(trainee.reload.hesa_trainee_detail).to be_nil
+        end
+      end
+
+      context "when the study mode is updated and the trainee has a hesa_trainee_detail" do
+        let(:trainee) do
+          create(:trainee, :provider_led_postgrad,
+                 course_uuid: SecureRandom.uuid,
+                 study_mode: COURSE_STUDY_MODES[:full_time])
+        end
+
+        before do
+          trainee.create_hesa_trainee_detail!(course_study_mode: "31")
+        end
+
+        it "syncs the course_study_mode to the canonical HESA code for the selected study mode" do
+          expect { form.save }
+            .to change { trainee.hesa_trainee_detail.reload.course_study_mode }
+            .from("31").to("01")
         end
       end
     end

--- a/spec/forms/concerns/hesa_course_study_mode_sync_spec.rb
+++ b/spec/forms/concerns/hesa_course_study_mode_sync_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HesaCourseStudyModeSync do
+  let(:host_class) do
+    Class.new do
+      include HesaCourseStudyModeSync
+
+      attr_accessor :trainee
+
+      def save!
+        sync_hesa_course_study_mode
+      end
+    end
+  end
+
+  let(:instance) { host_class.new.tap { |i| i.trainee = trainee } }
+
+  describe "#save!" do
+    context "when the trainee has no hesa_trainee_detail" do
+      let(:trainee) { build(:trainee, study_mode: "full_time") }
+
+      it "is a no-op" do
+        expect { instance.save! }.not_to raise_error
+      end
+    end
+
+    context "when the trainee has a hesa_trainee_detail" do
+      let(:trainee) { create(:trainee, study_mode: "part_time") }
+
+      before do
+        trainee.create_hesa_trainee_detail!(course_study_mode: "01")
+      end
+
+      it "assigns the canonical course_study_mode in memory using the mapper" do
+        expect { instance.save! }
+          .to change { trainee.hesa_trainee_detail.course_study_mode }
+          .from("01")
+          .to("31")
+      end
+
+      it "does not persist the change on its own" do
+        instance.save!
+
+        expect(trainee.hesa_trainee_detail.reload.course_study_mode).to eq("01")
+      end
+    end
+  end
+end

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -684,6 +684,21 @@ describe CourseDetailsForm, type: :model do
           expect(trainee.reload.hesa_trainee_detail).to be_nil
         end
       end
+
+      context "when the study mode is updated and the trainee has a hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, :provider_led_postgrad, study_mode: nil) }
+        let(:params) { super().merge(study_mode: COURSE_STUDY_MODES[:full_time]) }
+
+        before do
+          trainee.create_hesa_trainee_detail!(course_study_mode: "31")
+        end
+
+        it "syncs the course_study_mode to the canonical HESA code for the selected study mode" do
+          expect { subject.save! }
+            .to change { trainee.hesa_trainee_detail.reload.course_study_mode }
+            .from("31").to("01")
+        end
+      end
     end
 
     describe "#stash" do

--- a/spec/forms/publish_course_details_form_spec.rb
+++ b/spec/forms/publish_course_details_form_spec.rb
@@ -89,6 +89,22 @@ describe PublishCourseDetailsForm, type: :model do
             end
           end
         end
+
+        context "when the study mode is updated and the trainee has a hesa_trainee_detail" do
+          let(:trainee) do
+            create(:trainee, :submitted_for_trn, route, course_subject_one: nil, study_mode: COURSE_STUDY_MODES[:full_time])
+          end
+
+          before do
+            trainee.create_hesa_trainee_detail!(course_study_mode: "31")
+          end
+
+          it "syncs the course_study_mode to the canonical HESA code for the selected study mode" do
+            expect { subject.save! }
+              .to change { trainee.hesa_trainee_detail.reload.course_study_mode }
+              .from("31").to("01")
+          end
+        end
       end
     end
   end

--- a/spec/requests/api/v2025_0/put_trainee_spec.rb
+++ b/spec/requests/api/v2025_0/put_trainee_spec.rb
@@ -253,6 +253,26 @@ describe "`PUT /api/v2025.0/trainees/:id` endpoint" do
       end
     end
 
+    context "when the stored course_study_mode is missing and study_mode is not provided" do
+      let(:data) { { first_names: "Alice" } }
+
+      before do
+        trainee.update!(study_mode: COURSE_STUDY_MODES[:part_time])
+        trainee.hesa_trainee_detail.update!(course_study_mode: nil)
+
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
+      it "backfills course_study_mode from the trainee's study_mode using the mapper" do
+        expect(response).to have_http_status(:ok)
+        expect(trainee.reload.hesa_trainee_detail.course_study_mode).to eq("31")
+      end
+    end
+
     context "when updating with valid nationality" do
       let(:data) { { nationality: "IE" } }
 

--- a/spec/requests/api/v2026_1/put_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/put_trainee_spec.rb
@@ -295,6 +295,7 @@ describe "`PUT /api/v2026.1/trainees/:id` endpoint" do
 
       before do
         create(:degree, :uk_degree_with_details, :uk_foundation, trainee:)
+
         put(
           endpoint,
           headers: { Authorization: "Bearer #{token}", **json_headers },
@@ -305,6 +306,26 @@ describe "`PUT /api/v2026.1/trainees/:id` endpoint" do
       it "still updates the trainee, accepting the code-less degree type" do
         expect(response).to have_http_status(:ok)
         expect(trainee.reload.first_names).to eq("Alice")
+      end
+    end
+
+    context "when the stored course_study_mode is missing and study_mode is not provided" do
+      let(:data) { { first_names: "Alice" } }
+
+      before do
+        trainee.update!(study_mode: COURSE_STUDY_MODES[:part_time])
+        trainee.hesa_trainee_detail.update!(course_study_mode: nil)
+
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
+      it "backfills course_study_mode from the trainee's study_mode using the mapper" do
+        expect(response).to have_http_status(:ok)
+        expect(trainee.reload.hesa_trainee_detail.course_study_mode).to eq("31")
       end
     end
 

--- a/spec/services/trainees/map_study_mode_to_hesa_spec.rb
+++ b/spec/services/trainees/map_study_mode_to_hesa_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe MapStudyModeToHesa do
+    describe "::call" do
+      subject(:result) { described_class.call(trainee:) }
+
+      let(:trainee) { build(:trainee, study_mode:) }
+
+      before do
+        trainee.build_hesa_trainee_detail(course_study_mode:) if defined?(course_study_mode)
+      end
+
+      context "when no study mode is selected" do
+        let(:study_mode) { nil }
+
+        context "with a stored course_study_mode" do
+          let(:course_study_mode) { "01" }
+
+          it "preserves the stored value" do
+            expect(result).to eq("01")
+          end
+        end
+
+        context "without a stored course_study_mode" do
+          let(:course_study_mode) { nil }
+
+          it { is_expected.to be_nil }
+        end
+      end
+
+      context "when full time is selected" do
+        let(:study_mode) { "full_time" }
+
+        context "and the stored code already maps to full time" do
+          %w[01 02 63].each do |code|
+            context "stored as #{code}" do
+              let(:course_study_mode) { code }
+
+              it "preserves the stored value" do
+                expect(result).to eq(code)
+              end
+            end
+          end
+        end
+
+        context "and the stored code maps to part time" do
+          let(:course_study_mode) { "31" }
+
+          it "sets the canonical full time code" do
+            expect(result).to eq("01")
+          end
+        end
+
+        context "and there is no stored code" do
+          let(:course_study_mode) { nil }
+
+          it "sets the canonical full time code" do
+            expect(result).to eq("01")
+          end
+        end
+      end
+
+      context "when part time is selected" do
+        let(:study_mode) { "part_time" }
+
+        context "and the stored code already maps to part time" do
+          %w[31 64].each do |code|
+            context "stored as #{code}" do
+              let(:course_study_mode) { code }
+
+              it "preserves the stored value" do
+                expect(result).to eq(code)
+              end
+            end
+          end
+        end
+
+        context "and the stored code maps to full time" do
+          let(:course_study_mode) { "01" }
+
+          it "sets the canonical part time code" do
+            expect(result).to eq("31")
+          end
+        end
+
+        context "and there is no stored code" do
+          let(:course_study_mode) { nil }
+
+          it "sets the canonical part time code" do
+            expect(result).to eq("31")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

[9641-sync-coursestudymode-in-api-and-ui-on-post-put](https://trello.com/c/hQI2oKP6/9641-sync-coursestudymode-in-api-and-ui-on-post-put)

### Changes proposed in this pull request

* Add `Trainees::MapStudyModeToHesa`
* Add `HesaCourseStudyModeSync`
* Sync `course_study_mode` in the UI
* Sync `course_study_mode` in the API

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
