### PR TITLE
[9644] Sync hesa_disabilities on GET in API

### DIFF
--- a/app/serializers/api/v2025_0/trainee_serializer.rb
+++ b/app/serializers/api/v2025_0/trainee_serializer.rb
@@ -112,10 +112,15 @@ module Api
       end
 
       def assign_disabilities(attributes)
-        @trainee.hesa_trainee_detail&.hesa_disabilities&.each do |key, disability|
+        hesa_disabilities.each do |key, disability|
           attributes[key] = disability
         end
         attributes
+      end
+
+      def hesa_disabilities
+        @trainee.hesa_trainee_detail&.hesa_disabilities.presence ||
+          ::Trainees::MapDisabilitiesToHesa.call(trainee: @trainee)
       end
 
       def ethnicity

--- a/app/serializers/api/v2026_1/trainee_serializer.rb
+++ b/app/serializers/api/v2026_1/trainee_serializer.rb
@@ -115,10 +115,15 @@ module Api
       end
 
       def assign_disabilities(attributes)
-        @trainee.hesa_trainee_detail&.hesa_disabilities&.each do |key, disability|
+        hesa_disabilities.each do |key, disability|
           attributes[key] = disability
         end
         attributes
+      end
+
+      def hesa_disabilities
+        @trainee.hesa_trainee_detail&.hesa_disabilities.presence ||
+          ::Trainees::MapDisabilitiesToHesa.call(trainee: @trainee)
       end
 
       def ethnicity

--- a/app/services/api/get_trainees_service.rb
+++ b/app/services/api/get_trainees_service.rb
@@ -19,6 +19,7 @@ module Api
             :employing_school,
             :training_partner,
             :degrees,
+            :disabilities,
             :hesa_trainee_detail,
             :nationalities,
             { placements: :school },

--- a/spec/requests/api/v2025_0/get_trainee_spec.rb
+++ b/spec/requests/api/v2025_0/get_trainee_spec.rb
@@ -150,6 +150,59 @@ describe "`GET /api/v2025.0/trainees/:id` endpoint" do
     end
   end
 
