### PR TITLE
[9681] Replace HESA codesets in serializers with yaml reference data implementation

### DIFF
--- a/app/lib/reference_data/type.rb
+++ b/app/lib/reference_data/type.rb
@@ -64,8 +64,8 @@ module ReferenceData
       @values_by_hesa_code[hesa_code.to_s]
     end
 
-    def service_names
-      @service_names ||= @values.map(&:service_name)
+    def resolvable_names
+      @resolvable_names ||= @values.select { |value| value.hesa_codes.present? }.flat_map(&:labels).uniq
     end
 
     def hesa_code_for(value)

--- a/app/lib/reference_data/type.rb
+++ b/app/lib/reference_data/type.rb
@@ -64,6 +64,10 @@ module ReferenceData
       @values_by_hesa_code[hesa_code.to_s]
     end
 
+    def service_names
+      @service_names ||= @values.map(&:service_name)
+    end
+
     def hesa_code_for(value)
       return if value.blank?
 

--- a/app/lib/reference_data/type.rb
+++ b/app/lib/reference_data/type.rb
@@ -11,10 +11,18 @@ module ReferenceData
       @values = values
       @values_by_id = @values.index_by(&:id).transform_keys(&:to_s).with_indifferent_access
       @values_by_name = @values.index_by(&:name).transform_keys(&:to_s).with_indifferent_access
+      @values_by_display_name = @values.index_by(&:display_name).transform_keys(&:to_s).with_indifferent_access
       @values_by_hesa_code = {}.tap do |hash|
         @values.each do |value|
           value.hesa_codes.each do |hesa_code|
             hash[hesa_code.to_s] = value
+          end
+        end
+      end
+      @values_by_alias = {}.tap do |hash|
+        @values.each do |value|
+          value.aliases.each do |alias_name|
+            hash[alias_name.to_s] = value
           end
         end
       end
@@ -54,6 +62,14 @@ module ReferenceData
 
     def find_by_hesa_code(hesa_code)
       @values_by_hesa_code[hesa_code.to_s]
+    end
+
+    def hesa_code_for(value)
+      return if value.blank?
+
+      entry = @values_by_display_name[value.to_s] || find(value) || @values_by_alias[value.to_s]
+
+      entry&.hesa_codes&.first
     end
 
     def method_missing(method_name, *args)

--- a/app/lib/reference_data/value.rb
+++ b/app/lib/reference_data/value.rb
@@ -47,5 +47,9 @@ module ReferenceData
     def service_name
       name.presence || display_name
     end
+
+    def labels
+      [name, display_name, *aliases].compact_blank.uniq
+    end
   end
 end

--- a/app/lib/reference_data/value.rb
+++ b/app/lib/reference_data/value.rb
@@ -2,13 +2,14 @@
 
 module ReferenceData
   class Value
