### PR TITLE
[9642] Sync course_study_mode in API on  GET

### DIFF
--- a/app/serializers/api/v2025_0/trainee_serializer.rb
+++ b/app/serializers/api/v2025_0/trainee_serializer.rb
@@ -159,7 +159,8 @@ module Api
       end
 
       def course_study_mode
-        @trainee&.hesa_trainee_detail&.course_study_mode
+        @trainee&.hesa_trainee_detail&.course_study_mode.presence ||
+          ::Trainees::MapStudyModeToHesa.call(trainee: @trainee)
       end
 
       def course_itt_start_date

--- a/app/serializers/api/v2026_1/trainee_serializer.rb
+++ b/app/serializers/api/v2026_1/trainee_serializer.rb
@@ -162,7 +162,8 @@ module Api
       end
 
       def course_study_mode
-        @trainee&.hesa_trainee_detail&.course_study_mode
+        @trainee&.hesa_trainee_detail&.course_study_mode.presence ||
+          ::Trainees::MapStudyModeToHesa.call(trainee: @trainee)
       end
 
       def course_itt_start_date

--- a/spec/requests/api/v2025_0/get_trainee_spec.rb
+++ b/spec/requests/api/v2025_0/get_trainee_spec.rb
@@ -56,11 +56,29 @@ describe "`GET /api/v2025.0/trainees/:id` endpoint" do
         expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
       end
     end
+
+    context "with a course_study_mode" do
+      it "returns the stored course_study_mode as study_mode" do
+        expect(response.parsed_body["study_mode"]).to eq(trainee.hesa_trainee_detail.course_study_mode)
+      end
+    end
+
+    context "without a course_study_mode" do
+      let!(:trainee) do
+        create(:trainee, :with_hesa_trainee_detail, study_mode: COURSE_STUDY_MODES[:part_time], slug: "12345", provider: auth_token.provider).tap do |trainee|
+          trainee.hesa_trainee_detail.update!(course_study_mode: nil)
+        end
+      end
+
+      it "returns the canonical HESA code mapped from the trainee study mode" do
+        expect(response.parsed_body["study_mode"]).to eq("31")
+      end
+    end
   end
 
   context "when the trainee has no hesa_trainee_detail" do
     let!(:trainee) do
-      create(:trainee, :with_tiered_bursary, provider: auth_token.provider)
+      create(:trainee, :with_tiered_bursary, study_mode: COURSE_STUDY_MODES[:full_time], slug: "12345", provider: auth_token.provider)
     end
 
     before do
@@ -72,6 +90,10 @@ describe "`GET /api/v2025.0/trainees/:id` endpoint" do
 
     it "returns the funding_method mapped from the trainee funding attributes" do
       expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+    end
+
+    it "returns the canonical HESA code mapped from the trainee study mode" do
+      expect(response.parsed_body["study_mode"]).to eq("01")
     end
   end
 

--- a/spec/requests/api/v2025_0/get_trainees_spec.rb
+++ b/spec/requests/api/v2025_0/get_trainees_spec.rb
@@ -65,6 +65,33 @@ describe "`GET /trainees` endpoint" do
     end
   end
 
