### PR TITLE
2855 - Adds review app deletion workflow

### DIFF
--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -1,0 +1,117 @@
+name: Reconcile review apps on AKS
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only display stale review apps; do not delete"
+        required: true
+        default: true
+        type: boolean
+  schedule:
+    - cron: "0 08 * * 0"
+
+permissions:
+  id-token: write
+  pull-requests: write
+  contents: read
+
+env:
+  GLOBAL_CONFIG_PATH: global_config
+  TF_VARS_PATH: terraform/aks/workspace-variables
+  TERRAFORM_BASE: terraform/aks
+  TF_FILE: provider.tf
+  SERVICE_NAME: register
+  RESOURCE_GROUP_NAME: s189t01-rtt-rv-rg
+  STORAGE_ACCOUNT_NAME: s189t01rtttfstatervsa
+  CONTAINER_NAME: rtt-tfstate
+
+jobs:
+  display-review-apps-to-remove:
+    name: Reconcile review apps
+    runs-on: ubuntu-latest
+
+    environment: review
+
+    outputs:
+      stale_prs: ${{ steps.reconcile.outputs.stale_prs }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile review apps
+        id: reconcile
+        uses: DFE-Digital/github-actions/review-app-reconcile@master
+        with:
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          resource-group-name: ${{ env.RESOURCE_GROUP_NAME }}
+          storage-account-name: ${{ env.STORAGE_ACCOUNT_NAME }}
+          terraform-base: ${{ env.TERRAFORM_BASE }}
+          service-name: ${{ env.SERVICE_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-repo: ${{ github.repository }}
+          tf-vars-path: ${{ env.TF_VARS_PATH }}
+          global-config-path: ${{ env.GLOBAL_CONFIG_PATH }}
+
+  delete-review-apps-after-reconcile:
+    name: Delete review app ${{ matrix.pr_number }} after reconcile
+    needs: display-review-apps-to-remove
+    runs-on: ubuntu-latest
+    environment: review
+
+    if: >
+      (
+        github.event_name == 'schedule' ||
+        github.event.inputs.dry_run == 'false'
+      ) &&
+      needs.display-review-apps-to-remove.outputs.stale_prs != '[]'
+
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        pr_number: ${{ fromJson(needs.display-review-apps-to-remove.outputs.stale_prs) }}
+
+    concurrency: deploy_review_${{ matrix.pr_number }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set APP_NAME
+        id: set_env_var
+        shell: bash
+        run: |
+          echo "APP_NAME=pr-${{ matrix.pr_number }}" >> $GITHUB_ENV
+      
+      - name: Set Airbyte
+        if: (contains(github.event.pull_request.labels.*.name, 'airbyte'))
+        run: |
+          echo "TF_VAR_pg_airbyte_enabled=true" >> $GITHUB_ENV
+          echo "TF_VAR_airbyte_enabled=true" >> $GITHUB_ENV
+          echo "TF_VAR_connection_status=active" >> $GITHUB_ENV
+
+      - name: Delete stale review app
+        uses: DFE-Digital/github-actions/delete-review-app@master
+        env:
+          PULL_REQUEST_NUMBER: ${{ matrix.pr_number }}
+        with:
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          gcp-project-id: rugged-abacus-218110
+          gcp-wip: projects/712009772377/locations/global/workloadIdentityPools/register-trainee-teachers/providers/register-trainee-teachers
+          pr-number: ${{ matrix.pr_number }}
+          resource-group-name: ${{ env.RESOURCE_GROUP_NAME }}
+          storage-account-name: ${{ env.STORAGE_ACCOUNT_NAME }}
+          container-name: ${{ env.CONTAINER_NAME }}
+          tf-state-file: pr-${{ matrix.pr_number }}.tfstate
+          terraform-base: ${{ env.TERRAFORM_BASE }}
+          tf-file: ${{ env.TF_FILE }}


### PR DESCRIPTION
## Context

We get quite a few rogue review apps - i.e., the PR has been merged or closed, but the review app wasn’t deleted.

There are various reasons this can occur, but we now require a workflow that will check for rogue review apps and delete them on a scheduled basis. We require it to be run every Sunday.

## Changes proposed in this pull request

A workflow has been added that is set to run every Sunday at 8am. During this period it checks for stale review apps and deletes them. It can also be used to list any existing review apps without deleting by checking the dry run checkbox when run manually.

The code can be found here: [Review app reconcile](https://github.com/DFE-Digital/register-trainee-teachers/blob/2855-add-review-app-cleanup-workflow/.github/workflows/review-app-reconcile.yml)

## Guidance to review

Branch off of my feature branch and add the following code to the **review-app-reconcile.yml** file of your new branch:

```
schedule:
    - cron: "0 08 * * 0"
push:
    branches:
        - <your-branch-name>
```

Once this is pushed up to remote, the workflow will automatically process a dry run, which should complete successfully. My dry run is here for this service: [Dry run](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/30339105033)

Aside from waiting until it fails on Sunday, we can test the deletion of review apps by running the workflow manually and removing the dry run flag. I did not do this as it is during the day and the review apps may still be needed.

There will be no issue if it fails to delete the review apps on Sunday because it should just list any existing review apps, as it would in a manually launched dry run. This will just need revisiting if the automated deletion process should fail for any reason.

## Link to Trello card

[Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally

## Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
