### PR TITLE
[9643] Sync hesa_disabilities in API and UI on POST/PUT

### DIFF
--- a/app/forms/concerns/hesa_disabilities_sync.rb
+++ b/app/forms/concerns/hesa_disabilities_sync.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module HesaDisabilitiesSync
+private
+
+  def sync_hesa_disabilities
+    return unless trainee.hesa_trainee_detail
+
+    trainee.hesa_trainee_detail.hesa_disabilities = Trainees::MapDisabilitiesToHesa.call(trainee:)
+  end
+end

--- a/app/forms/diversities/disability_detail_form.rb
+++ b/app/forms/diversities/disability_detail_form.rb
@@ -2,6 +2,8 @@
 
 module Diversities
   class DisabilityDetailForm < TraineeForm
+    include HesaDisabilitiesSync
+
     attr_accessor :disability_ids, :additional_disability
 
     validate :disabilities_cannot_be_empty, if: -> { disability_disclosure_form.disabled? && disabilities.empty? }
@@ -16,6 +18,8 @@ module Diversities
         Trainee.transaction do
           trainee.disability_ids = fields[:disability_ids] # This will actually persist the records
           other_trainee_disability&.update!(additional_disability: fields[:additional_disability])
+          sync_hesa_disabilities
+          trainee.hesa_trainee_detail&.save!
         end
 
         clear_stash

--- a/app/forms/diversities/disability_disclosure_form.rb
+++ b/app/forms/diversities/disability_disclosure_form.rb
@@ -2,6 +2,8 @@
 
 module Diversities
   class DisabilityDisclosureForm < TraineeForm
+    include HesaDisabilitiesSync
+
     FIELDS = %i[
       disability_disclosure
     ].freeze
@@ -19,9 +21,14 @@ module Diversities
     end
 
     def save!
+      return false unless valid?
+
       ActiveRecord::Base.transaction do
         trainee.clear_disabilities if disability_not_provided? || no_disability?
-        super
+        assign_attributes_to_trainee
+        sync_hesa_disabilities
+        Trainees::Update.call(trainee:, update_trs:)
+        clear_stash
       end
     end
 

--- a/app/services/api/v2025_0/create_hesa_trainee_detail_service.rb
+++ b/app/services/api/v2025_0/create_hesa_trainee_detail_service.rb
@@ -18,6 +18,7 @@ module Api
         attributes.merge!(extract_attributes_from_metadatum_record(attributes))
         attributes[:funding_method] = ::Trainees::MapFundingToHesa.call(trainee:) if attributes[:funding_method].blank?
         attributes[:course_age_range] = ::Trainees::MapCourseAgeRangeToHesa.call(trainee:) if attributes[:course_age_range].blank?
+        attributes[:hesa_disabilities] = ::Trainees::MapDisabilitiesToHesa.call(trainee:) if attributes[:hesa_disabilities].blank?
         hesa_trainee_detail.assign_attributes(attributes)
 
         hesa_trainee_detail.save!

--- a/app/services/api/v2026_1/create_hesa_trainee_detail_service.rb
+++ b/app/services/api/v2026_1/create_hesa_trainee_detail_service.rb
@@ -18,6 +18,7 @@ module Api
         attributes.merge!(extract_attributes_from_metadatum_record(attributes))
         attributes[:funding_method] = ::Trainees::MapFundingToHesa.call(trainee:) if attributes[:funding_method].blank?
         attributes[:course_age_range] = ::Trainees::MapCourseAgeRangeToHesa.call(trainee:) if attributes[:course_age_range].blank?
+        attributes[:hesa_disabilities] = ::Trainees::MapDisabilitiesToHesa.call(trainee:) if attributes[:hesa_disabilities].blank?
         hesa_trainee_detail.assign_attributes(attributes)
 
         hesa_trainee_detail.save!

--- a/app/services/trainees/map_disabilities_to_hesa.rb
+++ b/app/services/trainees/map_disabilities_to_hesa.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Trainees
+  class MapDisabilitiesToHesa
+    include ServicePattern
+
+    NO_KNOWN_IMPAIRMENT = "95"
+    PREFER_NOT_TO_SAY = "98"
+    NOT_AVAILABLE = "99"
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      codes.each_with_index.to_h { |code, index| ["disability#{index + 1}", code] }
+    end
+
+  private
+
+    attr_reader :trainee
+
+    def codes
+      case trainee.disability_disclosure
+      when Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled]
+        disability_codes
+      when Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability]
+        [NO_KNOWN_IMPAIRMENT]
+      when Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided]
+        [not_provided_code]
+      else
+        []
+      end
+    end
+
+    def disability_codes
+      trainee.disabilities.map { |disability| code_for(disability.name) }.compact
+    end
+
+    def code_for(name)
+      canonical = ::ReferenceData::DISABILITIES.find(name)&.hesa_codes&.first
+      return if canonical.nil?
+
+      existing_code_for(name) || canonical
+    end
+
+    def existing_code_for(name)
+      existing_codes.find { |code| ::ReferenceData::DISABILITIES.find_by_hesa_code(code)&.id == name }
+    end
+
+    def not_provided_code
+      existing_codes.include?(NOT_AVAILABLE) ? NOT_AVAILABLE : PREFER_NOT_TO_SAY
+    end
+
+    def existing_codes
+      @existing_codes ||= trainee.hesa_trainee_detail&.hesa_disabilities&.values || []
+    end
+  end
+end