-    attr_reader :id, :name, :display_name, :hesa_codes, :start_year, :end_year
+    attr_reader :id, :name, :display_name, :aliases, :hesa_codes, :start_year, :end_year
 
     def self.from_yaml(attrs)
       new(
         id: attrs[:id],
         name: attrs[:name],
         display_name: attrs[:display_name],
+        aliases: attrs[:aliases],
         hesa_codes: attrs[:hesa_codes],
         start_year: attrs[:start_year]&.to_i,
         end_year: attrs[:end_year]&.to_i,
@@ -19,6 +20,7 @@ module ReferenceData
       @id = attrs[:id]
       @name = attrs[:name]
       @display_name = attrs[:display_name]
+      @aliases = attrs[:aliases] || []
       @hesa_codes = attrs[:hesa_codes] || []
       @start_year = attrs[:start_year]
       @end_year = attrs[:end_year]

--- a/app/lib/reference_data/value.rb
+++ b/app/lib/reference_data/value.rb
@@ -43,5 +43,9 @@ module ReferenceData
 
       hesa_codes.first
     end
+
+    def service_name
+      name.presence || display_name
+    end
   end
 end

--- a/app/models/api/v2026_1/degree_attributes.rb
+++ b/app/models/api/v2026_1/degree_attributes.rb
@@ -37,7 +37,7 @@ module Api
       validates :subject, presence: true
 
       validates :country, api_inclusion: {
-        in: ::ReferenceData::COUNTRIES.values.map(&:display_name),
+        in: ::ReferenceData::COUNTRIES.service_names,
         valid_values: ::ReferenceData::COUNTRIES.hesa_codes,
       }, allow_blank: true
 

--- a/app/models/api/v2026_1/degree_attributes.rb
+++ b/app/models/api/v2026_1/degree_attributes.rb
@@ -37,7 +37,7 @@ module Api
       validates :subject, presence: true
 
       validates :country, api_inclusion: {
-        in: ::ReferenceData::COUNTRIES.service_names,
+        in: ::ReferenceData::COUNTRIES.resolvable_names,
         valid_values: ::ReferenceData::COUNTRIES.hesa_codes,
       }, allow_blank: true
 

--- a/app/models/api/v2026_1/trainee_attributes.rb
+++ b/app/models/api/v2026_1/trainee_attributes.rb
@@ -174,7 +174,7 @@ module Api
       validates :iqts_country, absence: true, unless: :iqts_route?
 
       validates :iqts_country, api_inclusion: {
-        in: ::ReferenceData::COUNTRIES.service_names,
+        in: ::ReferenceData::COUNTRIES.resolvable_names,
         valid_values: ::ReferenceData::COUNTRIES.hesa_codes,
       }, if: :iqts_route?, allow_blank: true
 

--- a/app/models/api/v2026_1/trainee_attributes.rb
+++ b/app/models/api/v2026_1/trainee_attributes.rb
@@ -174,7 +174,7 @@ module Api
       validates :iqts_country, absence: true, unless: :iqts_route?
 
       validates :iqts_country, api_inclusion: {
-        in: ::ReferenceData::COUNTRIES.values.map(&:display_name),
+        in: ::ReferenceData::COUNTRIES.service_names,
         valid_values: ::ReferenceData::COUNTRIES.hesa_codes,
       }, if: :iqts_route?, allow_blank: true
 

--- a/app/serializers/api/v2026_1/degree_serializer.rb
+++ b/app/serializers/api/v2026_1/degree_serializer.rb
@@ -34,48 +34,27 @@ module Api
       end
 
       def subject
-        subjects = DfEReference::DegreesQuery::SUBJECTS.constituent_lists.first.all_as_hash
-        subject = subjects.find { |_, item| item[:name] == @degree.subject }&.last
-        return if subject.blank?
-
-        subject[:hecos_code]
+        ::ReferenceData::DEGREE_SUBJECTS.hesa_code_for(@degree.subject)
       end
 
       def institution
-        institutions = DfEReference::DegreesQuery::INSTITUTIONS.constituent_lists.first.all_as_hash
-        institution = institutions.find { |_, item| item[:name] == @degree.institution }&.last
-        return if institution.blank?
-
-        institution[:hesa_itt_code]
+        ::ReferenceData::INSTITUTIONS.hesa_code_for(@degree.institution)
       end
 
       def country
-        Hesa::CodeSets::Countries::MAPPING.key(@degree.country)
+        ::ReferenceData::COUNTRIES.hesa_code_for(@degree.country)
       end
 
       def uk_degree
-        types = DfE::ReferenceData::Degrees::TYPES.all_as_hash
-        matching_type = types.find { |_, item| item[:name] == @degree.uk_degree }&.last
-
-        return if matching_type.blank?
-
-        matching_type[:hesa_itt_code]
+        ::ReferenceData::DEGREE_TYPES.hesa_code_for(@degree.uk_degree)
       end
 
       def non_uk_degree
-        matching_type = DfE::ReferenceData::Degrees::TYPES.all.detect { |type| type[:name] == @degree.non_uk_degree }
-
-        return if matching_type.blank?
-
-        matching_type[:hesa_itt_code]
+        ::ReferenceData::DEGREE_TYPES.hesa_code_for(@degree.non_uk_degree)
       end
 
       def grade
-        grades = DfE::ReferenceData::Degrees::GRADES.all_as_hash
-        matching_grade = grades.find { |_, item| item[:name] == @degree.grade }&.last
-        return if matching_grade.blank?
-
-        matching_grade[:hesa_code]
+        ::ReferenceData::DEGREE_GRADES.hesa_code_for(@degree.grade)
       end
     end
   end

--- a/app/serializers/api/v2026_1/degree_serializer.rb
+++ b/app/serializers/api/v2026_1/degree_serializer.rb
@@ -2,7 +2,81 @@
 
 module Api
   module V20261
-    class DegreeSerializer < Api::V20250::DegreeSerializer
+    class DegreeSerializer
+      EXCLUDED_ATTRIBUTES = %w[
+        id
+        slug
+        trainee_id
+        dttp_id
+        locale_code
+      ].freeze
+
+      def initialize(degree)
+        @degree = degree
+      end
+
+      def as_hash
+        @degree.attributes
+          .except(*EXCLUDED_ATTRIBUTES)
+          .with_indifferent_access.merge({
+            degree_id:,
+            subject:,
+            institution:,
+            country:,
+            uk_degree:,
+            non_uk_degree:,
+            grade:,
+          })
+      end
+
+      def degree_id
+        @degree.slug
+      end
+
+      def subject
+        subjects = DfEReference::DegreesQuery::SUBJECTS.constituent_lists.first.all_as_hash
+        subject = subjects.find { |_, item| item[:name] == @degree.subject }&.last
+        return if subject.blank?
+
+        subject[:hecos_code]
+      end
+
+      def institution
+        institutions = DfEReference::DegreesQuery::INSTITUTIONS.constituent_lists.first.all_as_hash
+        institution = institutions.find { |_, item| item[:name] == @degree.institution }&.last
+        return if institution.blank?
+
+        institution[:hesa_itt_code]
+      end
+
+      def country
+        Hesa::CodeSets::Countries::MAPPING.key(@degree.country)
+      end
+
+      def uk_degree
+        types = DfE::ReferenceData::Degrees::TYPES.all_as_hash
+        matching_type = types.find { |_, item| item[:name] == @degree.uk_degree }&.last
+
+        return if matching_type.blank?
+
+        matching_type[:hesa_itt_code]
+      end
+
+      def non_uk_degree
+        matching_type = DfE::ReferenceData::Degrees::TYPES.all.detect { |type| type[:name] == @degree.non_uk_degree }
+
+        return if matching_type.blank?
+
+        matching_type[:hesa_itt_code]
+      end
+
+      def grade
+        grades = DfE::ReferenceData::Degrees::GRADES.all_as_hash
+        matching_grade = grades.find { |_, item| item[:name] == @degree.grade }&.last
+        return if matching_grade.blank?
+
+        matching_grade[:hesa_code]
+      end
     end
   end
 end

--- a/app/serializers/api/v2026_1/trainee_serializer.rb
+++ b/app/serializers/api/v2026_1/trainee_serializer.rb
@@ -127,7 +127,7 @@ module Api
       end
 
       def ethnicity
-        Hesa::CodeSets::Ethnicities::MAPPING.key(@trainee.ethnic_background)
+        ::ReferenceData::ETHNICITIES.hesa_code_for(@trainee.ethnic_background)
       end
 
       def course_attributes
@@ -155,15 +155,15 @@ module Api
       end
 
       def course_subject_1
-        ::Hesa::CodeSets::CourseSubjects::MAPPING.key(@trainee.course_subject_one)
+        ::ReferenceData::COURSE_SUBJECTS.hesa_code_for(@trainee.course_subject_one)
       end
 
       def course_subject_2
-        ::Hesa::CodeSets::CourseSubjects::MAPPING.key(@trainee.course_subject_two)
+        ::ReferenceData::COURSE_SUBJECTS.hesa_code_for(@trainee.course_subject_two)
       end
 
       def course_subject_3
-        ::Hesa::CodeSets::CourseSubjects::MAPPING.key(@trainee.course_subject_three)
+        ::ReferenceData::COURSE_SUBJECTS.hesa_code_for(@trainee.course_subject_three)
       end
 
       def course_study_mode
@@ -218,25 +218,23 @@ module Api
       def nationality
         return if @trainee.nationalities.blank?
 
-        RecruitsApi::CodeSets::Nationalities::APPLY_MAPPING[
-          @trainee.nationalities.first.name,
-        ]
+        ::ReferenceData::NATIONALITIES.hesa_code_for(@trainee.nationalities.first.name)
       end
 
       def training_route
-        ::Hesa::CodeSets::TrainingRoutes::MAPPING.key(@trainee.training_route)
+        ::ReferenceData::TRAINING_ROUTES.hesa_code_for(@trainee.training_route)
       end
 
       def iqts_country
-        ::Hesa::CodeSets::Countries::MAPPING.key(@trainee.iqts_country)
+        ::ReferenceData::COUNTRIES.hesa_code_for(@trainee.iqts_country)
       end
 
       def training_initiative
-        ::Hesa::CodeSets::TrainingInitiatives::MAPPING.key(@trainee.training_initiative)
+        ::ReferenceData::TRAINING_INITIATIVES.hesa_code_for(@trainee.training_initiative)
       end
 
       def sex
-        ::Hesa::CodeSets::Sexes::MAPPING.key(::Trainee.sexes[@trainee.sex])
+        ::ReferenceData::SEXES.hesa_code_for(::Trainee.sexes[@trainee.sex])
       end
 
       def withdrawal_reasons

--- a/app/services/api/v2026_1/hesa_mapper/attributes.rb
+++ b/app/services/api/v2026_1/hesa_mapper/attributes.rb
@@ -130,7 +130,7 @@ module Api
         end
 
         def iqts_country
-          mapped_value = ::ReferenceData::COUNTRIES.find_by_hesa_code(params[:iqts_country])&.display_name
+          mapped_value = ::ReferenceData::COUNTRIES.find_by_hesa_code(params[:iqts_country])&.service_name
 
           return InvalidValue.new(params[:iqts_country]) if params[:iqts_country].present? && mapped_value.nil?
 

--- a/app/services/api/v2026_1/hesa_mapper/degree_attributes.rb
+++ b/app/services/api/v2026_1/hesa_mapper/degree_attributes.rb
@@ -146,7 +146,7 @@ module Api
 
         def country_from_mapping
           @country_from_mapping ||= begin
-            mapped_value = ::ReferenceData::COUNTRIES.find_by_hesa_code(@params[:country])&.display_name
+            mapped_value = ::ReferenceData::COUNTRIES.find_by_hesa_code(@params[:country])&.service_name
 
             if @params[:country].present? && mapped_value.nil?
               Api::V20261::HesaMapper::Attributes::InvalidValue.new(@params[:country])

--- a/config/reference_data/country.yml
+++ b/config/reference_data/country.yml
@@ -10,6 +10,12 @@ metadata:
   - date: "2026-03-17"
     change: "Aligned with v2025.0 reference data (and Hesa::CodeSets::Countries::MAPPING)"
     author: "Register team"
+  - date: "2026-07-27"
+    change: "Moved the service label 'Kosovo' to QO, leaving XK without one. Ids in
+      this file are HESA codes, where XK is 'United Kingdom, not otherwise specified'
+      and Kosovo is QO. The dfe-reference-data gem used by the UI keys Kosovo as XK,
+      which is where the difference comes from."
+    author: "Register team"
 data:
 - id: "AF"
   name: "Afghanistan"
@@ -657,7 +663,7 @@ data:
   hesa_codes:
   - "KR"
 - id: "QO"
-  name: ""
+  name: "Kosovo"
   display_name: "Kosovo"
   hesa_codes:
   - "QO"
@@ -1261,7 +1267,7 @@ data:
   hesa_codes:
   - "AE"
 - id: "XK"
-  name: "Kosovo"
+  name: ""
   display_name: "United Kingdom, not otherwise specified"
   hesa_codes:
   - "XK"

--- a/config/reference_data/degree_subject.yml
+++ b/config/reference_data/degree_subject.yml
@@ -1227,6 +1227,8 @@ data:
   - id: "a042524a-b918-457c-bfaf-2e2432785d6d"
     name: "computing_and_information_technology"
     display_name: "Computing"
+    aliases:
+      - "Computing and information technology"
     hesa_codes:
       - "100367"
   - id: "0f8670f0-5dce-e911-a985-000d3ab79618"
@@ -4882,6 +4884,8 @@ data:
   - id: "ba1ffe89-73fb-4de8-a48d-12e644ee5687"
     name: "sport_and_exercise_sciences"
     display_name: "Physical education"
+    aliases:
+      - "Sport and exercise sciences"
     hesa_codes:
       - "100433"
   - id: "bd8670f0-5dce-e911-a985-000d3ab79618"

--- a/config/reference_data/nationality.yml
+++ b/config/reference_data/nationality.yml
@@ -137,6 +137,14 @@ data:
 - id: GB
   name: british
   display_name: British
+  aliases:
+    - cymraes
+    - cymro
+    - english
+    - northern irish
+    - prydeinig
+    - scottish
+    - welsh
   hesa_codes:
     - "GB"
     - "FK"
@@ -1021,6 +1029,8 @@ data:
 - id: SH
   name: tristanian
   display_name: Tristanian
+  aliases:
+    - st helenian
   hesa_codes:
     - "SH"
 - id: TN

--- a/spec/config/reference_data_spec.rb
+++ b/spec/config/reference_data_spec.rb
@@ -182,6 +182,50 @@ RSpec.describe "Reference data integrity" do
     end
   end
 
+  describe "alias integrity" do
+    it "has no alias that collides with a canonical label or another alias" do
+      collisions = ReferenceData::Loader.instance.types.flat_map do |type|
+        canonical = type.values.flat_map { |value| [value.name.to_s, value.display_name.to_s] }.reject(&:empty?)
+        seen = {}
+
+        type.values.flat_map do |value|
+          value.aliases.filter_map do |alias_name|
+            owner = seen[alias_name]
+            seen[alias_name] = value.id
+
+            if canonical.include?(alias_name.to_s)
+              "#{type.name}: alias #{alias_name.inspect} on #{value.id.inspect} is already a canonical label"
+            elsif owner
+              "#{type.name}: alias #{alias_name.inspect} claimed by both #{owner.inspect} and #{value.id.inspect}"
+            end
+          end
+        end
+      end
+
+      expect(collisions).to be_empty, "reference data alias collisions:\n#{collisions.join("\n")}"
+    end
+  end
+
+  describe "name lookup integrity" do
+    it "has no entry whose name is another entry's display_name" do
+      collisions = ReferenceData::Loader.instance.types.flat_map do |type|
+        entries_by_display_name = type.values.index_by(&:display_name)
+
+        type.values.filter_map do |value|
+          next if value.name.to_s.empty?
+
+          other = entries_by_display_name[value.name.to_s]
+          next unless other && other.id != value.id
+
+          "#{type.name}: #{value.id.inspect} has name #{value.name.inspect}, " \
+            "which is the display_name of #{other.id.inspect}"
+        end
+      end
+
+      expect(collisions).to be_empty, "reference data name collisions:\n#{collisions.join("\n")}"
+    end
+  end
+
   describe "trainee reference types match the source they replaced" do
     {
       "ethnicity" => {
@@ -247,6 +291,61 @@ RSpec.describe "Reference data integrity" do
           out << "#{code}: #{config[:field]}=#{actual.inspect} != source #{expected.inspect}" if actual != expected
         end
         expect(divergences).to be_empty, "#{name} diverges from source:\n#{divergences.first(20).join("\n")}"
+      end
+    end
+  end
+
+  # The UI still writes gem labels while the v2026 serializers resolve from YAML,
+  # so every label the UI can persist must resolve to the same HESA code the gem gives.
+  describe "no outbound gaps against the writable UI vocabulary" do
+    {
+      "degree.subject" => {
+        writable: -> { DfEReference::DegreesQuery::SUBJECTS.all.map(&:name) },
+        gem: ->(value) { DfEReference::DegreesQuery.find_subject(name: value)&.hecos_code },
+        yaml: -> { ReferenceData::DEGREE_SUBJECTS },
+      },
+      "degree.institution" => {
+        writable: -> { DfEReference::DegreesQuery::INSTITUTIONS.all.map(&:name) },
+        gem: ->(value) { DfEReference::DegreesQuery.find_institution(name: value)&.hesa_itt_code },
+        yaml: -> { ReferenceData::INSTITUTIONS },
+      },
+      "degree.uk_degree" => {
+        writable: -> { DfEReference::DegreesQuery::TYPES.all.map(&:name) },
+        gem: ->(value) { DfEReference::DegreesQuery.find_type(name: value)&.hesa_itt_code },
+        yaml: -> { ReferenceData::DEGREE_TYPES },
+      },
+      "degree.grade" => {
+        writable: -> { DfEReference::DegreesQuery::SUPPORTED_GRADES_WITH_OTHER.all.map(&:name) },
+        gem: ->(value) { DfEReference::DegreesQuery.find_grade(name: value)&.hesa_code },
+        yaml: -> { ReferenceData::DEGREE_GRADES },
+      },
+      "degree.country" => {
+        writable: -> { DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all.map(&:name) },
+        gem: ->(value) { Hesa::CodeSets::Countries::MAPPING.key(value) },
+        yaml: -> { ReferenceData::COUNTRIES },
+      },
+      "trainee.nationality" => {
+        writable: -> { CodeSets::Nationalities::MAPPING.keys.map(&:to_s) },
+        gem: ->(value) { RecruitsApi::CodeSets::Nationalities::APPLY_MAPPING[value.downcase] },
+        yaml: -> { ReferenceData::NATIONALITIES },
+      },
+    }.each do |field, config|
+      it "resolves every writable #{field} label with no gap or mismatch" do
+        yaml = config[:yaml].call
+
+        problems = config[:writable].call.compact.uniq.each_with_object([]) do |label, out|
+          gem_code = config[:gem].call(label)
+          next if gem_code.nil? # the gem itself does not resolve it, so no regression is possible
+
+          yaml_code = yaml.hesa_code_for(label)
+          if yaml_code.nil?
+            out << "GAP #{label.inspect}: gem=#{gem_code.inspect} yaml=nil"
+          elsif yaml_code.to_s != gem_code.to_s
+            out << "WRONG #{label.inspect}: gem=#{gem_code.inspect} yaml=#{yaml_code.inspect}"
+          end
+        end
+
+        expect(problems).to be_empty, "#{field} outbound gaps:\n#{problems.first(20).join("\n")}"
       end
     end
   end

--- a/spec/config/reference_data_spec.rb
+++ b/spec/config/reference_data_spec.rb
@@ -329,6 +329,36 @@ RSpec.describe "Reference data integrity" do
         gem: ->(value) { RecruitsApi::CodeSets::Nationalities::APPLY_MAPPING[value.downcase] },
         yaml: -> { ReferenceData::NATIONALITIES },
       },
+      "trainee.ethnicity" => {
+        writable: -> { Diversities::BACKGROUNDS.values.flatten },
+        gem: ->(value) { Hesa::CodeSets::Ethnicities::MAPPING.key(value) },
+        yaml: -> { ReferenceData::ETHNICITIES },
+      },
+      "trainee.course_subject" => {
+        writable: -> { Hesa::CodeSets::CourseSubjects::MAPPING.values },
+        gem: ->(value) { Hesa::CodeSets::CourseSubjects::MAPPING.key(value) },
+        yaml: -> { ReferenceData::COURSE_SUBJECTS },
+      },
+      "trainee.training_route" => {
+        writable: -> { TRAINING_ROUTE_ENUMS.keys.map(&:to_s) },
+        gem: ->(value) { Hesa::CodeSets::TrainingRoutes::MAPPING.key(value) },
+        yaml: -> { ReferenceData::TRAINING_ROUTES },
+      },
+      "trainee.training_initiative" => {
+        writable: -> { ROUTE_INITIATIVES_ENUMS.keys.map(&:to_s) },
+        gem: ->(value) { Hesa::CodeSets::TrainingInitiatives::MAPPING.key(value) },
+        yaml: -> { ReferenceData::TRAINING_INITIATIVES },
+      },
+      "trainee.sex" => {
+        writable: -> { Trainee.sexes.values },
+        gem: ->(value) { Hesa::CodeSets::Sexes::MAPPING.key(value) },
+        yaml: -> { ReferenceData::SEXES },
+      },
+      "trainee.iqts_country" => {
+        writable: -> { DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all.map(&:name) },
+        gem: ->(value) { Hesa::CodeSets::Countries::MAPPING.key(value) },
+        yaml: -> { ReferenceData::COUNTRIES },
+      },
     }.each do |field, config|
       it "resolves every writable #{field} label with no gap or mismatch" do
         yaml = config[:yaml].call

--- a/spec/lib/reference_data/type_spec.rb
+++ b/spec/lib/reference_data/type_spec.rb
@@ -159,4 +159,81 @@ RSpec.describe ReferenceData::Type do
       expect { type.over_time }.to raise_error(NoMethodError)
     end
   end
+
+  describe "#hesa_code_for" do
+    it "looks up by `display_name`" do
+      expect(type.hesa_code_for("Part-time")).to eq("31")
+    end
+
+    it "looks up by `id`" do
+      expect(type.hesa_code_for(1)).to eq("01")
+    end
+
+    it "looks up by `name`" do
+      expect(type.hesa_code_for("full_time")).to eq("01")
+    end
+
+    it "returns nil for unknown values" do
+      expect(type.hesa_code_for("Flexi-time")).to be_nil
+    end
+
+    it "returns nil for a blank value" do
+      countries = ReferenceData::Loader.instance.find("country")
+      ethnicities = ReferenceData::Loader.instance.find("ethnicity")
+
+      expect(countries.hesa_code_for(nil)).to be_nil
+      expect(countries.hesa_code_for("")).to be_nil
+      expect(ethnicities.hesa_code_for(nil)).to be_nil
+    end
+
+    it "returns nil rather than raising when the value has no HESA code" do
+      degree_types = ReferenceData::Loader.instance.find("degree_type")
+      code_less = degree_types.values.find { |value| value.hesa_codes.empty? }
+
+      expect(degree_types.hesa_code_for(code_less.display_name)).to be_nil
+    end
+
+    context "when a `name` shadows another entry's `display_name`" do
+      subject(:countries) { ReferenceData::Loader.instance.find("country") }
+
+      it "resolves to the entry whose `display_name` matches" do
+        expect(countries.hesa_code_for("Kosovo")).to eq("QO")
+        expect(countries.hesa_code_for("United Kingdom, not otherwise specified")).to eq("XK")
+      end
+    end
+
+    context "with a label recorded as an alias" do
+      subject(:degree_subjects) { ReferenceData::Loader.instance.find("degree_subject") }
+
+      it "resolves the alias to the canonical entry's HESA code" do
+        expect(degree_subjects.hesa_code_for("Computing and information technology")).to eq("100367")
+        expect(degree_subjects.hesa_code_for("Sport and exercise sciences")).to eq("100433")
+      end
+
+      it "still resolves the canonical display_name" do
+        expect(degree_subjects.hesa_code_for("Computing")).to eq("100367")
+        expect(degree_subjects.hesa_code_for("Physical education")).to eq("100433")
+      end
+    end
+  end
+
+  describe "aliases are outbound-only" do
+    subject(:degree_subjects) { ReferenceData::Loader.instance.find("degree_subject") }
+
+    it "excludes aliases from `names`" do
+      expect(degree_subjects.names).not_to include("Computing and information technology")
+    end
+
+    it "excludes aliases from `names_with_hesa_codes`" do
+      expect(degree_subjects.names_with_hesa_codes).not_to include("Computing and information technology")
+    end
+
+    it "does not resolve aliases through `find`" do
+      expect(degree_subjects.find("Computing and information technology")).to be_nil
+    end
+
+    it "leaves the code to canonical entry lookup untouched" do
+      expect(degree_subjects.find_by_hesa_code("100367").display_name).to eq("Computing")
+    end
+  end
 end

--- a/spec/lib/reference_data/type_spec.rb
+++ b/spec/lib/reference_data/type_spec.rb
@@ -160,6 +160,29 @@ RSpec.describe ReferenceData::Type do
     end
   end
 
+  describe "#service_names" do
+    subject(:countries) { ReferenceData::Loader.instance.find("country") }
+
+    it "uses the service label where the entry has one" do
+      expect(countries.service_names).to include("Bolivia")
+      expect(countries.service_names).not_to include("Bolivia [Bolivia, Plurinational State of]")
+    end
+
+    it "falls back to the display_name for entries with no service label" do
+      expect(countries.service_names).to include("Aruba")
+    end
+
+    it "covers every entry" do
+      expect(countries.service_names.size).to eq(countries.values.size)
+    end
+
+    it "resolves every service name back to its own HESA code" do
+      unresolvable = countries.values.reject { |value| countries.hesa_code_for(value.service_name) == value.hesa_codes.first }
+
+      expect(unresolvable).to be_empty
+    end
+  end
+
   describe "#hesa_code_for" do
     it "looks up by `display_name`" do
       expect(type.hesa_code_for("Part-time")).to eq("31")

--- a/spec/lib/reference_data/type_spec.rb
+++ b/spec/lib/reference_data/type_spec.rb
@@ -160,26 +160,21 @@ RSpec.describe ReferenceData::Type do
     end
   end
 
-  describe "#service_names" do
+  describe "#resolvable_names" do
     subject(:countries) { ReferenceData::Loader.instance.find("country") }
 
-    it "uses the service label where the entry has one" do
-      expect(countries.service_names).to include("Bolivia")
-      expect(countries.service_names).not_to include("Bolivia [Bolivia, Plurinational State of]")
+    it "includes both the service label and the HESA display name" do
+      expect(countries.resolvable_names).to include("Bolivia", "Bolivia [Bolivia, Plurinational State of]")
     end
 
-    it "falls back to the display_name for entries with no service label" do
-      expect(countries.service_names).to include("Aruba")
+    it "does not include HESA codes that are only entry IDs" do
+      expect(countries.resolvable_names).not_to include("BO")
     end
 
-    it "covers every entry" do
-      expect(countries.service_names.size).to eq(countries.values.size)
-    end
+    it "accepts every label #hesa_code_for can resolve" do
+      unaccepted = countries.resolvable_names.reject { |label| countries.hesa_code_for(label).present? }
 
-    it "resolves every service name back to its own HESA code" do
-      unresolvable = countries.values.reject { |value| countries.hesa_code_for(value.service_name) == value.hesa_codes.first }
-
-      expect(unresolvable).to be_empty
+      expect(unaccepted).to be_empty
     end
   end
 

--- a/spec/lib/reference_data/value_spec.rb
+++ b/spec/lib/reference_data/value_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe ReferenceData::Value do
       expect(training_initiatives.future_teaching_scholars.hesa_code).to be_nil
     end
   end
+
+  describe "#aliases" do
+    it "defaults to an empty array when the entry declares none" do
+      expect(training_routes.provider_led_postgrad.aliases).to eq([])
+    end
+
+    it "exposes aliases declared in the YAML" do
+      value = described_class.from_yaml(
+        { id: "1", name: "computing", display_name: "Computing", aliases: ["Computing and information technology"] }.with_indifferent_access,
+      )
+
+      expect(value.aliases).to eq(["Computing and information technology"])
+    end
+  end
 end

--- a/spec/lib/reference_data/value_spec.rb
+++ b/spec/lib/reference_data/value_spec.rb
@@ -48,4 +48,23 @@ RSpec.describe ReferenceData::Value do
       expect(value.service_name).to eq("Aruba")
     end
   end
+
+  describe "#labels" do
+    it "returns every non-blank name that can identify the value" do
+      value = described_class.from_yaml(
+        {
+          id: "BO",
+          name: "Bolivia",
+          display_name: "Bolivia [Bolivia, Plurinational State of]",
+          aliases: ["Bolivia alias"],
+        }.with_indifferent_access,
+      )
+
+      expect(value.labels).to contain_exactly(
+        "Bolivia",
+        "Bolivia [Bolivia, Plurinational State of]",
+        "Bolivia alias",
+      )
+    end
+  end
 end

--- a/spec/lib/reference_data/value_spec.rb
+++ b/spec/lib/reference_data/value_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe ReferenceData::Value do
       expect(value.aliases).to eq(["Computing and information technology"])
     end
   end
+
+  describe "#service_name" do
+    it "is the name when the entry has one" do
+      value = described_class.from_yaml({ id: "BO", name: "Bolivia", display_name: "Bolivia [Bolivia, Plurinational State of]" }.with_indifferent_access)
+
+      expect(value.service_name).to eq("Bolivia")
+    end
+
+    it "falls back to the display_name when the entry has no name" do
+      value = described_class.from_yaml({ id: "AW", name: "", display_name: "Aruba" }.with_indifferent_access)
+
+      expect(value.service_name).to eq("Aruba")
+    end
+  end
 end

--- a/spec/models/api/v2026_1/degree_attributes_spec.rb
+++ b/spec/models/api/v2026_1/degree_attributes_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V20261::DegreeAttributes do
 
     it {
       expect(subject).to validate_inclusion_of(:country)
-        .in_array(ReferenceData::COUNTRIES.values.map(&:display_name))
+        .in_array(ReferenceData::COUNTRIES.service_names)
         .with_message(/has invalid reference data value of '.*'/)
     }
 

--- a/spec/models/api/v2026_1/degree_attributes_spec.rb
+++ b/spec/models/api/v2026_1/degree_attributes_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V20261::DegreeAttributes do
 
     it {
       expect(subject).to validate_inclusion_of(:country)
-        .in_array(ReferenceData::COUNTRIES.service_names)
+        .in_array(ReferenceData::COUNTRIES.resolvable_names)
         .with_message(/has invalid reference data value of '.*'/)
     }
 

--- a/spec/requests/api/v2026_1/get_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/get_trainee_spec.rb
@@ -203,6 +203,31 @@ describe "`GET /api/v2026.1/trainees/:id` endpoint" do
     end
   end
 
+  context "when a nationality shares a HESA code" do
+    let!(:trainee) do
+      create(:trainee, :with_hesa_trainee_detail, slug: "12345", provider: auth_token.provider,
+                                                  nationalities: [build(:nationality, name: nationality_name)])
+    end
+
+    before { get("/api/v2026.1/trainees/#{trainee.slug}", headers: { Authorization: "Bearer #{token}" }) }
+
+    context "with the canonical nationality" do
+      let(:nationality_name) { "british" }
+
+      it "serializes the nationality as its HESA code" do
+        expect(response.parsed_body["nationality"]).to eq("GB")
+      end
+    end
+
+    context "with a superseded nationality label" do
+      let(:nationality_name) { "cymraes" }
+
+      it "serializes the nationality as the same HESA code" do
+        expect(response.parsed_body["nationality"]).to eq("GB")
+      end
+    end
+  end
+
   context "when the trainee does not exist" do
     before do
       get(

--- a/spec/requests/api/v2026_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v2026_1/post_hesa_trainees_spec.rb
@@ -2355,7 +2355,7 @@ describe "`POST /api/v2026.1/trainees` endpoint" do
 
   context "when creating a trainee with IQTS route" do
     let(:training_route) { "15" }
-    let(:iqts_country) { Hesa::CodeSets::Countries::MAPPING.keys.sample }
+    let(:iqts_country) { "BO" }
 
     before do
       post endpoint, params: params.to_json, headers: { Authorization: token, **json_headers }
@@ -2373,7 +2373,7 @@ describe "`POST /api/v2026.1/trainees` endpoint" do
       it "stores the trainee with iqts training route" do
         trainee = Trainee.last
         expect(trainee.training_route).to eq("iqts")
-        expect(trainee.iqts_country).to eq(Hesa::CodeSets::Countries::MAPPING[iqts_country])
+        expect(trainee.iqts_country).to eq("Bolivia")
       end
     end
 

--- a/spec/requests/api/v2026_1/put_trainee_spec.rb
+++ b/spec/requests/api/v2026_1/put_trainee_spec.rb
@@ -2706,7 +2706,7 @@ describe "`PUT /api/v2026.1/trainees/:id` endpoint" do
     end
 
     context "when updating a trainee to IQTS route" do
-      let(:iqts_country) { Hesa::CodeSets::Countries::MAPPING.keys.sample }
+      let(:iqts_country) { "BO" }
       let(:data) { { training_route: "15", iqts_country: iqts_country } }
 
       before do
@@ -2722,7 +2722,7 @@ describe "`PUT /api/v2026.1/trainees/:id` endpoint" do
       it "stores the updated values" do
         trainee.reload
         expect(trainee.training_route).to eq("iqts")
-        expect(trainee.iqts_country).to eq(Hesa::CodeSets::Countries::MAPPING[iqts_country])
+        expect(trainee.iqts_country).to eq("Bolivia")
       end
     end
 

--- a/spec/requests/api/v2026_1/trainees/get_degree_spec.rb
+++ b/spec/requests/api/v2026_1/trainees/get_degree_spec.rb
@@ -17,6 +17,30 @@ describe "`GET /trainees/:trainee_slug/degrees/:slug` endpoint" do
       end
     end
 
+    context "with a subject label that shares a HESA code" do
+      let(:trainee) { create(:trainee) }
+      let!(:degree) { create(:degree, :uk_degree_type, trainee: trainee, subject: subject_name) }
+      let(:slug) { degree.slug }
+
+      before { get "/api/v2026.1//trainees/#{trainee_slug}/degrees/#{slug}", headers: { Authorization: token } }
+
+      context "with the canonical label" do
+        let(:subject_name) { "Computing" }
+
+        it "serializes the subject as its HESA code" do
+          expect(response.parsed_body.dig(:data, :subject)).to eq("100367")
+        end
+      end
+
+      context "with the superseded alias label" do
+        let(:subject_name) { "Computing and information technology" }
+
+        it "serializes the subject as the same HESA code" do
+          expect(response.parsed_body.dig(:data, :subject)).to eq("100367")
+        end
+      end
+    end
+
     context "non existant degree" do
       let(:slug) { "non-existant" }
 

--- a/spec/requests/api/v2026_1/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v2026_1/trainees/post_degrees_spec.rb
@@ -88,6 +88,33 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
       end
     end
 
+    context "when the posted subject code has an aliased label" do
+      let(:degrees_attributes) do
+        {
+          grade: "02",
+          subject: "100367",
+          institution: "1166",
+          uk_degree: "014",
+          graduation_year: "2015-01-01",
+          country: "XF",
+        }
+      end
+
+      before do
+        post(
+          "/api/v2026.1/trainees/#{trainee.slug}/degrees",
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: { data: degrees_attributes }.to_json,
+        )
+      end
+
+      it "stores the canonical label, never the alias" do
+        expect(response).to have_http_status(:created)
+        expect(trainee.degrees.last.subject).to eq("Computing")
+        expect(response.parsed_body.dig("data", "subject")).to eq("100367")
+      end
+    end
+
     context "with a valid trainee and non uk degree" do
       let(:degrees_attributes) do
         {

--- a/spec/requests/api/v2026_1/trainees/post_degrees_spec.rb
+++ b/spec/requests/api/v2026_1/trainees/post_degrees_spec.rb
@@ -115,6 +115,32 @@ describe "`POST /trainees/:trainee_id/degrees` endpoint" do
       end
     end
 
+    context "when the country label differs from its HESA display name" do
+      let(:degrees_attributes) do
+        {
+          grade: "02",
+          subject: "100425",
+          non_uk_degree: "083",
+          graduation_year: "2015-01-01",
+          country: "BO",
+        }
+      end
+
+      before do
+        post(
+          "/api/v2026.1/trainees/#{trainee.slug}/degrees",
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: { data: degrees_attributes }.to_json,
+        )
+      end
+
+      it "stores the label the UI writes and serializes it back as the same code" do
+        expect(response).to have_http_status(:created)
+        expect(trainee.degrees.last.country).to eq("Bolivia")
+        expect(response.parsed_body.dig("data", "country")).to eq("BO")
+      end
+    end
+
     context "with a valid trainee and non uk degree" do
       let(:degrees_attributes) do
         {

--- a/spec/requests/api/v2026_1/trainees/put_degrees_spec.rb
+++ b/spec/requests/api/v2026_1/trainees/put_degrees_spec.rb
@@ -216,6 +216,29 @@ describe "`PUT /trainees/:trainee_slug/degrees/:slug` endpoint" do
       end
     end
 
+    context "when the stored country is a HESA display name written by a previous API version" do
+      let!(:degree) do
+        create(
+          :degree,
+          :non_uk_degree_with_details,
+          trainee: trainee,
+          country: "Bolivia [Bolivia, Plurinational State of]",
+          non_uk_degree: "Bachelor of Education Scotland and Northern Ireland",
+        )
+      end
+
+      it "updates the degree and returns a 200 status (ok)" do
+        put(
+          "/api/v2026.1/trainees/#{trainee.slug}/degrees/#{degree.slug}",
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: { data: { grade: "02" } }.to_json,
+        )
+
+        expect(response).to have_http_status(:ok)
+        expect(degree.reload.grade).to eq("Upper second-class honours (2:1)")
+      end
+    end
+
     context "with duplicate degree" do
       let(:uk_degree) { build(:degree, :uk_degree_with_details) }
       let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details) }

--- a/spec/requests/api/v2026_1/trainees/put_degrees_spec.rb
+++ b/spec/requests/api/v2026_1/trainees/put_degrees_spec.rb
@@ -251,6 +251,22 @@ describe "`PUT /trainees/:trainee_slug/degrees/:slug` endpoint" do
           uk_degree.reload
         }.not_to change(uk_degree, :attributes)
       end
+
+      context "when the stored country label differs from its HESA display name" do
+        let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: "Bolivia") }
+
+        it "returns a 409 (conflict) status", openapi: false do
+          put(
+            "/api/v2026.1/trainees/#{trainee.slug}/degrees/#{uk_degree.slug}",
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: {
+              data: degrees_attributes,
+            }.to_json,
+          )
+
+          expect(response).to have_http_status(:conflict)
+        end
+      end
     end
 
     context "with an invalid trainee" do

