### PR TITLE
[9717] - AY specified in RoTP provider checker

### DIFF
--- a/app/jobs/rotp/check_providers_job.rb
+++ b/app/jobs/rotp/check_providers_job.rb
@@ -7,13 +7,13 @@ module Rotp
     MAX_LISTED = 10
 
     def perform
-      return false unless Rails.env.production?
+      return false unless Rails.env.production? || Rails.env.productiondata?
 
       checker = Rotp::ProviderChecker.new
       download_url = generate_csv_download_url(checker)
 
       TeamsNotifierService.call(
-        title: "RoTP Provider Checker Results [#{Rails.env}]",
+        title: "RoTP Provider Checker Results for #{Settings.current_recruitment_cycle_year} [#{Rails.env}]",
         message: build_message(checker, download_url:),
         icon_emoji: checker.any_discrepancies? ? "🚨" : "✅",
       )

--- a/app/lib/rotp/providers.rb
+++ b/app/lib/rotp/providers.rb
@@ -3,7 +3,7 @@
 module Rotp
   class Providers
     def self.list
-      response = Client.get(path)
+      response = Client.get(path, query: { academic_year: Settings.current_recruitment_cycle_year })
       response.parsed_response["data"]
     end
 

--- a/spec/jobs/rotp/check_providers_job_spec.rb
+++ b/spec/jobs/rotp/check_providers_job_spec.rb
@@ -67,7 +67,7 @@ module Rotp
       it "sends a clean report to Teams with a success icon" do
         described_class.perform_now
         expect(TeamsNotifierService).to have_received(:call).with(
-          title: include("RoTP Provider Checker Results"),
+          title: "RoTP Provider Checker Results for #{Settings.current_recruitment_cycle_year} [test]",
           message: include(
             "Matched: 2",
             "In RoTP but not Register: 0",
@@ -111,7 +111,7 @@ module Rotp
       it "includes discrepancy details and an alert icon" do
         described_class.perform_now
         expect(TeamsNotifierService).to have_received(:call).with(
-          title: include("RoTP Provider Checker Results"),
+          title: "RoTP Provider Checker Results for #{Settings.current_recruitment_cycle_year} [test]",
           message: include(
             "In RoTP but not Register: 1",
             "Unknown University (Z99)",
@@ -123,9 +123,20 @@ module Rotp
       end
     end
 
-    context "when not in production" do
+    context "when in productiondata" do
       before do
-        allow(Rails.env).to receive(:production?).and_return(false)
+        allow(Rails.env).to receive_messages(production?: false, productiondata?: true)
+      end
+
+      it "runs the checker" do
+        described_class.perform_now
+        expect(TeamsNotifierService).to have_received(:call)
+      end
+    end
+
+    context "when not in production or productiondata" do
+      before do
+        allow(Rails.env).to receive_messages(production?: false, productiondata?: false)
       end
 
       it "does not run" do

--- a/spec/lib/rotp/providers_spec.rb
+++ b/spec/lib/rotp/providers_spec.rb
@@ -20,7 +20,10 @@ module Rotp
 
       it "GETs the providers index and returns the data array" do
         expect(described_class.list).to eq(payload["data"])
-        expect(Client).to have_received(:get).with(described_class.path)
+        expect(Client).to have_received(:get).with(
+          described_class.path,
+          query: { academic_year: Settings.current_recruitment_cycle_year },
+        )
       end
     end
   end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/hixCOKM9/9717-onboarding-rotp-api-sync-with-rotp-based-on-ay-setting)

Register trainee teachers is the early adopter of the RoTP API. We want to incrementally integrate with RoTP in the Register service.

We want to be able to run the checker on `productiondata` for the next academic cycle.

### Changes proposed in this pull request

Passes Academic Year to the RoTP api call

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