--- a/spec/forms/concerns/hesa_disabilities_sync_spec.rb
+++ b/spec/forms/concerns/hesa_disabilities_sync_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HesaDisabilitiesSync do
+  let(:host_class) do
+    Class.new do
+      include HesaDisabilitiesSync
+
+      attr_accessor :trainee
+
+      def save!
+        sync_hesa_disabilities
+      end
+    end
+  end
+
+  let(:instance) { host_class.new.tap { |i| i.trainee = trainee } }
+
+  describe "#save!" do
+    context "when the trainee has no hesa_trainee_detail" do
+      let(:trainee) { build(:trainee, :disabled) }
+
+      it "is a no-op" do
+        expect { instance.save! }.not_to raise_error
+      end
+    end
+
+    context "when the trainee has a hesa_trainee_detail" do
+      let(:trainee) { create(:trainee, :disabled) }
+
+      before do
+        trainee.disabilities << create(:disability, :learning_difficulty)
+        trainee.create_hesa_trainee_detail!(hesa_disabilities: {})
+      end
+
+      it "rebuilds hesa_disabilities in memory using the mapper" do
+        expect { instance.save! }
+          .to change { trainee.hesa_trainee_detail.hesa_disabilities }
+          .from({})
+          .to("disability1" => "51")
+      end
+
+      it "does not persist the change on its own" do
+        instance.save!
+
+        expect(trainee.hesa_trainee_detail.reload.hesa_disabilities).to eq({})
+      end
+    end
+  end
+end

--- a/spec/forms/diversities/disability_detail_form_spec.rb
+++ b/spec/forms/diversities/disability_detail_form_spec.rb
@@ -23,5 +23,28 @@ module Diversities
         end
       end
     end
+
+    describe "#save!" do
+      let(:trainee) { create(:trainee, :disabled, :diversity_disclosed) }
+      let(:learning_difficulty) { create(:disability, :learning_difficulty) }
+      let(:form_store) { class_double(FormStore) }
+
+      subject { described_class.new(trainee, params: { "disability_ids" => [learning_difficulty.id] }, store: form_store) }
+
+      before do
+        allow(form_store).to receive(:get).and_return(nil)
+        allow(form_store).to receive(:set)
+      end
+
+      context "when the trainee has a hesa_trainee_detail" do
+        before { trainee.create_hesa_trainee_detail!(hesa_disabilities: {}) }
+
+        it "syncs hesa_trainee_detail.hesa_disabilities via the mapper" do
+          subject.save!
+
+          expect(trainee.reload.hesa_trainee_detail.hesa_disabilities).to eq("disability1" => "51")
+        end
+      end
+    end
   end
 end

--- a/spec/forms/diversities/disability_disclosure_form_spec.rb
+++ b/spec/forms/diversities/disability_disclosure_form_spec.rb
@@ -46,6 +46,24 @@ module Diversities
       it "takes any data from the form store and saves it to the database" do
         expect { subject.save! }.to change(trainee, :disability_disclosure).to(disability_not_provided)
       end
+
+      context "when the trainee has a hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, :incomplete, :diversity_disclosed, :disabled) }
+        let(:disabled) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] }
+
+        before do
+          trainee.disabilities << create(:disability, :learning_difficulty)
+          trainee.create_hesa_trainee_detail!(hesa_disabilities: {})
+          allow(form_store).to receive(:get).and_return({ "disability_disclosure" => disabled })
+          allow(form_store).to receive(:set)
+        end
+
+        it "syncs hesa_trainee_detail.hesa_disabilities via the mapper" do
+          subject.save!
+
+          expect(trainee.reload.hesa_trainee_detail.hesa_disabilities).to eq("disability1" => "51")
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/v2025_0/put_trainee_spec.rb
+++ b/spec/requests/api/v2025_0/put_trainee_spec.rb
@@ -2380,6 +2380,39 @@ describe "`PUT /api/v2025.0/trainees/:id` endpoint" do
         expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13918")
       end
     end