--- a/spec/serializers/api/v2026_1/degree_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/degree_serializer_spec.rb
@@ -31,4 +31,41 @@ RSpec.describe Api::V20261::DegreeSerializer do
       expect(json.keys).to match_array(fields)
     end
   end
+
+  describe "HESA codes" do
+    context "with a UK degree" do
+      let(:degree) do
+        create(:degree, :uk_degree_type,
+               subject: "Computing",
+               institution: "Brunel University London",
+               grade: "First-class honours",
+               uk_degree: "Bachelor of Arts")
+      end
+
+      it "serializes each reference value as its HESA code" do
+        expect(json[:subject]).to eq("100367")
+        expect(json[:institution]).to eq("0113")
+        expect(json[:grade]).to eq("01")
+        expect(json[:uk_degree]).to eq("051")
+      end
+    end
+
+    context "with a non-UK degree" do
+      let(:degree) do
+        create(:degree, :non_uk_degree_type, country: "Kosovo", subject: "Computing")
+      end
+
+      it "serializes the country as its HESA code" do
+        expect(json[:country]).to eq("QO")
+      end
+    end
+
+    context "with a superseded subject label still stored against the degree" do
+      let(:degree) { create(:degree, :uk_degree_type, subject: "Computing and information technology") }
+
+      it "still serializes the subject HESA code" do
+        expect(json[:subject]).to eq("100367")
+      end
+    end
+  end
 end

