### PR TITLE
Disable Airbyte in staging ENV

### DIFF
--- a/.github/workflows/database-replication-monitor.yml
+++ b/.github/workflows/database-replication-monitor.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa,staging,production]
+        environment: [qa,production]
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/fix-airbyte-replication.yml
+++ b/.github/workflows/fix-airbyte-replication.yml
@@ -10,7 +10,6 @@ on:
         type: choice
         options:
           - qa
-          - staging
           - production
       dry-run:
         description: Check slot status only do not create slot

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -54,7 +54,7 @@ DfE::Analytics.configure do |config|
   # use a new version of the BigQuery streaming APIs.
   config.azure_federated_auth = true
 
-  if Rails.env.in?(%w[development review qa staging production])
+  if Rails.env.in?(%w[development review qa production])
     # Path of airbyte stream config file relative to the App root (Rails.root)
     config.airbyte_stream_config_path = "terraform/aks/workspace-variables/airbyte_stream_config.json"
 

--- a/terraform/aks/workspace-variables/staging.tfvars.json
+++ b/terraform/aks/workspace-variables/staging.tfvars.json
@@ -46,7 +46,5 @@
   "enable_prometheus_monitoring": true,
   "send_traffic_to_maintenance_page": false,
   "pg_airbyte_enabled": true,
-  "wal_threshold": 15000000000,
-  "airbyte_enabled": true,
-  "connection_status": "active"
+  "airbyte_enabled": false
 }


### PR DESCRIPTION
### Context

Disable Airbyte in the staging environment. 

Staging Airbyte is not used. Being in the Production namespace it causes unnecessary alerts when the database is refreshed nightly.

### Changes proposed in this pull request

Disable Airbyte in the staging environment., through the Dfe Analytics config file.

Also disable provisioning in Terraform.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