+
+    context "when the trainee has no hesa_trainee_detail, the hesa_student has no disabilities and disabilities are not in the update payload" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :in_progress,
+          :disabled,
+          trainee_route_trait,
+          hesa_id: "0310261553104",
+          funding_eligibility: :not_eligible,
+          applying_for_bursary: false,
+          applying_for_scholarship: false,
+          applying_for_grant: false,
+          bursary_tier: nil,
+          course_min_age: 11,
+          course_max_age: 16,
+        )
+      end
+      let(:data) { { course_year: "2015", itt_aim: "202", itt_qualification_aim: "001" } }
+
+      before do
+        trainee.disabilities << create(:disability, :learning_difficulty)
+        create(:hesa_student, hesa_id: trainee.hesa_id, course_age_range: "13918", fund_code: "7", bursary_level: nil)
+        create(:hesa_metadatum, trainee:)
+      end
+
+      it "falls back to Trainees::MapDisabilitiesToHesa for hesa_disabilities" do
+        put(endpoint, params: params.to_json, headers: { Authorization: "Bearer #{token}", **json_headers })
+
+        expect(response).to have_http_status(:ok)
+        expect(trainee.reload.hesa_trainee_detail.hesa_disabilities).to eq("disability1" => "51")
+      end
+    end
   end
 
   context "Updating a newly created trainee" do

--- a/spec/requests/api/v2026_1/put_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/put_trainee_spec.rb
@@ -2896,6 +2896,39 @@ describe "`PUT /api/v2026.1/trainees/:id` endpoint" do
         expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13918")
       end
     end
+
+    context "when the trainee has no hesa_trainee_detail, the hesa_student has no disabilities and disabilities are not in the update payload" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :in_progress,
+          :disabled,
+          trainee_route_trait,
+          hesa_id: "0310261553104",
+          funding_eligibility: :not_eligible,
+          applying_for_bursary: false,
+          applying_for_scholarship: false,
+          applying_for_grant: false,
+          bursary_tier: nil,
+          course_min_age: 11,
+          course_max_age: 16,
+        )
+      end
+      let(:data) { { course_year: "2015", itt_aim: "202", itt_qualification_aim: "001" } }
+
+      before do
+        trainee.disabilities << create(:disability, :learning_difficulty)
+        create(:hesa_student, hesa_id: trainee.hesa_id, course_age_range: "13918", fund_code: "7", bursary_level: nil)
+        create(:hesa_metadatum, trainee:)
+      end
+
+      it "falls back to Trainees::MapDisabilitiesToHesa for hesa_disabilities" do
+        put(endpoint, params: params.to_json, headers: { Authorization: "Bearer #{token}", **json_headers })
+
+        expect(response).to have_http_status(:ok)
+        expect(trainee.reload.hesa_trainee_detail.hesa_disabilities).to eq("disability1" => "51")
+      end
+    end
   end
 
   context "Updating a newly created trainee" do

--- a/spec/services/api/v2025_0/create_hesa_trainee_detail_service_spec.rb
+++ b/spec/services/api/v2025_0/create_hesa_trainee_detail_service_spec.rb
@@ -190,6 +190,33 @@ RSpec.describe Api::V20250::CreateHesaTraineeDetailService do
           expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13915")
         end
       end
+
+      context "when hesa_disabilities is missing" do
+        let(:trainee) { create(:trainee, :disabled) }
+
+        before { trainee.disabilities << create(:disability, :learning_difficulty) }
+
+        it "derives hesa_disabilities from the trainee's disabilities via Trainees::MapDisabilitiesToHesa" do
+          subject.call(trainee:)
+
+          expect(trainee.reload.hesa_trainee_detail.hesa_disabilities).to eq("disability1" => "51")
+        end
+      end
+
+      context "when a hesa_student has disabilities" do
+        let(:trainee) { create(:trainee, :disabled) }
+
+        before do
+          trainee.disabilities << create(:disability, :learning_difficulty)
+          create(:hesa_student, disability1: "58", trainee: trainee)
+        end
+
+        it "prefers the student record's disabilities over the fallback" do
+          subject.call(trainee:)
+
+          expect(trainee.reload.hesa_trainee_detail.hesa_disabilities).to eq("disability1" => "58")
+        end
+      end
     end
   end
 end

--- a/spec/services/api/v2026_1/create_hesa_trainee_detail_service_spec.rb
+++ b/spec/services/api/v2026_1/create_hesa_trainee_detail_service_spec.rb
@@ -190,6 +190,33 @@ RSpec.describe Api::V20261::CreateHesaTraineeDetailService do
           expect(trainee.reload.hesa_trainee_detail.course_age_range).to eq("13915")
         end
       end