--- a/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
@@ -251,6 +251,28 @@ RSpec.describe Api::V20261::TraineeSerializer do
       it "serializes nationality to HESA code" do
         expect(json[:nationality]).to eq("FR")
       end
+
+      context "with a canonical nationality" do
+        let(:trainee) do
+          create(:trainee, :with_training_partner_scitt, :with_hesa_trainee_detail, :with_diversity_information,
+                 :in_progress, :with_placements, nationalities: [build(:nationality, name: "british")])
+        end
+
+        it "serializes the HESA code" do
+          expect(json[:nationality]).to eq("GB")
+        end
+      end
+
+      context "with a superseded nationality label still stored against the trainee" do
+        let(:trainee) do
+          create(:trainee, :with_training_partner_scitt, :with_hesa_trainee_detail, :with_diversity_information,
+                 :in_progress, :with_placements, nationalities: [build(:nationality, name: "cymraes")])
+        end
+
+        it "still serializes the HESA code" do
+          expect(json[:nationality]).to eq("GB")
+        end
+      end
     end
 
     describe "training partner attributes" do
@@ -320,12 +342,20 @@ RSpec.describe Api::V20261::TraineeSerializer do
         expect(json[:training_route]).to eq("15")
       end
 
-      it "includes iqts_country as HESA code in the output" do
-        expect(json[:iqts_country]).to eq(Hesa::CodeSets::Countries::MAPPING.key(trainee.iqts_country))
-      end
-
       it "includes iqts_country in the fields list" do
         expect(json.keys).to include("iqts_country")
