### PR TITLE
[9712] - publish to production FauAPI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -215,13 +215,23 @@ jobs:
         basic-auth-username: ${{ secrets.BASIC_AUTH_USERNAME }}
         basic-auth-password: ${{ secrets.BASIC_AUTH_PASSWORD }}
 
-  update-fauapi-catalogue:
+  update-fauapi-catalogue-preprod:
     name: Update FauAPI catalogue (pre-prod)
     if: ${{ success() && github.ref == 'refs/heads/main' }}
     needs: [deploy-production]
     uses: ./.github/workflows/update-fauapi-catalogue.yml
     secrets:
       fauapi_token: ${{ secrets.FAUAPI_PP_AUTOMATION_TOKEN }}
+
+  update-fauapi-catalogue-production:
+    name: Update FauAPI catalogue (production)
+    if: ${{ success() && github.ref == 'refs/heads/main' }}
+    needs: [deploy-production]
+    uses: ./.github/workflows/update-fauapi-catalogue.yml
+    with:
+      fauapi_url: https://apimanagement.education.gov.uk
+    secrets:
+      fauapi_token: ${{ secrets.FAUAPI_AUTOMATION_TOKEN }}
 
   deploy-after-production:
     name: Parallel deployment after production

--- a/.github/workflows/update-fauapi-catalogue.yml
+++ b/.github/workflows/update-fauapi-catalogue.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   update-fauapi-catalogue:
-    name: Update FauAPI catalogue (pre-prod)
+    name: Update FauAPI catalogue
     runs-on: ubuntu-latest
     env:
       FAUAPI_URL: ${{ inputs.fauapi_url || github.event.inputs.fauapi_url }}
@@ -86,4 +86,4 @@ jobs:
           exit 1
         fi
 
-        echo "Published API $API_ID to FauAPI catalogue (pre-prod)"
+        echo "Published API $API_ID to FauAPI catalogue ($FAUAPI_URL)"

--- a/bin/test_fauapi_publish
+++ b/bin/test_fauapi_publish
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FAUAPI_URL="https://pp-apimanagement.education.gov.uk"
+FAUAPI_URL="${FAUAPI_URL:-https://pp-apimanagement.education.gov.uk}"
 FAUAPI_API_NAME="register-trainee-teachers-api"
 FAUAPI_TOKEN="${1:-}"
 
 if [ -z "$FAUAPI_TOKEN" ]; then
   echo "usage: bin/test_fauapi_publish <fauapi_token>"
+  echo "       FAUAPI_URL=https://apimanagement.education.gov.uk bin/test_fauapi_publish <fauapi_token>"
   exit 1
 fi
 
@@ -53,4 +54,4 @@ if [[ "$PUBLISH_HTTP_CODE" != 2* ]]; then
   exit 1
 fi
 
-echo "Published API $API_ID to FauAPI catalogue (pre-prod)"
+echo "Published API $API_ID to FauAPI catalogue ($FAUAPI_URL)"

--- a/docs/fauapi.md
+++ b/docs/fauapi.md
@@ -2,13 +2,13 @@
 
 [Find and Use an API](https://find-and-use-an-api.education.gov.uk/) (fauapi) is DfE's central API catalogue. We publish the Register API spec there so it shows up in the directory.
 
-## Current status: pre-prod only
+## Current status
 
-We're currently only publishing to FauAPI **pre-prod**. The OpenAPI spec is attached via `schema.documentContentValue` (base64-encoded YAML). Once we've verified this works in pre-prod, we'll switch the workflow to target production.
+We publish to both FauAPI **pre-prod** and **production** on every deploy to production. The OpenAPI spec is attached via `schema.documentContentValue` (base64-encoded YAML).
 
 ## How it works
 
-On every deploy to production, a GitHub Actions job (`update-fauapi-catalogue` in `build-and-deploy.yml`) runs `bin/generate_fauapi_manifest` to build the manifest JSON from `config/settings.yml` and the openapi yaml files in `public/openapi/`, then POSTs it to the fauapi platform API and publishes it. The current API version's OpenAPI spec is embedded in the import payload as base64-encoded YAML in `schema.documentContentValue`. Import is idempotent by `name` — repeat imports update rather than duplicate.
+On every deploy to production, GitHub Actions jobs in `build-and-deploy.yml` call `update-fauapi-catalogue.yml` twice (pre-prod and production). Each run runs `bin/generate_fauapi_manifest` to build the manifest JSON from `config/settings.yml` and the openapi yaml files in `public/openapi/`, then POSTs it to the fauapi platform API and publishes it. The current API version's OpenAPI spec is embedded in the import payload as base64-encoded YAML in `schema.documentContentValue`. Import is idempotent by `name` — repeat imports update rather than duplicate.
 
 The manifest is generated fresh in CI on every deploy — nothing to keep in sync manually. You can run the script locally to inspect the output:
 
@@ -18,13 +18,18 @@ ruby bin/generate_fauapi_manifest
 
 ## Setup that was done
 
-Pre-prod required manual one-time setup in the fauapi management portal. The workspace already exists — to get access, ask an existing dev on the team to add you.
+Pre-prod and production each needed a one-time workspace in the fauapi management portal. Workspaces already exist — to get access, ask an existing dev on the team to add you.
 
-The linked API was created via import with `name: "register-trainee-teachers-api"`, `displayName: "Register trainee teachers API"`. Note: `displayName` is globally unique across all fauapi workspaces. The CI workflow keeps it updated on each deploy.
+The linked API is created via import with `name: "register-trainee-teachers-api"`, `displayName: "Register trainee teachers API"` (no need to create the API by hand in an empty workspace). Note: `displayName` is globally unique across all fauapi workspaces. The CI workflow keeps it updated on each deploy.
 
-A `FAUAPI_PP_AUTOMATION_TOKEN` [secret](https://github.com/DFE-Digital/register-trainee-teachers/settings/secrets/actions) is needed in GitHub Actions — this is a bearer token from the fauapi pre-prod management portal.
+GitHub Actions [secrets](https://github.com/DFE-Digital/register-trainee-teachers/settings/secrets/actions) needed:
 
-Production workspace setup hasn't been done yet. Once base64 schema upload is verified in pre-prod, create the workspace + API at [apimanagement.education.gov.uk](https://apimanagement.education.gov.uk), generate a `FAUAPI_AUTOMATION_TOKEN` secret, and update the workflow to target the production URL.
+| Secret | Environment |
+|---|---|
+| `FAUAPI_PP_AUTOMATION_TOKEN` | Pre-prod bearer token from [pp-apimanagement.education.gov.uk](https://pp-apimanagement.education.gov.uk) |
+| `FAUAPI_AUTOMATION_TOKEN` | Production bearer token from [apimanagement.education.gov.uk](https://apimanagement.education.gov.uk) (workspace 51) |
+
+These are GitHub Actions secrets only — not stored in Azure Key Vault.
 
 ## Links
 


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/dSbEmuUr/9712-publish-the-register-api-to-fauapi-production-env)

Following on from https://trello.com/c/0iDShvJm/1335-update-fauapi-api-request-so-data-is-encoded we now want to publish the Register API to the FaUAPI production service.

### Changes proposed in this pull request

* Modifies the existing workflow to accept url and api key ars
* deploys to both pre-prod and prodction
* `bin/test_fauapi_publish` has also been updated to take args for url and api key

### Guidance to review

sanity check the code, but this will require a merge to properly test e2e

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
