### PR TITLE
[9652] Changes for 2026 academic year to check on productiondata

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -234,7 +234,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [sandbox, productiondata]
+        environment: [sandbox] # productiondata temporarily disabled for testing new academic year
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -153,10 +153,11 @@ jobs:
     - name: Setup postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
 
-    - name: Restore backup to aks productiondata database
-      shell: bash
-      run: |
-        bin/konduit.sh -n bat-production -i ${{ env.BACKUP_FILE }} -c -t 7200 register-productiondata -- psql
+    # productiondata restore temporarily disabled for testing new academic year
+    # - name: Restore backup to aks productiondata database
+    #   shell: bash
+    #   run: |
+    #     bin/konduit.sh -n bat-production -i ${{ env.BACKUP_FILE }} -c -t 7200 register-productiondata -- psql
 
     - name: Restore backup to aks analysis database
       shell: bash

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -39,6 +39,7 @@ apply_applications:
 
 api:
   allowed_versions: [v2026.1]
+  current_version: v2026.1
 
 bulk_update:
   add_trainees:

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -24,7 +24,7 @@ features:
   google:
     send_data_to_big_query: false
   integrate_with_trs: false
-  register_api: false
+  register_api: true
   school_data_auto_import: true
 
 current_recruitment_cycle_year: 2026
@@ -36,6 +36,13 @@ apply_applications:
       - 2026
   create:
     recruitment_cycle_year: 2026
+
+api:
+  allowed_versions: [v2026.1]
+
+bulk_update:
+  add_trainees:
+    version: v2026.1
 
 environment:
   name: productiondata

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -27,6 +27,16 @@ features:
   register_api: false
   school_data_auto_import: true
 
+current_recruitment_cycle_year: 2026
+current_default_course_year: 2026
+
+apply_applications:
+  import:
+    recruitment_cycle_years:
+      - 2026
+  create:
+    recruitment_cycle_year: 2026
+
 environment:
   name: productiondata
   display_name: Production Data

--- a/terraform/aks/workspace-variables/productiondata.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata.tfvars.json
@@ -17,7 +17,7 @@
   "worker_apps": {
     "worker": {
       "startup_command": ["/bin/sh", "-c", "bundle exec sidekiq -C config/sidekiq.all.yml"],
-      "replicas": 0,
+      "replicas": 1,
       "memory_max": "1Gi"
     }
   },


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/vRmN3Ot6/9652-changes-for-ay-2026-27-to-check-on-productiondata)

### Changes proposed in this pull request

1. Take productiondata out of deploy pipelines
2. Disable productiondata DB restore
3. Temporarily add worker on productiondata
4. Change recruitment cycle settings to 2026
5. Change API and CSV setting to v2026.1

### Guidance to review

* Does syntax still look ok?
* Has anything been missed?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml