### PR TITLE
[9698] Withdrawal workflow step-skip - investigate validation

### DIFF
--- a/app/forms/withdrawal/reason_form.rb
+++ b/app/forms/withdrawal/reason_form.rb
@@ -3,6 +3,7 @@
 module Withdrawal
   class ReasonForm < TraineeForm
     validate :reasons_present?
+    validate :reasons_valid_for_trigger?
     validates :another_reason, presence: true, if: :another_reason_id_provided?
     validates :safeguarding_concern_reasons, presence: true, if: :safeguarding_concern?
 
@@ -17,15 +18,8 @@ module Withdrawal
     end
 
     def reasons
-      if provider_triggered?
-        WithdrawalReason.where(name: WithdrawalReasons::PROVIDER_REASONS).sort_by do |reason|
-          WithdrawalReasons::PROVIDER_REASONS.index(reason.name)
-        end
-      else
-        WithdrawalReason.where(name: WithdrawalReasons::TRAINEE_REASONS).sort_by do |reason|
-          WithdrawalReasons::TRAINEE_REASONS.index(reason.name)
-        end
-      end
+      names = WithdrawalReasons.for_trigger(trigger)
+      WithdrawalReason.where(name: names).sort_by { |reason| names.index(reason.name) }
     end
 
     def save!
@@ -46,10 +40,6 @@ module Withdrawal
     end
 
   private
-
-    def provider_triggered?
-      trigger_form.trigger == "provider"
-    end
 
     def trigger_form
       @trigger_form ||= TriggerForm.new(trainee)
@@ -78,6 +68,12 @@ module Withdrawal
       error = I18n.t("activemodel.errors.models.withdrawal/reason_form.attributes.reason_ids.#{trigger_form.trigger}.blank").html_safe
 
       errors.add(:reason_ids, error)
+    end
+
+    def reasons_valid_for_trigger?
+      return true if reason_ids.empty? || (reason_ids - reasons.map(&:id)).empty?
+
+      errors.add(:reason_ids, :invalid)
     end
 
     def another_reason_id_provided?

--- a/app/models/api/v2025_0/withdrawal_attributes.rb
+++ b/app/models/api/v2025_0/withdrawal_attributes.rb
@@ -83,9 +83,7 @@ module Api
       end
 
       def valid_reasons
-        return WithdrawalReasons::PROVIDER_REASONS if trigger == "provider"
-
-        WithdrawalReasons::TRAINEE_REASONS
+        WithdrawalReasons.for_trigger(trigger)
       end
 
       def withdrawal_reasons

--- a/app/models/api/v2026_1/withdrawal_attributes.rb
+++ b/app/models/api/v2026_1/withdrawal_attributes.rb
@@ -83,9 +83,7 @@ module Api
       end
 
       def valid_reasons
-        return WithdrawalReasons::PROVIDER_REASONS if trigger == "provider"
-
-        WithdrawalReasons::TRAINEE_REASONS
+        WithdrawalReasons.for_trigger(trigger)
       end
 
       def withdrawal_reasons

--- a/config/initializers/withdrawal_reasons.rb
+++ b/config/initializers/withdrawal_reasons.rb
@@ -121,4 +121,10 @@ module WithdrawalReasons
   ].freeze
 
   SEED = (LEGACY_REASONS + LEGACY_2023_REASONS + REASONS).map { |name| { name: } }.freeze
+
+  def self.for_trigger(trigger)
+    return PROVIDER_REASONS if trigger == "provider"
+
+    TRAINEE_REASONS
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1802,6 +1802,7 @@ en:
         withdrawal/reason_form:
           attributes:
             reason_ids:
+              invalid: Select a reason from the list
               trainee:
                 blank: Select why the trainee chose to withdraw
               provider:

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -45,6 +45,15 @@ feature "Withdrawing a trainee" do
       and_i_continue(:future_interest)
       then_i_see_the_error_message_for_future_interest_not_chosen
     end
+
+    scenario "reasons that do not match the trigger" do
+      given_a_trainee_only_withdrawal_reason_exists
+      and_i_have_completed_the_withdrawal_steps_choosing_the_provider_trigger
+      when_i_submit_a_reason_that_does_not_match_the_trigger
+      then_i_see_the_error_message_for_invalid_reasons
+      when_i_submit_the_confirmation_page_directly
+      then_the_trainee_is_not_withdrawn
+    end
   end
 
   context "trainee withdrawn" do
@@ -416,6 +425,44 @@ feature "Withdrawing a trainee" do
       trainee_start_date: 10.days.ago,
       itt_end_date: 1.year.from_now,
     )
+  end
+
+  def given_a_trainee_only_withdrawal_reason_exists
+    @trainee_only_reason = create(:withdrawal_reason, name: WithdrawalReasons::DOES_NOT_WANT_TO_BECOME_A_TEACHER)
+  end
+
+  def and_i_have_completed_the_withdrawal_steps_choosing_the_provider_trigger
+    when_i_am_on_the_date_page
+    when_i_choose_today
+    and_i_continue(:date)
+    when_i_am_on_the_trigger_page
+    when_i_choose(:trigger, "We chose to withdraw the trainee")
+    and_i_continue(:trigger)
+    when_i_am_on_the_future_interest_page
+    when_i_choose_future_interest
+    and_i_continue(:future_interest)
+  end
+
+  def when_i_submit_a_reason_that_does_not_match_the_trigger
+    page.driver.submit(
+      :put,
+      "/trainees/#{trainee.slug}/withdrawal/reason",
+      { withdrawal_reason_form: { reason_ids: [@trainee_only_reason.id.to_s] } },
+    )
+  end
+
+  def then_i_see_the_error_message_for_invalid_reasons
+    expect(page).to have_text(I18n.t("activemodel.errors.models.withdrawal/reason_form.attributes.reason_ids.invalid"))
+  end
+
+  def when_i_submit_the_confirmation_page_directly
+    page.driver.submit(:put, "/trainees/#{trainee.slug}/withdrawal/confirm", {})
+  end
+
+  def then_the_trainee_is_not_withdrawn
+    trainee.reload
+    expect(trainee).not_to be_withdrawn
+    expect(trainee.trainee_withdrawals).to be_empty
   end
 
   def given_a_trainee_exists_to_be_withdrawn_with_no_start_date