+  context "when trainees are missing a course_study_mode" do
+    let!(:trainee_without_stored_course_study_mode) do
+      create(:trainee, :with_hesa_trainee_detail, :trn_received, study_mode: COURSE_STUDY_MODES[:part_time], provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.hesa_trainee_detail.update!(course_study_mode: nil)
+      end
+    end
+
+    let!(:trainee_without_hesa_trainee_detail) do
+      create(:trainee, :trn_received, study_mode: COURSE_STUDY_MODES[:part_time], provider: auth_token.provider, start_academic_cycle: start_academic_cycle)
+    end
+
+    before do
+      get(
+        "/api/v2025.0/trainees",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the canonical HESA code mapped from the trainee study mode as study_mode" do
+      [trainee_without_stored_course_study_mode, trainee_without_hesa_trainee_detail].each do |trainee|
+        serialized_trainee = response.parsed_body["data"].find { |data| data["trainee_id"] == trainee.slug }
+
+        expect(serialized_trainee["study_mode"]).to eq("31")
+      end
+    end
+  end
+
   context "filtering out draft trainees" do
     let!(:draft_trainee) { create(:trainee, :draft, :with_hesa_trainee_detail) }
 

--- a/spec/requests/api/v2026_1/get_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/get_trainee_spec.rb
@@ -56,11 +56,29 @@ describe "`GET /api/v2026.1/trainees/:id` endpoint" do
         expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
       end
     end
+
+    context "with a course_study_mode" do
+      it "returns the stored course_study_mode as study_mode" do
+        expect(response.parsed_body["study_mode"]).to eq(trainee.hesa_trainee_detail.course_study_mode)
+      end
+    end
+
+    context "without a course_study_mode" do
+      let!(:trainee) do
+        create(:trainee, :with_hesa_trainee_detail, study_mode: COURSE_STUDY_MODES[:part_time], slug: "12345", provider: auth_token.provider).tap do |trainee|
+          trainee.hesa_trainee_detail.update!(course_study_mode: nil)
+        end
+      end
+
+      it "returns the canonical HESA code mapped from the trainee study mode" do
+        expect(response.parsed_body["study_mode"]).to eq("31")
+      end
+    end
   end
 
   context "when the trainee has no hesa_trainee_detail" do
     let!(:trainee) do
-      create(:trainee, :with_tiered_bursary, slug: "12345", provider: auth_token.provider)
+      create(:trainee, :with_tiered_bursary, study_mode: COURSE_STUDY_MODES[:full_time], slug: "12345", provider: auth_token.provider)
     end
 
     before do
@@ -72,6 +90,10 @@ describe "`GET /api/v2026.1/trainees/:id` endpoint" do
 
     it "returns the funding_method mapped from the trainee funding attributes" do
       expect(response.parsed_body["funding_method"]).to eq(Hesa::CodeSets::BursaryLevels::TIER_ONE)
+    end
+
+    it "returns the canonical HESA code mapped from the trainee study mode" do
+      expect(response.parsed_body["study_mode"]).to eq("01")
     end
   end
 

--- a/spec/requests/api/v2026_1/get_trainees_spec.rb
+++ b/spec/requests/api/v2026_1/get_trainees_spec.rb
@@ -65,6 +65,33 @@ describe "`GET /trainees` endpoint" do
     end
   end
 
+  context "when trainees are missing a course_study_mode" do
+    let!(:trainee_without_stored_course_study_mode) do
+      create(:trainee, :with_hesa_trainee_detail, :trn_received, study_mode: COURSE_STUDY_MODES[:part_time], provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.hesa_trainee_detail.update!(course_study_mode: nil)
+      end
+    end
+
+    let!(:trainee_without_hesa_trainee_detail) do
+      create(:trainee, :trn_received, study_mode: COURSE_STUDY_MODES[:part_time], provider: auth_token.provider, start_academic_cycle: start_academic_cycle)
+    end
+
+    before do
+      get(
+        "/api/v2026.1/trainees",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the canonical HESA code mapped from the trainee study mode as study_mode" do
+      [trainee_without_stored_course_study_mode, trainee_without_hesa_trainee_detail].each do |trainee|
+        serialized_trainee = response.parsed_body["data"].find { |data| data["trainee_id"] == trainee.slug }
+
+        expect(serialized_trainee["study_mode"]).to eq("31")
+      end
+    end
+  end
+
   context "filtering out draft trainees" do
     let!(:draft_trainee) { create(:trainee, :draft, :with_hesa_trainee_detail) }
 

--- a/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
@@ -190,6 +190,34 @@ RSpec.describe Api::V20250::TraineeSerializer do
       end
     end
 
+    describe "study_mode" do
+      context "when the hesa_trainee_detail has a course_study_mode" do
+        it "serializes the stored course_study_mode" do
+          expect(json["study_mode"]).to eq(trainee.hesa_trainee_detail.course_study_mode)
+        end
+      end
+
+      context "when the hesa_trainee_detail has no course_study_mode" do
+        let(:trainee) do
+          create(:trainee, :with_hesa_trainee_detail, study_mode: COURSE_STUDY_MODES[:part_time]).tap do |trainee|
+            trainee.hesa_trainee_detail.update!(course_study_mode: nil)
+          end
+        end
+
+        it "serializes the canonical HESA code mapped from the trainee study mode" do
+          expect(json["study_mode"]).to eq("31")
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, study_mode: COURSE_STUDY_MODES[:full_time]) }
+
+        it "serializes the canonical HESA code mapped from the trainee study mode" do
+          expect(json["study_mode"]).to eq("01")
+        end
+      end
+    end
+
     describe "nationality" do
       it "serializes nationality to HESA code" do
         expect(json[:nationality]).to eq("FR")

--- a/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
@@ -191,6 +191,34 @@ RSpec.describe Api::V20261::TraineeSerializer do
       end
     end
 
+    describe "study_mode" do
+      context "when the hesa_trainee_detail has a course_study_mode" do
+        it "serializes the stored course_study_mode" do
+          expect(json["study_mode"]).to eq(trainee.hesa_trainee_detail.course_study_mode)
+        end
+      end
+
+      context "when the hesa_trainee_detail has no course_study_mode" do
+        let(:trainee) do
+          create(:trainee, :with_hesa_trainee_detail, study_mode: COURSE_STUDY_MODES[:part_time]).tap do |trainee|
+            trainee.hesa_trainee_detail.update!(course_study_mode: nil)
+          end
+        end
+
+        it "serializes the canonical HESA code mapped from the trainee study mode" do
+          expect(json["study_mode"]).to eq("31")
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, study_mode: COURSE_STUDY_MODES[:full_time]) }
+
+        it "serializes the canonical HESA code mapped from the trainee study mode" do
+          expect(json["study_mode"]).to eq("01")
+        end
+      end
+    end
+
     describe "nationality" do
       it "serializes nationality to HESA code" do
         expect(json[:nationality]).to eq("FR")


### PR DESCRIPTION
### Context

[9642-sync-coursestudymode-in-api-on-get](https://trello.com/c/eX8XJyhJ/9642-sync-coursestudymode-in-api-on-get)

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