+
+      context "when hesa_disabilities is missing" do
+        let(:trainee) { create(:trainee, :disabled) }
+
+        before { trainee.disabilities << create(:disability, :learning_difficulty) }
+
+        it "derives hesa_disabilities from the trainee's disabilities via Trainees::MapDisabilitiesToHesa" do
+          subject.call(trainee:)
+
+          expect(trainee.reload.hesa_trainee_detail.hesa_disabilities).to eq("disability1" => "51")
+        end
+      end
+
+      context "when a hesa_student has disabilities" do
+        let(:trainee) { create(:trainee, :disabled) }
+
+        before do
+          trainee.disabilities << create(:disability, :learning_difficulty)
+          create(:hesa_student, disability1: "58", trainee: trainee)
+        end
+
+        it "prefers the student record's disabilities over the fallback" do
+          subject.call(trainee:)
+
+          expect(trainee.reload.hesa_trainee_detail.hesa_disabilities).to eq("disability1" => "58")
+        end
+      end
     end
   end
 end

--- a/spec/services/trainees/map_disabilities_to_hesa_spec.rb
+++ b/spec/services/trainees/map_disabilities_to_hesa_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe MapDisabilitiesToHesa do
+    subject(:hesa_disabilities) { described_class.call(trainee:) }
+
+    context "when the trainee is disabled" do
+      let(:trainee) { create(:trainee, :disabled) }
+
+      context "with a single selected disability" do
+        before { trainee.disabilities << create(:disability, :learning_difficulty) }
+
+        it "maps the disability to its HESA code" do
+          expect(hesa_disabilities).to eq("disability1" => "51")
+        end
+      end
+
+      context "with multiple selected disabilities" do
+        before do
+          trainee.disabilities << create(:disability, :learning_difficulty)
+          trainee.disabilities << create(:disability, :blind)
+        end
+
+        it "maps each disability to its HESA code with contiguous keys" do
+          expect(hesa_disabilities.keys).to eq(%w[disability1 disability2])
+          expect(hesa_disabilities.values).to match_array(%w[51 58])
+        end
+      end
+
+      context "with a disability that is not listed" do
+        before { trainee.disabilities << create(:disability, :other) }
+
+        it "maps it to the 'not listed' HESA code" do
+          expect(hesa_disabilities).to eq("disability1" => "96")
+        end
+      end
+
+      context "when the stored codes include a disability that is no longer selected" do
+        before do
+          trainee.disabilities << create(:disability, :blind)
+          trainee.create_hesa_trainee_detail!(hesa_disabilities: { "disability1" => "51", "disability2" => "58" })
+        end
+
+        it "drops the deselected code and renumbers contiguously" do
+          expect(hesa_disabilities).to eq("disability1" => "58")
+        end
+      end
+
+      context "when the stored code already maps to a selected disability" do
+        before do
+          trainee.disabilities << create(:disability, :learning_difficulty)
+          trainee.create_hesa_trainee_detail!(hesa_disabilities: { "disability1" => "51" })
+        end
+
+        it "preserves the existing code" do
+          expect(hesa_disabilities).to eq("disability1" => "51")
+        end
+      end
+    end
+
+    context "when the trainee has no disability" do
+      let(:trainee) do
+        create(:trainee, disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
+      end
+
+      it "returns the 'no known impairment' HESA code" do
+        expect(hesa_disabilities).to eq("disability1" => "95")
+      end
+    end
+
+    context "when the trainee has not provided disability information" do
+      let(:trainee) { create(:trainee, :disability_not_provided) }
+
+      it "returns the 'prefer not to say' HESA code" do
+        expect(hesa_disabilities).to eq("disability1" => "98")
+      end
+
+      context "when the stored value was already 'not available'" do
+        before { trainee.create_hesa_trainee_detail!(hesa_disabilities: { "disability1" => "99" }) }
+
+        it "preserves the 'not available' HESA code" do
+          expect(hesa_disabilities).to eq("disability1" => "99")
+        end
+      end
+    end
+
+    context "when disability disclosure is not set" do
+      let(:trainee) { create(:trainee, disability_disclosure: nil) }
+
+      it "returns an empty hash" do
+        expect(hesa_disabilities).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

[9643-sync-hesadisabilities-in-api-and-ui-on-post-put](https://trello.com/c/uCigRg75/9643-sync-hesadisabilities-in-api-and-ui-on-post-put)

### Changes proposed in this pull request

* Add `Trainees::MapDisabilitiesToHesa`
* Sync `hesa_disabilities` from the disability UI
* Sync `hesa_disabilities` in the API on POST/PUT

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