--- a/spec/forms/withdrawal/reason_form_spec.rb
+++ b/spec/forms/withdrawal/reason_form_spec.rb
@@ -43,6 +43,64 @@ module Withdrawal
         end
       end
 
+      context "when the trigger is provider" do
+        let(:trigger) { "provider" }
+
+        context "with a reason from the trainee-only list" do
+          let(:reason_id) { WithdrawalReason.where(name: WithdrawalReasons::DOES_NOT_WANT_TO_BECOME_A_TEACHER).first.id }
+          let(:params) { { reason_ids: [reason_id] } }
+
+          it "provides the correct error message" do
+            subject.validate
+
+            expect(subject.errors[:reason_ids]).to include(I18n.t("activemodel.errors.models.withdrawal/reason_form.attributes.reason_ids.invalid"))
+          end
+        end
+
+        context "with a reason from the provider list" do
+          let(:reason_id) { WithdrawalReason.where(name: WithdrawalReasons::PROVIDER_REASONS.first).first.id }
+          let(:params) { { reason_ids: [reason_id] } }
+
+          it "is valid" do
+            expect(subject).to be_valid
+          end
+        end
+
+        context "with a reason id that does not exist" do
+          let(:params) { { reason_ids: [-1] } }
+
+          it "provides the correct error message" do
+            subject.validate
+
+            expect(subject.errors[:reason_ids]).to include(I18n.t("activemodel.errors.models.withdrawal/reason_form.attributes.reason_ids.invalid"))
+          end
+        end
+      end
+
+      context "when the trigger is trainee" do
+        let(:trigger) { "trainee" }
+
+        context "with a reason from the provider-only list" do
+          let(:reason_id) { WithdrawalReason.where(name: WithdrawalReasons::RECORD_ADDED_IN_ERROR).first.id }
+          let(:params) { { reason_ids: [reason_id] } }
+
+          it "provides the correct error message" do
+            subject.validate
+
+            expect(subject.errors[:reason_ids]).to include(I18n.t("activemodel.errors.models.withdrawal/reason_form.attributes.reason_ids.invalid"))
+          end
+        end
+
+        context "with a reason from the trainee list" do
+          let(:reason_id) { WithdrawalReason.where(name: WithdrawalReasons::TRAINEE_REASONS.first).first.id }
+          let(:params) { { reason_ids: [reason_id] } }
+
+          it "is valid" do
+            expect(subject).to be_valid
+          end
+        end
+      end
+
       context "when another reason has been chosen" do
         let(:trigger) { "trainee" }
         let(:another_reason_id) { WithdrawalReason.where(name: "trainee_chose_to_withdraw_another_reason").first.id }
@@ -77,20 +135,25 @@ module Withdrawal
     end
 
     describe "#stash" do
+      let(:reason_ids) { WithdrawalReason.where(name: WithdrawalReasons::TRAINEE_REASONS.first(2)).ids }
+      let(:params) { { reason_ids: } }
+
       it "uses FormStore to temporarily save the fields under a key combination of trainee withdrawal ID and future interest" do
-        expect(form_store).to receive(:set).with(trainee.id, :withdrawal_reasons, { reason_ids: [1, 2], another_reason: nil })
+        expect(form_store).to receive(:set).with(trainee.id, :withdrawal_reasons, { reason_ids: reason_ids, another_reason: nil })
 
         subject.stash
       end
     end
 
     describe "#reasons" do
+      let(:trigger_form) { instance_double(Withdrawal::TriggerForm, trigger:) }
+
       before do
-        allow(subject).to receive(:provider_triggered?).and_return(provider_triggered)
+        allow(Withdrawal::TriggerForm).to receive(:new).and_return(trigger_form)
       end
 
       context "when the trigger is provider" do
-        let(:provider_triggered) { true }
+        let(:trigger) { "provider" }
 
         it "returns provider triggered withdrawal reasons in order" do
           expect(subject.reasons.pluck(:name)).to match_array(WithdrawalReasons::PROVIDER_REASONS)
@@ -98,9 +161,9 @@ module Withdrawal
       end
 
       context "when the trigger is trainee" do
-        let(:provider_triggered) { false }
+        let(:trigger) { "trainee" }
 
-        it "returns provider triggered withdrawal reasons in order" do
+        it "returns trainee triggered withdrawal reasons in order" do
           expect(subject.reasons.pluck(:name)).to match_array(WithdrawalReasons::TRAINEE_REASONS)
         end
       end


### PR DESCRIPTION
### Context

[9698-withdrawal-workflow-step-skip-investigate-validation](https://trello.com/c/2deGc7Zx/9698-withdrawal-workflow-step-skip-investigate-validation)

### Changes proposed in this pull request

* Mirrors the rule the API already enforces in `WithdrawalAttributes`
* Reasons must belong to the list for whoever triggered the withdrawal. 
* Extracts the shared mapping into `WithdrawalReasons::for_trigger`.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
