### PR TITLE
[9694] Make sure sessions are reset before and after sign-in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,6 +22,8 @@ class SessionsController < ApplicationController
   end
 
   def signout
+    reset_session
+
     redirect_to(root_path)
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,8 @@ class SessionsController < ApplicationController
   skip_before_action :authenticate
 
   def callback
+    reset_session
+
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
 
     if current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,9 +4,11 @@ class SessionsController < ApplicationController
   skip_before_action :authenticate
 
   def callback
+    requested_path = session[:requested_path]
     reset_session
 
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
+    session[:requested_path] = requested_path.presence
 
     if current_user
       DfESignInUsers::Update.call(user: current_user, sign_in_user: sign_in_user)

--- a/spec/requests/dfe_signin_callback_spec.rb
+++ b/spec/requests/dfe_signin_callback_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DfE Sign-in callback" do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user:)
+  end
+
+  after do
+    OmniAuth.config.mock_auth.clear
+  end
+
+  describe "GET /auth/dfe/callback" do
+    it "resets the session cookie when signing in to prevent session fixation" do
+      get root_path
+
+      original_session_cookie = response.cookies["_register_trainee_teachers_session"]
+
+      get "/auth/dfe/callback"
+
+      authenticated_session_cookie = response.cookies["_register_trainee_teachers_session"]
+
+      expect(authenticated_session_cookie).not_to eq(original_session_cookie)
+      expect(session["dfe_sign_in_user"]).to be_present
+    end
+  end
+end

--- a/spec/requests/dfe_signin_callback_spec.rb
+++ b/spec/requests/dfe_signin_callback_spec.rb
@@ -28,5 +28,17 @@ RSpec.describe "DfE Sign-in callback" do
       expect(authenticated_session_cookie).not_to eq(original_session_cookie)
       expect(session["dfe_sign_in_user"]).to be_present
     end
+
+    it "preserves the requested path when resetting the session during sign in" do
+      requested_path = "/bulk-update/add-details/new"
+
+      get requested_path
+
+      expect(session[:requested_path]).to eq(requested_path)
+
+      get "/auth/dfe/callback"
+
+      expect(response).to redirect_to(requested_path)
+    end
   end
 end

--- a/spec/requests/dfe_signout_spec.rb
+++ b/spec/requests/dfe_signout_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DfE Sign out" do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user:)
+  end
+
+  after do
+    OmniAuth.config.mock_auth.clear
+  end
+
+  describe "GET /auth/dfe/sign-out" do
+    it "destroys the session when signing out" do
+      get "/auth/dfe/callback"
+      signed_in_session_cookie = response.cookies["_register_trainee_teachers_session"]
+
+      expect(session["dfe_sign_in_user"]).to be_present
+
+      get "/auth/dfe/sign-out"
+      signed_out_session_cookie = response.cookies["_register_trainee_teachers_session"]
+
+      expect(signed_out_session_cookie).not_to eq(signed_in_session_cookie)
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/yfEQD4qK)

### Changes proposed in this pull request

* Reset session before authenticated session starts
* Reset session on sign-out

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
