### PR TITLE
[9682] - Add documentation for GET reference data endpoint

### DIFF
--- a/app/lib/api/reference_data/withdrawal_reasons.rb
+++ b/app/lib/api/reference_data/withdrawal_reasons.rb
@@ -31,7 +31,7 @@ module Api
 
       def self.entry_for(slug, trigger)
         {
-          slug: slug,
+          code: slug,
           display_name: I18n.t("components.withdrawal_details.reasons.#{slug}"),
           trigger: trigger,
           requires_another_reason: slug.include?("another_reason"),

--- a/app/lib/hesa/reference_data/v2026_1.rb
+++ b/app/lib/hesa/reference_data/v2026_1.rb
@@ -65,8 +65,17 @@ module Hesa
       end
 
       def self.api_payload(field: nil)
-        payload = docs_payload.merge(withdrawal_reasons: withdrawal_reasons_payload)
+        payload = docs_payload
+          .transform_values { |data| public_field_payload(data) }
+          .merge(withdrawal_reasons: withdrawal_reasons_payload)
         field.present? ? payload.fetch(field.to_sym) : payload
+      end
+
+      def self.public_field_payload(data)
+        {
+          metadata: data[:metadata].except("source", "change_log"),
+          entries: data[:entries].map { |e| e.transform_keys(hesa_code: :code) },
+        }
       end
     end
   end

--- a/public/openapi/v2026.1.yaml
+++ b/public/openapi/v2026.1.yaml
@@ -45,6 +45,117 @@ paths:
                 version:
                   requested: v2026.1
                   latest: v2025.0
+  "/api/{api_version}/reference-data":
+    get:
+      summary: show
+      tags:
+      - Api::ReferenceDatum
+      parameters:
+      - name: api_version
+        in: path
+        required: true
+        schema:
+          type: string
+        example: v2026.1
+      - name: field
+        in: query
+        required: false
+        schema:
+          type: string
+        example: sex
+      responses:
+        '200':
+          description: returns the unwrapped field payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      display_name:
+                        type: string
+                      description:
+                        type: string
+                    required:
+                    - name
+                    - display_name
+                    - description
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        code:
+                          type: string
+                        display_name:
+                          type: string
+                        start_year:
+                          type: 'null'
+                        end_year:
+                          type: 'null'
+                      required:
+                      - code
+                      - display_name
+                      - start_year
+                      - end_year
+                required:
+                - metadata
+                - entries
+              example:
+                metadata:
+                  name: sex
+                  display_name: Sex
+                  description: ''
+                entries:
+                - code: '10'
+                  display_name: Female
+                  start_year:
+                  end_year:
+                - code: '11'
+                  display_name: Male
+                  start_year:
+                  end_year:
+                - code: '12'
+                  display_name: Other
+                  start_year:
+                  end_year:
+                - code: '96'
+                  display_name: Information refused
+                  start_year:
+                  end_year:
+                - code: '99'
+                  display_name: Not available
+                  start_year:
+                  end_year:
+        '404':
+          description: unknown field
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        error:
+                          type: string
+                        message:
+                          type: string
+                      required:
+                      - error
+                      - message
+                required:
+                - errors
+              example:
+                errors:
+                - error: NotFound
+                  message: Reference data field 'bogus' not found
   "/api/{api_version}/trainees":
     get:
       summary: index

--- a/spec/lib/api/reference_data/withdrawal_reasons_spec.rb
+++ b/spec/lib/api/reference_data/withdrawal_reasons_spec.rb
@@ -19,26 +19,26 @@ RSpec.describe Api::ReferenceData::WithdrawalReasons do
     end
 
     it "includes all provider and trainee reasons" do
-      slugs_by_trigger = payload.fetch(:entries).group_by { |entry| entry.fetch(:trigger) }
+      codes_by_trigger = payload.fetch(:entries).group_by { |entry| entry.fetch(:trigger) }
 
-      expect(slugs_by_trigger.fetch("provider").pluck(:slug)).to eq(WithdrawalReasons::PROVIDER_REASONS)
-      expect(slugs_by_trigger.fetch("trainee").pluck(:slug)).to eq(WithdrawalReasons::TRAINEE_REASONS)
+      expect(codes_by_trigger.fetch("provider").pluck(:code)).to eq(WithdrawalReasons::PROVIDER_REASONS)
+      expect(codes_by_trigger.fetch("trainee").pluck(:code)).to eq(WithdrawalReasons::TRAINEE_REASONS)
     end
 
-    it "marks another-reason slugs as requiring another_reason" do
-      another_reason_entries = payload.fetch(:entries).select { |entry| entry.fetch(:slug).include?("another_reason") }
+    it "marks another-reason codes as requiring another_reason" do
+      another_reason_entries = payload.fetch(:entries).select { |entry| entry.fetch(:code).include?("another_reason") }
 
       expect(another_reason_entries).to all(include(requires_another_reason: true))
     end
 
     it "marks safeguarding concerns as requiring safeguarding_concern_reasons" do
-      safeguarding_entries = payload.fetch(:entries).select { |entry| entry.fetch(:slug) == "safeguarding_concerns" }
+      safeguarding_entries = payload.fetch(:entries).select { |entry| entry.fetch(:code) == "safeguarding_concerns" }
 
       expect(safeguarding_entries).to all(include(requires_safeguarding_concern_reasons: true))
     end
 
     it "uses locale labels for display names" do
-      entry = payload.fetch(:entries).find { |e| e.fetch(:slug) == "record_added_in_error" }
+      entry = payload.fetch(:entries).find { |e| e.fetch(:code) == "record_added_in_error" }
 
       expect(entry.fetch(:display_name)).to eq(
         I18n.t("components.withdrawal_details.reasons.record_added_in_error"),

--- a/spec/lib/hesa/reference_data/v20261_spec.rb
+++ b/spec/lib/hesa/reference_data/v20261_spec.rb
@@ -76,10 +76,21 @@ RSpec.describe Hesa::ReferenceData::V20261 do
       expect(payload.keys).to match_array(described_class.available_fields)
     end
 
-    it "matches docs_payload for HESA fields" do
-      described_class::TYPES.each_key do |type_name|
-        expect(payload.fetch(type_name)).to eq(described_class.docs_payload.fetch(type_name))
-      end
+    it "exposes public metadata without source or change_log" do
+      metadata = payload.fetch(:disability).fetch(:metadata)
+
+      expect(metadata).to include(
+        "name" => "disability",
+        "display_name" => "Disability",
+      )
+      expect(metadata).not_to have_key("source")
+      expect(metadata).not_to have_key("change_log")
+    end
+
+    it "renames hesa_code to code on entries" do
+      first_entry = payload.fetch(:disability).fetch(:entries).first
+
+      expect(first_entry.keys).to contain_exactly(:code, :display_name, :start_year, :end_year)
     end
 
     it "includes withdrawal reasons" do

--- a/spec/requests/api/v2026_1/get_reference_data_spec.rb
+++ b/spec/requests/api/v2026_1/get_reference_data_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe "`GET /reference-data` endpoint" do
   it_behaves_like "a reference data endpoint", "v2026.1"
 
-  context "using version v2025.0" do
+  context "using version v2025.0", openapi: false do
     before do
       get "/api/v2025.0/reference-data"
     end
@@ -18,7 +18,7 @@ describe "`GET /reference-data` endpoint" do
     end
   end
 
-  context "using version v2026.1" do
+  context "using version v2026.1", openapi: false do
     before do
       get "/api/v2026.1/reference-data"
     end
@@ -27,9 +27,9 @@ describe "`GET /reference-data` endpoint" do
       expect(response.parsed_body.keys).to include("course_subject", "degree_type", "disability")
     end
 
-    it "matches docs_payload for a sample field" do
+    it "matches api_payload for a sample field" do
       expect(response.parsed_body.fetch("sex")).to eq(
-        Hesa::ReferenceData::V20261.docs_payload.fetch(:sex).deep_stringify_keys,
+        Hesa::ReferenceData::V20261.api_payload(field: :sex).deep_stringify_keys,
       )
     end
   end

--- a/spec/support/shared_examples/reference_data_endpoint.rb
+++ b/spec/support/shared_examples/reference_data_endpoint.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples "a reference data endpoint" do |version|
   end
 
   describe "GET /api/#{version}/reference-data" do
-    context "without authentication" do
+    context "without authentication", openapi: false do
       before do
         get "/api/#{version}/reference-data"
       end
@@ -16,7 +16,7 @@ RSpec.shared_examples "a reference data endpoint" do |version|
       end
     end
 
-    context "when the register_api feature flag is off", feature_register_api: false do
+    context "when the register_api feature flag is off", feature_register_api: false, openapi: false do
       before do
         get "/api/#{version}/reference-data"
       end
@@ -26,7 +26,7 @@ RSpec.shared_examples "a reference data endpoint" do |version|
       end
     end
 
-    context "without a field parameter" do
+    context "without a field parameter", openapi: false do
       before do
         get "/api/#{version}/reference-data"
       end
@@ -52,19 +52,19 @@ RSpec.shared_examples "a reference data endpoint" do |version|
 
         expect(entries).to include(
           hash_including(
-            "slug" => "record_added_in_error",
+            "code" => "record_added_in_error",
             "trigger" => "provider",
             "requires_another_reason" => false,
             "requires_safeguarding_concern_reasons" => false,
           ),
           hash_including(
-            "slug" => "trainee_chose_to_withdraw_another_reason",
+            "code" => "trainee_chose_to_withdraw_another_reason",
             "trigger" => "trainee",
             "requires_another_reason" => true,
             "requires_safeguarding_concern_reasons" => false,
           ),
           hash_including(
-            "slug" => "safeguarding_concerns",
+            "code" => "safeguarding_concerns",
             "trigger" => "provider",
             "requires_another_reason" => false,
             "requires_safeguarding_concern_reasons" => true,
@@ -75,15 +75,15 @@ RSpec.shared_examples "a reference data endpoint" do |version|
 
     context "with a valid field parameter" do
       before do
-        get "/api/#{version}/reference-data", params: { field: field_name }
+        get "/api/#{version}/reference-data", params: { field: "sex" }
       end
-
-      let(:field_name) { reference_data_klass.available_fields.first }
 
       it "returns the unwrapped field payload" do
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include("metadata", "entries")
-        expect(response.parsed_body.fetch("metadata")).to include("name" => field_name.to_s)
+        expect(response.parsed_body.fetch("metadata")).to include("name" => "sex")
+        expect(response.parsed_body.fetch("metadata")).not_to have_key("source")
+        expect(response.parsed_body.fetch("metadata")).not_to have_key("change_log")
       end
     end
 

--- a/tech_docs/source/api-docs/release-notes.html.md
+++ b/tech_docs/source/api-docs/release-notes.html.md
@@ -9,6 +9,7 @@ weight: 2
 
 ### Changes
 
+* Added [`GET /reference-data`](/api-docs/v2026.1/endpoints/get-reference-data.html) — returns HESA reference data and withdrawal reasons. Optional `field` query parameter returns a single field.
 * Renamed `POST /trainees/{trainee_id}/recommend-for-qts` to `POST /trainees/{trainee_id}/update-qts-or-eyts-status`. [The old URL](/api-docs/v2026.1/endpoints/post-trainees-trainee-id-recommend-for-qts.html) is still supported but deprecated. Move to [the new URL](/api-docs/v2026.1/endpoints/post-trainees-trainee-id-update-qts-or-eyts-status.html) before the 2027 academic year.
 * Added support for the iQTS training route ([HESA code `15`](/reference-data/v2026.1/training-route.html))
 * New `iqts_country` field. Mandatory when the training route is iQTS. Accepts a valid HESA country code.

--- a/tech_docs/source/api-docs/v2026.1/contents.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/contents.html.md.erb
@@ -14,6 +14,7 @@ weight: 1
     - <%= link_to "Enhanced Errors", "/api-docs/v2026.1/developing-on-the-api.html#enhanced-errors" %>
 - <%= link_to "Endpoints", "/api-docs/v2026.1/endpoints/" %>
     - <%= link_to "GET /info", "/api-docs/v2026.1/endpoints/get-info.html" %>
+    - <%= link_to "GET /reference-data", "/api-docs/v2026.1/endpoints/get-reference-data.html" %>
     - <%= link_to "GET /trainees", "/api-docs/v2026.1/endpoints/get-trainees.html" %>
     - <%= link_to "GET /trainees/{trainee_id}", "/api-docs/v2026.1/endpoints/get-trainees-trainee-id.html" %>
     - <%= link_to "GET /trainees/{trainee_id}/placements", "/api-docs/v2026.1/endpoints/get-trainees-trainee-id-placements.html" %>

--- a/tech_docs/source/api-docs/v2026.1/endpoints/delete-trainees-trainee-id-degrees-degree-id.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/delete-trainees-trainee-id-degrees-degree-id.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: DELETE /trainees/{trainee_id}/degrees/{degree_id}
-weight: 19
+weight: 20
 ---
 
 # `DELETE /trainees/{trainee_id}/degrees/{degree_id}`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/delete-trainees-trainee-id-placements-placement-id.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/delete-trainees-trainee-id-placements-placement-id.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: DELETE /trainees/{trainee_id}/placements/{placement_id}
-weight: 18
+weight: 19
 ---
 
 # `DELETE /trainees/{trainee_id}/placements/{placement_id}`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/get-reference-data.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/get-reference-data.html.md.erb
@@ -1,0 +1,134 @@
+---
+title: GET /reference-data
+weight: 2
+---
+
+# `GET /reference-data`
+
+<%= preview_warning_if_needed %>
+
+Returns reference data values used by the Register API, including HESA codes and withdrawal reasons.
+
+This endpoint does not require authentication. It is available from v2026.1 onwards.
+
+For human-readable lists of reference data values, see the [reference data documentation](/reference-data/).
+
+## Request
+
+    GET /api/v2026.1/reference-data
+
+## Parameters
+
+| **Parameter** | **In**  | **Type** | **Required** | **Description** |
+| ------------- | ------- | -------- | ------------ | --------------- |
+| **field** | query | string | false | Return a single field only. Valid values are `country`, `course_age_range`, `course_subject`, `degree_subject`, `degree_grade`, `degree_type`, `disability`, `ethnicity`, `fund_code`, `funding_method`, `institution`, `itt_aim`, `nationality`, `itt_qualification_aim`, `sex`, `study_mode`, `training_route`, `training_initiative`, and `withdrawal_reasons`. |
+
+## Response
+
+Without a `field` parameter, the response is an object keyed by field name. Each HESA field has:
+
+* `metadata` — `name`, `display_name`, and `description`
+* `entries` — an array of values with `code`, `display_name`, `start_year`, and `end_year`
+
+`withdrawal_reasons` also includes `triggers`, `future_interest`, and entries with `code`, `display_name`, `trigger`, `requires_another_reason`, and `requires_safeguarding_concern_reasons`.
+
+With a valid `field` parameter, the response is the unwrapped payload for that field only.
+
+## Possible responses
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">HTTP 200<span> - All reference data fields</span></summary>
+  <div class="govuk-details__text">
+    <pre class="json-code-sample">
+    {
+      "sex": {
+        "metadata": {
+          "name": "sex",
+          "display_name": "Sex",
+          "description": ""
+        },
+        "entries": [
+          {
+            "code": "10",
+            "display_name": "Female",
+            "start_year": null,
+            "end_year": null
+          },
+          {
+            "code": "11",
+            "display_name": "Male",
+            "start_year": null,
+            "end_year": null
+          }
+        ]
+      },
+      "withdrawal_reasons": {
+        "metadata": {
+          "name": "withdrawal_reasons",
+          "display_name": "Withdrawal reasons"
+        },
+        "triggers": [
+          "provider",
+          "trainee"
+        ],
+        "future_interest": [
+          "yes",
+          "no",
+          "unknown"
+        ],
+        "entries": [
+          {
+            "code": "record_added_in_error",
+            "display_name": "This training record was added in error",
+            "trigger": "provider",
+            "requires_another_reason": false,
+            "requires_safeguarding_concern_reasons": false
+          }
+        ]
+      }
+    }</pre>
+  </div>
+</details>
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">HTTP 200<span> - Single field (`?field=sex`)</span></summary>
+  <div class="govuk-details__text">
+    <pre class="json-code-sample">
+    {
+      "metadata": {
+        "name": "sex",
+        "display_name": "Sex",
+        "description": ""
+      },
+      "entries": [
+        {
+          "code": "10",
+          "display_name": "Female",
+          "start_year": null,
+          "end_year": null
+        },
+        {
+          "code": "11",
+          "display_name": "Male",
+          "start_year": null,
+          "end_year": null
+        }
+      ]
+    }</pre>
+  </div>
+</details>
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">HTTP 404<span> - Unknown field</span></summary>
+  <div class="govuk-details__text">
+    <pre class="json-code-sample">
+    {
+      "errors": [
+        {
+          "error": "NotFound",
+          "message": "Reference data field 'bogus' not found"
+        }
+      ]
+    }</pre>
+  </div>
+</details>

--- a/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id-degrees-degree-id.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id-degrees-degree-id.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GET /trainees/{trainee_id}/degrees/{degree_id}
-weight: 7
+weight: 8
 ---
 
 # `GET /trainees/{trainee_id}/degrees/{degree_id}`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id-degrees.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id-degrees.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GET /trainees/{trainee_id}/degrees
-weight: 6
+weight: 7
 ---
 
 # `GET /trainees/{trainee_id}/degrees`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id-placements-placement-id.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id-placements-placement-id.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GET /trainees/{trainee_id}/placements/{placement_id}
-weight: 5
+weight: 6
 ---
 
 # `GET /trainees/{trainee_id}/placements/{placement_id}`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id-placements.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id-placements.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GET /trainees/{trainee_id}/placements
-weight: 4
+weight: 5
 ---
 
 # `GET /trainees/{trainee_id}/placements`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees-trainee-id.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GET /trainees/{trainee_id}
-weight: 3
+weight: 4
 ---
 
 # `GET /trainees/{trainee_id}`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/get-trainees.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GET /trainees
-weight: 2
+weight: 3
 ---
 
 # `GET /trainees`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-defer.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-defer.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: POST /trainees/{trainee_id}/defer
-weight: 13
+weight: 14
 ---
 
 # `POST /trainees/{trainee_id}/defer`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-degrees.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-degrees.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: POST /trainees/{trainee_id}/degrees
-weight: 10
+weight: 11
 ---
 
 # `POST /trainees/{trainee_id}/degrees`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-placements.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-placements.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: POST /trainees/{trainee_id}/placements
-weight: 9
+weight: 10
 ---
 
 # `POST /trainees/{trainee_id}/placements`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-recommend-for-qts.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-recommend-for-qts.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: POST /trainees/{trainee_id}/recommend-for-qts (deprecated)
-weight: 12
+weight: 13
 ---
 
 # `POST /trainees/{trainee_id}/recommend-for-qts` (deprecated)

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-update-qts-or-eyts-status.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-update-qts-or-eyts-status.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: POST /trainees/{trainee_id}/update-qts-or-eyts-status
-weight: 11
+weight: 12
 ---
 
 # `POST /trainees/{trainee_id}/update-qts-or-eyts-status`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-withdraw.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-withdraw.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: POST /trainees/{trainee_id}/withdraw
-weight: 14
+weight: 15
 ---
 
 # `POST /trainees/{trainee_id}/withdraw`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: POST /trainees
-weight: 8
+weight: 9
 ---
 
 # `POST /trainees`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/put-patch-trainees-trainee-id-degrees-degree-id.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/put-patch-trainees-trainee-id-degrees-degree-id.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: PUT|PATCH /trainees/{trainee_id}/degrees/{degree_id}
-weight: 17
+weight: 18
 ---
 
 # `PUT|PATCH /trainees/{trainee_id}/degrees/{degree_id}`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/put-patch-trainees-trainee-id-placements-placement-id.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/put-patch-trainees-trainee-id-placements-placement-id.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: PUT|PATCH /trainees/{trainee_id}/placements/{placement_id}
-weight: 16
+weight: 17
 ---
 
 # `PUT|PATCH /trainees/{trainee_id}/placements/{placement_id}`

--- a/tech_docs/source/api-docs/v2026.1/endpoints/put-patch-trainees-trainee-id.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/put-patch-trainees-trainee-id.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: PUT|PATCH /trainees/{trainee_id}
-weight: 15
+weight: 16
 ---
 
 # `PUT|PATCH /trainees/{trainee_id}`


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/bCrimUFz/9682-add-documentation-for-get-reference-data-endpoint)

Following on from [9624-endpoint-get-reference-data](https://trello.com/c/cFjtZf4U/9624-endpoint-get-reference-data) (#6249) we want to add documentation for the new endpoint so vendors and providers can find it and know how it works.

We also want to make some tweaks to it:

- Add documentation for the endpoint at `/api-docs/v2026.1/endpoints`
- Add openapi docs
- Add to release notes at `/api-docs/release-notes.html`
- Remove items from `metadata` as they are for internal use:
  - `source`
  - `change_log`
- Rename `hesa_code` to `code`
- Rename `slug` to `code`

### Changes proposed in this pull request

* uses the `Hesa::ReferenceData::V20261` to remove the `source` and `change_log` fields
* uses the `Hesa::ReferenceData::V20261` to rename `hesa_code` to `code` and `slug` to `code`
* updates the docs and change logs
* re-writes weights for correct ordering (this is why so many files are touched)

### Guidance to review

* Have a look through the review app to test both the endpoint and the documentation guidance

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
