### PR TITLE
[9652] Allow Provider checkers to run on productiondata

### DIFF
--- a/app/jobs/rotp/check_providers_job.rb
+++ b/app/jobs/rotp/check_providers_job.rb
@@ -7,7 +7,7 @@ module Rotp
     MAX_LISTED = 10
 
     def perform
-      return false unless Rails.env.production?
+      return false unless Rails.env.production? || Rails.env.productiondata?
 
       checker = Rotp::ProviderChecker.new
       download_url = generate_csv_download_url(checker)

--- a/app/jobs/teacher_training_api/check_courses_for_missing_providers_job.rb
+++ b/app/jobs/teacher_training_api/check_courses_for_missing_providers_job.rb
@@ -6,7 +6,7 @@ module TeacherTrainingApi
     retry_on TeacherTrainingApi::Client::HttpError
 
     def perform(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
-      return false unless Rails.env.production?
+      return false unless Rails.env.production? || Rails.env.productiondata?
 
       checker = TeacherTrainingApi::CheckCoursesForMissingProviders.call(
         recruitment_cycle_year:,

--- a/app/jobs/teacher_training_api/publish_provider_checker_job.rb
+++ b/app/jobs/teacher_training_api/publish_provider_checker_job.rb
@@ -8,7 +8,7 @@ module TeacherTrainingApi
     MAX_MISSING_PROVIDERS_TO_DISPLAY = 10
 
     def perform
-      return false unless Rails.env.production?
+      return false unless Rails.env.production? || Rails.env.productiondata?
 
       checker = TeacherTrainingApi::PublishProviderChecker.call(
         recruitment_cycle_year: Settings.current_recruitment_cycle_year,


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/vRmN3Ot6)
### Changes proposed in this pull request

* Allow Provider checkers to run on productiondata so we can check the next academic year

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