+      end
+    end
+
+    context "when the trainee's IQTS country label is also another country's reference data name" do
+      let(:trainee) do
+        create(:trainee, :iqts, :with_training_partner_scitt, :with_hesa_trainee_detail,
+               :with_diversity_information, :in_progress, :with_placements, :with_french_nationality,
+               iqts_country: "Kosovo")
+      end
+
+      it "serializes the country the trainee actually has" do
+        expect(json[:iqts_country]).to eq("QO")
       end
     end
   end

--- a/spec/services/api/v2026_1/hesa_mapper/attributes_spec.rb
+++ b/spec/services/api/v2026_1/hesa_mapper/attributes_spec.rb
@@ -34,8 +34,25 @@ RSpec.describe Api::V20261::HesaMapper::Attributes do
     expect(divergences).to be_empty, divergences.join("\n")
   end
 
-  it "maps iqts_country for every code" do
-    divergences = diverging(Hesa::CodeSets::Countries::MAPPING) { |code| mapped(iqts_country: code)[:iqts_country] }
+  it "maps iqts_country to the label the UI writes" do
+    ui_labels = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all.map(&:name).compact.uniq
+
+    divergences = ui_labels.each_with_object([]) do |ui_label, out|
+      code = ReferenceData::COUNTRIES.hesa_code_for(ui_label)
+      next if code.nil?
+
+      actual = mapped(iqts_country: code)[:iqts_country]
+      out << "#{code}: #{actual.inspect} != #{ui_label.inspect}" if actual != ui_label
+    end
+    expect(divergences).to be_empty, divergences.join("\n")
+  end
+
+  it "maps iqts_country for every code to a label that serializes back to the same code" do
+    divergences = Hesa::CodeSets::Countries::MAPPING.keys.each_with_object([]) do |code, out|
+      stored = mapped(iqts_country: code)[:iqts_country]
+      resolved = ReferenceData::COUNTRIES.hesa_code_for(stored)
+      out << "#{code}: stored #{stored.inspect}, which serializes back as #{resolved.inspect}" if resolved != code
+    end
     expect(divergences).to be_empty, divergences.join("\n")
   end
 

