### PR TITLE
[9608] - fix bug in support console user email search

### DIFF
--- a/app/services/user_search.rb
+++ b/app/services/user_search.rb
@@ -16,7 +16,7 @@ class UserSearch
   DEFAULT_LIMIT = Settings.pagination.records_per_page
 
   def initialize(query: nil, limit: DEFAULT_LIMIT, scope: User.all)
-    @query = ReplaceAbbreviation.call(string: StripPunctuation.call(string: query))
+    @raw_query = query&.strip
     @limit = limit
     @scope = scope
   end
@@ -27,12 +27,28 @@ class UserSearch
 
   def specified_users
     users = scope
-    users = users.search(query) if query
+    users = filter_users(users) if raw_query.present?
     users = users.limit(limit) if limit
     users
   end
 
 private
 
-  attr_reader :query, :limit, :scope
+  attr_reader :raw_query, :limit, :scope
+
+  def filter_users(users)
+    if email_query?
+      users.where(email: raw_query.downcase)
+    else
+      users.search(normalised_query)
+    end
+  end
+
+  def email_query?
+    raw_query.include?("@")
+  end
+
+  def normalised_query
+    ReplaceAbbreviation.call(string: StripPunctuation.call(string: raw_query))
+  end
 end

--- a/app/services/user_search.rb
+++ b/app/services/user_search.rb
@@ -38,7 +38,7 @@ private
 
   def filter_users(users)
     if email_query?
-      users.where(email: raw_query.downcase)
+      users.where("email LIKE ?", "#{ActiveRecord::Base.sanitize_sql_like(raw_query.downcase)}%")
     else
       users.search(normalised_query)
     end

--- a/app/services/user_search.rb
+++ b/app/services/user_search.rb
@@ -38,7 +38,7 @@ private
 
   def filter_users(users)
     if email_query?
-      users.where("email LIKE ?", "#{ActiveRecord::Base.sanitize_sql_like(raw_query.downcase)}%")
+      users.where("email LIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(raw_query.downcase)}%")
     else
       users.search(normalised_query)
     end

--- a/spec/features/system_admin/users/search_users_spec.rb
+++ b/spec/features/system_admin/users/search_users_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "Search users" do
   context "as a system admin" do
     let(:user) { create(:user, system_admin: true) }
-    let!(:second_user) { create(:user, system_admin: true) }
+    let!(:second_user) { create(:user, system_admin: true, email: "j.smith@mdx.ac.uk") }
 
     before do
       given_i_am_authenticated(user:)

--- a/spec/services/user_search_spec.rb
+++ b/spec/services/user_search_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UserSearch do
+  describe "#call" do
+    let!(:user) { create(:user, first_name: "Jane", last_name: "Smith", email: "j.smith@mdx.ac.uk") }
+    let!(:other_user) { create(:user, first_name: "Bob", last_name: "Jones", email: "bob.jones@example.com") }
+
+    it "can search by dotted email address" do
+      expect(described_class.call(query: "j.smith@mdx.ac.uk").users).to match([user])
+    end
+
+    it "can search by email address case-insensitively" do
+      expect(described_class.call(query: "J.Smith@MDX.AC.UK").users).to match([user])
+    end
+
+    it "can search by last name" do
+      expect(described_class.call(query: "Smith").users).to match([user])
+    end
+
+    it "can search by first name" do
+      expect(described_class.call(query: "Jane").users).to match([user])
+    end
+
+    context "too many results" do
+      before { create_list(:user, 2, last_name: user.last_name) }
+
+      it "supports truncation" do
+        expect(described_class.call(query: user.last_name, limit: 1).users.size).to eq(1)
+      end
+    end
+
+    context "limit" do
+      it "can set a limit for the returned results" do
+        expect(described_class.call(query: user.email, limit: 10).limit).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/services/user_search_spec.rb
+++ b/spec/services/user_search_spec.rb
@@ -11,6 +11,10 @@ describe UserSearch do
       expect(described_class.call(query: "j.smith@mdx.ac.uk").users).to match([user])
     end
 
+    it "can search by partial email address" do
+      expect(described_class.call(query: "j.smith@mdx").users).to match([user])
+    end
+
     it "can search by email address case-insensitively" do
       expect(described_class.call(query: "J.Smith@MDX.AC.UK").users).to match([user])
     end

--- a/spec/services/user_search_spec.rb
+++ b/spec/services/user_search_spec.rb
@@ -15,6 +15,10 @@ describe UserSearch do
       expect(described_class.call(query: "j.smith@mdx").users).to match([user])
     end
 
+    it "can search by email domain with a leading @" do
+      expect(described_class.call(query: "@mdx.ac.uk").users).to match([user])
+    end
+
     it "can search by email address case-insensitively" do
       expect(described_class.call(query: "J.Smith@MDX.AC.UK").users).to match([user])
     end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/bxAF1CSI/9608-fix-bug-in-support-console-users-page-search)

BAT support have reported that the search on the Users page in the support console (admin area) of Register is not working for some search terms.

[https://www.register-trainee-teachers.service.gov.uk/system-admin/users](https://www.register-trainee-teachers.service.gov.uk/system-admin/users "‌")

### Changes proposed in this pull request

* stops passing every user search query string to the `ReplaceAbbreviation` which strips punctuation making email search fail for emails with multiple punctuation characters (see new specs for example)
* simply looks for `@` to determine if the query should go straight to lookup rather than relying on pg_search index 

### Guidance to review

* can be tested in the review app - ideally with a user with an email with punctuation

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
