### PR TITLE
[9652] Settings changes for academic year 2026

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -106,15 +106,15 @@ recruits_api:
   base_url: "https://www.apply-for-teacher-training.service.gov.uk/register-api"
   auth_token: "auth-token-from-env"
 
-current_recruitment_cycle_year: 2025
-current_default_course_year: 2025
+current_recruitment_cycle_year: 2026
+current_default_course_year: 2026
 
 apply_applications:
   import:
     recruitment_cycle_years:
-      - 2025
+      - 2026
   create:
-    recruitment_cycle_year: 2025
+    recruitment_cycle_year: 2026
 
 jobs:
   poll_delay_hours: 1
@@ -201,12 +201,12 @@ api:
   blacklist:
     ua: []
     ip: []
-  allowed_versions: [v2025.0-rc, v2025.0]
-  current_version: v2025.0
+  allowed_versions: [v2026.1]
+  current_version: v2026.1
 
 bulk_update:
   add_trainees:
-    version: v2025.0
+    version: v2026.1
 
 qualtrics:
   api_token: please_change_me

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -19,7 +19,7 @@ environment:
   display_name: Review
 
 api:
-  allowed_versions: [v2025.0-rc, v2025.0, v2026.1]
+  allowed_versions: [v2026.1]
 
 bulk_update:
   add_trainees:

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -33,7 +33,7 @@ google:
     entity_table_checks_enabled: false
 
 api:
-  allowed_versions: [v2025.0-rc, v2025.0, v2026.1]
+  allowed_versions: [v2026.1]
 
 bulk_update:
   add_trainees:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -35,6 +35,3 @@ google_tag_manager:
   env_id: 12
 
 sign_off_period: # census_period, performance_period, outside_period. See app/services/determine_sign_off_period.rb
-
-api:
-  allowed_versions: [v2025.0-rc, v2025.0]

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -27,3 +27,7 @@ govuk_notify:
 
 api:
   allowed_versions: [v2025.0-rc, v2025.0, v2026.1]
+
+bulk_update:
+  add_trainees:
+    version: v2025.0

--- a/spec/requests/api/v2025_0/get_info_spec.rb
+++ b/spec/requests/api/v2025_0/get_info_spec.rb
@@ -16,7 +16,7 @@ describe "`GET /info` endpoint" do
     it_behaves_like "a register API endpoint", "/api/v2025.0/info"
 
     it "shows the requested version" do
-      expect(response.parsed_body).to eq({ "status" => "ok", "version" => { "latest" => "v2025.0", "requested" => "v2025.0" } })
+      expect(response.parsed_body).to eq({ "status" => "ok", "version" => { "latest" => "v2026.1", "requested" => "v2025.0" } })
     end
   end
 end

--- a/spec/requests/api/v2025_0_rc/get_info_spec.rb
+++ b/spec/requests/api/v2025_0_rc/get_info_spec.rb
@@ -16,7 +16,7 @@ describe "`GET /info` endpoint" do
     it_behaves_like "a register API endpoint", "/api/v2025.0-rc/info"
 
     it "shows the requested version" do
-      expect(response.parsed_body).to eq({ "status" => "ok", "version" => { "latest" => "v2025.0", "requested" => "v2025.0-rc" } })
+      expect(response.parsed_body).to eq({ "status" => "ok", "version" => { "latest" => "v2026.1", "requested" => "v2025.0-rc" } })
     end
   end
 end

--- a/spec/requests/api/v2026_1/get_info_spec.rb
+++ b/spec/requests/api/v2026_1/get_info_spec.rb
@@ -16,7 +16,7 @@ describe "`GET /info` endpoint" do
     it_behaves_like "a register API endpoint", "/api/v2026.1/info"
 
     it "shows the requested version" do
-      expect(response.parsed_body).to eq({ "status" => "ok", "version" => { "latest" => "v2025.0", "requested" => "v2026.1" } })
+      expect(response.parsed_body).to eq({ "status" => "ok", "version" => { "latest" => "v2026.1", "requested" => "v2026.1" } })
     end
   end
 end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/vRmN3Ot6)

### Changes proposed in this pull request

* Change relevant settings for the academic year switch to 2026
* Tweak settings and tests to keep 2025 tests working for now. We'll tidy them up after go-live.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