--- a/spec/services/api/v2026_1/hesa_mapper/degree_attributes_spec.rb
+++ b/spec/services/api/v2026_1/hesa_mapper/degree_attributes_spec.rb
@@ -45,9 +45,41 @@ RSpec.describe Api::V20261::HesaMapper::DegreeAttributes do
     expect(divergences_for(params)).to be_empty
   end
 
-  it "maps every country code the same as the gem" do
-    params = Hesa::CodeSets::Countries::MAPPING.keys.map { |code| { country: code, subject: "100104", non_uk_degree: "051", grade: "01" } }
-    expect(divergences_for(params)).to be_empty
+  def country_stored_for(code)
+    described_class.call({ country: code, subject: "100104", non_uk_degree: "051", grade: "01" })[:country]
+  end
+
+  def country_codes_stored_on_degrees
+    Hesa::CodeSets::Countries::MAPPING.reject { |_, name| Hesa::CodeSets::Countries::UK_COUNTRIES.include?(name) }.keys
+  end
+
+  it "does not store a country for UK degrees, which carry locale_code instead" do
+    uk_codes = Hesa::CodeSets::Countries::MAPPING.keys - country_codes_stored_on_degrees
+
+    expect(uk_codes.map { |code| country_stored_for(code) }).to all(be_nil)
+  end
+
+  it "maps country to the label the UI writes" do
+    ui_labels = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all.map(&:name).compact.uniq
+    codes = country_codes_stored_on_degrees
+
+    divergences = ui_labels.each_with_object([]) do |ui_label, out|
+      code = ReferenceData::COUNTRIES.hesa_code_for(ui_label)
+      next unless codes.include?(code)
+
+      actual = country_stored_for(code)
+      out << "#{code}: #{actual.inspect} != #{ui_label.inspect}" if actual != ui_label
+    end
+    expect(divergences).to be_empty, divergences.join("\n")
+  end
+
+  it "maps every country code to a label that serializes back to the same code" do
+    divergences = country_codes_stored_on_degrees.each_with_object([]) do |code, out|
+      stored = country_stored_for(code)
+      resolved = ReferenceData::COUNTRIES.hesa_code_for(stored)
+      out << "#{code}: stored #{stored.inspect}, which serializes back as #{resolved.inspect}" if resolved != code
+    end
+    expect(divergences).to be_empty, divergences.join("\n")
   end
 
   it "remaps Institute of Education to UCL the same as the gem" do


### PR DESCRIPTION
### Context

[9681-replace-hesa-codesets-in-serializers-with-yaml-reference-data-implementation](https://trello.com/c/QeZneXoG/9681-replace-hesa-codesets-in-serializers-with-yaml-reference-data-implementation)

Replaces `Hesa::CodeSets` and gem lookups in the `v2026.1` serializers with
`config/reference_data/*.yml`.

### Changes proposed in this pull request

- Adds `hesa_code_for` to `ReferenceData::Type`. A resolver that handles
  `display_name`, `name/id` and `aliases`, since the DB holds all three spellings
- Swaps serialiser lookups to use it (degree + trainee)
- Fixes Kosovo, `country.yml` had the label on `XK`, which is HESA's
  "United Kingdom, not otherwise specified". Kosovo is `QO`
- API now stores the UI's country spelling. `"BO"` saves as `"Bolivia"`,
  not `"Bolivia [Bolivia, Plurinational State of]"`
- Accepts legacy country labels on update to support existing records

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
