### PR TITLE
[9695] - Check for API token expiry

### DIFF
--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -101,4 +101,8 @@ class AuthenticationToken < ApplicationRecord
 
     update!(last_used_at: Time.current)
   end
+
+  def expired_by_date?
+    expires_at <= Date.current
+  end
 end

--- a/app/services/api/validate_authentication_token.rb
+++ b/app/services/api/validate_authentication_token.rb
@@ -9,7 +9,7 @@ module Api
     end
 
     def call
-      auth_token.present? && auth_token.active? && provider&.kept?
+      auth_token.present? && auth_token.active? && !auth_token.expired_by_date? && provider&.kept?
     end
 
   private

--- a/spec/models/authentication_token_spec.rb
+++ b/spec/models/authentication_token_spec.rb
@@ -177,6 +177,34 @@ RSpec.describe AuthenticationToken do
     end
   end
 
+  describe "#expired_by_date?" do
+    subject(:authentication_token) { create(:authentication_token, expires_at:) }
+
+    context "when the expiry date is in the past" do
+      let(:expires_at) { 1.day.ago }
+
+      it "returns true" do
+        expect(subject.expired_by_date?).to be(true)
+      end
+    end
+
+    context "when the expiry date is today" do
+      let(:expires_at) { Date.current }
+
+      it "returns true" do
+        expect(subject.expired_by_date?).to be(true)
+      end
+    end
+
+    context "when the expiry date is in the future" do
+      let(:expires_at) { 1.day.from_now }
+
+      it "returns false" do
+        expect(subject.expired_by_date?).to be(false)
+      end
+    end
+  end
+
   describe ".update_last_used_at!" do
     subject(:authentication_token) { create(:authentication_token, last_used_at:) }
 

--- a/spec/services/api/validate_authentication_token_spec.rb
+++ b/spec/services/api/validate_authentication_token_spec.rb
@@ -12,6 +12,22 @@ describe Api::ValidateAuthenticationToken do
       end
     end
 
+    context "when the auth_token is active but the expiry date is in the past" do
+      let(:auth_token) { create(:authentication_token, expires_at: 1.day.ago) }
+
+      it "returns false" do
+        expect(described_class.call(auth_token:)).to be(false)
+      end
+    end
+
+    context "when the auth_token is active but the expiry date is today" do
+      let(:auth_token) { create(:authentication_token, expires_at: Date.current) }
+
+      it "returns false" do
+        expect(described_class.call(auth_token:)).to be(false)
+      end
+    end
+
     context "when the auth_token is revoked and the provider is present" do
       let(:auth_token) { create(:authentication_token, :revoked) }
 


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/xPfVNgD6/9695-api-token-expiry-bypass-add-check-for-expiresat)

`ValidateAuthenticationToken` checks `auth_token.active?` (an enum/string comparison) but never evaluates `expires_at` against the current date. Token expiry is enforced solely by a nightly Sidekiq cron job, leaving a window of up to 24 hours during which an expired token remains valid. If Sidekiq is down, tokens remain valid indefinitely.

### Changes proposed in this pull request

Validates expires_at against the current date

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