+  context "when the trainee has stored disabilities" do
+    let!(:trainee) do
+      create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilities_disclosed, provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2025.0/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the stored disabilities" do
+      expect(response.parsed_body["disability1"]).to eq(trainee.hesa_trainee_detail.hesa_disabilities["disability1"])
+    end
+  end
+
+  context "when the hesa_trainee_detail has no stored disabilities" do
+    let!(:trainee) do
+      create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilities_disclosed, provider: auth_token.provider).tap do |trainee|
+        trainee.hesa_trainee_detail.update!(hesa_disabilities: {})
+      end
+    end
+
+    before do
+      get(
+        "/api/v2025.0/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the disabilities mapped from the trainee's disabilities" do
+      expect(response.parsed_body["disability1"]).to eq("55")
+    end
+  end
+
+  context "when the trainee has no hesa_trainee_detail and has disabilities" do
+    let!(:trainee) do
+      create(:trainee, :disabled_with_disabilities_disclosed, provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2025.0/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the disabilities mapped from the trainee's disabilities" do
+      expect(response.parsed_body["disability1"]).to eq("55")
+    end
+  end
+
   context "when the trainee does not exist" do
     before do
       get(

--- a/spec/requests/api/v2025_0/get_trainees_spec.rb
+++ b/spec/requests/api/v2025_0/get_trainees_spec.rb
@@ -92,6 +92,38 @@ describe "`GET /trainees` endpoint" do
     end
   end
 
+  context "when trainees are missing disabilities" do
+    let!(:disability) { create(:disability, :mental_health_condition) }
+
+    let!(:trainee_without_stored_disabilities) do
+      create(:trainee, :with_hesa_trainee_detail, :disabled, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.disabilities << disability
+        trainee.hesa_trainee_detail.update!(hesa_disabilities: {})
+      end
+    end
+
+    let!(:trainee_without_hesa_trainee_detail) do
+      create(:trainee, :disabled, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.disabilities << disability
+      end
+    end
+
+    before do
+      get(
+        "/api/v2025.0/trainees",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the disabilities mapped from the trainee's disabilities" do
+      [trainee_without_stored_disabilities, trainee_without_hesa_trainee_detail].each do |trainee|
+        serialized_trainee = response.parsed_body["data"].find { |data| data["trainee_id"] == trainee.slug }
+
+        expect(serialized_trainee["disability1"]).to eq("55")
+      end
+    end
+  end
+
   context "filtering out draft trainees" do
     let!(:draft_trainee) { create(:trainee, :draft, :with_hesa_trainee_detail) }
 

--- a/spec/requests/api/v2026_1/get_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/get_trainee_spec.rb
@@ -150,6 +150,59 @@ describe "`GET /api/v2026.1/trainees/:id` endpoint" do
     end
   end
 
+  context "when the trainee has stored disabilities" do
+    let!(:trainee) do
+      create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilities_disclosed, slug: "12345", provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2026.1/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the stored disabilities" do
+      expect(response.parsed_body["disability1"]).to eq(trainee.hesa_trainee_detail.hesa_disabilities["disability1"])
+    end
+  end
+
+  context "when the hesa_trainee_detail has no stored disabilities" do
+    let!(:trainee) do
+      create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilities_disclosed, slug: "12345", provider: auth_token.provider).tap do |trainee|
+        trainee.hesa_trainee_detail.update!(hesa_disabilities: {})
+      end
+    end
+
+    before do
+      get(
+        "/api/v2026.1/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the disabilities mapped from the trainee's disabilities" do
+      expect(response.parsed_body["disability1"]).to eq("55")
+    end
+  end
+
+  context "when the trainee has no hesa_trainee_detail and has disabilities" do
+    let!(:trainee) do
+      create(:trainee, :disabled_with_disabilities_disclosed, slug: "12345", provider: auth_token.provider)
+    end
+
+    before do
+      get(
+        "/api/v2026.1/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the disabilities mapped from the trainee's disabilities" do
+      expect(response.parsed_body["disability1"]).to eq("55")
+    end
+  end
+
   context "when the trainee does not exist" do
     before do
       get(

--- a/spec/requests/api/v2026_1/get_trainees_spec.rb
+++ b/spec/requests/api/v2026_1/get_trainees_spec.rb
@@ -92,6 +92,38 @@ describe "`GET /trainees` endpoint" do
     end
   end
 
+  context "when trainees are missing disabilities" do
+    let!(:disability) { create(:disability, :mental_health_condition) }
+
+    let!(:trainee_without_stored_disabilities) do
+      create(:trainee, :with_hesa_trainee_detail, :disabled, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.disabilities << disability
+        trainee.hesa_trainee_detail.update!(hesa_disabilities: {})
+      end
+    end
+
+    let!(:trainee_without_hesa_trainee_detail) do
+      create(:trainee, :disabled, :trn_received, provider: auth_token.provider, start_academic_cycle: start_academic_cycle).tap do |trainee|
+        trainee.disabilities << disability
+      end
+    end
+
+    before do
+      get(
+        "/api/v2026.1/trainees",
+        headers: { Authorization: "Bearer #{token}" },
+      )
+    end
+
+    it "returns the disabilities mapped from the trainee's disabilities" do
+      [trainee_without_stored_disabilities, trainee_without_hesa_trainee_detail].each do |trainee|
+        serialized_trainee = response.parsed_body["data"].find { |data| data["trainee_id"] == trainee.slug }
+
+        expect(serialized_trainee["disability1"]).to eq("55")
+      end
+    end
+  end
+
   context "filtering out draft trainees" do
     let!(:draft_trainee) { create(:trainee, :draft, :with_hesa_trainee_detail) }
 

--- a/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2025_0/trainee_serializer_spec.rb
@@ -218,6 +218,34 @@ RSpec.describe Api::V20250::TraineeSerializer do
       end
     end
 
+    describe "disabilities" do
+      context "when the hesa_trainee_detail has stored disabilities" do
+        it "serializes the stored disabilities" do
+          expect(json["disability1"]).to eq(trainee.hesa_trainee_detail.hesa_disabilities["disability1"])
+        end
+      end
+
+      context "when the hesa_trainee_detail has no stored disabilities" do
+        let(:trainee) do
+          create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilities_disclosed).tap do |trainee|
+            trainee.hesa_trainee_detail.update!(hesa_disabilities: {})
+          end
+        end
+
+        it "serializes the disabilities mapped from the trainee's disabilities" do
+          expect(json["disability1"]).to eq("55")
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, :disabled_with_disabilities_disclosed) }
+
+        it "serializes the disabilities mapped from the trainee's disabilities" do
+          expect(json["disability1"]).to eq("55")
+        end
+      end
+    end
+
     describe "nationality" do
       it "serializes nationality to HESA code" do
         expect(json[:nationality]).to eq("FR")

--- a/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
@@ -219,6 +219,34 @@ RSpec.describe Api::V20261::TraineeSerializer do
       end
     end
 
+    describe "disabilities" do
+      context "when the hesa_trainee_detail has stored disabilities" do
+        it "serializes the stored disabilities" do
+          expect(json["disability1"]).to eq(trainee.hesa_trainee_detail.hesa_disabilities["disability1"])
+        end
+      end
+
+      context "when the hesa_trainee_detail has no stored disabilities" do
+        let(:trainee) do
+          create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilities_disclosed).tap do |trainee|
+            trainee.hesa_trainee_detail.update!(hesa_disabilities: {})
+          end
+        end
+
+        it "serializes the disabilities mapped from the trainee's disabilities" do
+          expect(json["disability1"]).to eq("55")
+        end
+      end
+
+      context "when the trainee has no hesa_trainee_detail" do
+        let(:trainee) { create(:trainee, :disabled_with_disabilities_disclosed) }
+
+        it "serializes the disabilities mapped from the trainee's disabilities" do
+          expect(json["disability1"]).to eq("55")
+        end
+      end
+    end
+
     describe "nationality" do
       it "serializes nationality to HESA code" do
         expect(json[:nationality]).to eq("FR")


### PR DESCRIPTION
### Context

[9644-sync-disabilities-in-api-on-get
](https://trello.com/c/f0q1NT4S/9644-sync-disabilities-in-api-on-get)

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
