### PR TITLE
[9672] Do not show funding eligibility fields for SCITT providers

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -122,6 +122,8 @@ module Funding
     end
 
     def fund_code_row
+      return unless trainee.provider.hei?
+
       fund_code_text = Hesa::CodeSets::FundCodes::MAPPING[fund_code_value] ||
         Hesa::CodeSets::FundCodes::NO_FUND_CODE_PROVIDED
 

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -302,8 +302,10 @@ module Funding
       end
 
       describe "fund code row" do
+        let(:provider) { create(:provider, :hei) }
+
         context "when trainee has eligible funding eligibility" do
-          let(:trainee) { create(:trainee, :imported_from_hesa, funding_eligibility: :eligible) }
+          let(:trainee) { create(:trainee, :imported_from_hesa, provider: provider, funding_eligibility: :eligible) }
 
           before { render_inline(View.new(data_model: trainee)) }
 
@@ -314,7 +316,7 @@ module Funding
         end
 
         context "when trainee has not eligible funding eligibility" do
-          let(:trainee) { create(:trainee, :imported_from_hesa, funding_eligibility: :not_eligible) }
+          let(:trainee) { create(:trainee, :imported_from_hesa, provider: provider, funding_eligibility: :not_eligible) }
 
           before { render_inline(View.new(data_model: trainee)) }
 
@@ -325,7 +327,7 @@ module Funding
         end
 
         context "when trainee has no funding eligibility" do
-          let(:trainee) { create(:trainee, :imported_from_hesa, funding_eligibility: nil) }
+          let(:trainee) { create(:trainee, :imported_from_hesa, provider: provider, funding_eligibility: nil) }
 
           before { render_inline(View.new(data_model: trainee)) }
 
@@ -342,6 +344,40 @@ module Funding
 
         it "renders the hesa bursary level along with the code" do
           expect(rendered_content).to have_text("#{hesa_bursary_code} - #{Hesa::CodeSets::BursaryLevels::VALUES[hesa_bursary_code]}")
+        end
+      end
+    end
+
+    context "when trainee belongs to an HEI provider" do
+      describe "fund code row" do
+        let(:provider) { create(:provider, :hei) }
+        let(:trainee) { create(:trainee, :completed, provider: provider, funding_eligibility: :eligible) }
+
+        it "renders the fund code with description" do
+          expect(rendered_content).to have_text("Fund code")
+          expect(rendered_content).to have_text("Eligible for funding from the DfE")
+        end
+      end
+    end
+
+    context "when trainee belongs to a SCITT provider" do
+      describe "fund code row" do
+        let(:provider) { create(:provider, :scitt) }
+
+        context "with a previously answered funding eligibility" do
+          let(:trainee) { create(:trainee, :completed, provider: provider, funding_eligibility: :eligible) }
+
+          it "does not render the fund code row" do
+            expect(rendered_content).not_to have_text("Fund code")
+          end
+        end
+
+        context "without a funding eligibility" do
+          let(:trainee) { create(:trainee, :completed, provider:) }
+
+          it "does not render the fund code row" do
+            expect(rendered_content).not_to have_text("Fund code")
+          end
         end
       end
     end

--- a/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
@@ -29,6 +29,16 @@ feature "View trainees" do
     end
   end
 
+  context "when i am a SCITT provider user" do
+    background { given_i_am_authenticated(user: create(:user, :scitt)) }
+
+    scenario "viewing a manually created trainee with a previously answered funding eligibility" do
+      given_a_trainee_exists(:completed, :trn_received, funding_eligibility: :eligible)
+      and_i_visit_the_trainee
+      then_i_should_not_see_the_fund_code_displayed
+    end
+  end
+
   context "when trainee does not belong to me" do
     background { given_i_am_authenticated }
 
@@ -105,6 +115,7 @@ feature "View trainees" do
         :with_hesa_trainee_detail,
         hesa_id: "5678",
         record_source: :hesa_collection,
+        provider: create(:provider, :hei),
         training_partner: @current_user.training_partners.first,
         funding_eligibility: :eligible,
       )
@@ -209,5 +220,10 @@ private
     expected_text = Hesa::CodeSets::FundCodes::MAPPING[Hesa::CodeSets::FundCodes::ELIGIBLE]
     expect(page).to have_text("Fund code")
     expect(page).to have_text(expected_text)
+  end
+
+  def then_i_should_not_see_the_fund_code_displayed
+    expect(page).to have_text("Funding")
+    expect(page).not_to have_text("Fund code")
   end
 end


### PR DESCRIPTION
### Context

[9672-do-not-show-funding-eligibility-fields-for-scitt-providers](https://trello.com/c/b9XOTkcn/9672-do-not-show-funding-eligibility-fields-for-scitt-providers)

### Changes proposed in this pull request

* Add guard for `hei` providers

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
