### PR TITLE
[9723] Duplicate checks for degrees with legacy country names

### DIFF
--- a/app/lib/reference_data/type.rb
+++ b/app/lib/reference_data/type.rb
@@ -68,12 +68,12 @@ module ReferenceData
       @resolvable_names ||= @values.select { |value| value.hesa_codes.present? }.flat_map(&:labels).uniq
     end
 
+    def labels_for(value)
+      find_by_value(value)&.labels || [value]
+    end
+
     def hesa_code_for(value)
-      return if value.blank?
-
-      entry = @values_by_display_name[value.to_s] || find(value) || @values_by_alias[value.to_s]
-
-      entry&.hesa_codes&.first
+      find_by_value(value)&.hesa_codes&.first
     end
 
     def method_missing(method_name, *args)
@@ -89,6 +89,12 @@ module ReferenceData
     end
 
   private
+
+    def find_by_value(value)
+      return if value.blank?
+
+      @values_by_display_name[value.to_s] || find(value) || @values_by_alias[value.to_s]
+    end
 
     def valid_values_for(year: nil)
       @values.select { |value| value.valid_in?(year:) }

--- a/app/models/api/v2026_1/degree_attributes.rb
+++ b/app/models/api/v2026_1/degree_attributes.rb
@@ -30,6 +30,11 @@ module Api
         attribute attr
       end
 
+      DUPLICATE_REFERENCE_DATA = {
+        "country" => ::ReferenceData::COUNTRIES,
+        "subject" => ::ReferenceData::DEGREE_SUBJECTS,
+      }.freeze
+
       attr_reader :existing_degrees
 
       validates :locale_code, presence: true
@@ -86,9 +91,14 @@ module Api
       end
 
       def duplicates
-        existing_degrees&.where(
-          attributes_for_duplicates,
-        )
+        existing_degrees&.where(attributes_for_duplicate_query)
+      end
+
+      def attributes_for_duplicate_query
+        attributes_for_duplicates.to_h do |attribute, value|
+          reference_data = DUPLICATE_REFERENCE_DATA[attribute]
+          [attribute, reference_data ? reference_data.labels_for(value) : value]
+        end
       end
 
       def attributes_for_duplicates

--- a/spec/requests/api/v2026_1/trainees/put_degrees_spec.rb
+++ b/spec/requests/api/v2026_1/trainees/put_degrees_spec.rb
@@ -275,8 +275,44 @@ describe "`PUT /trainees/:trainee_slug/degrees/:slug` endpoint" do
         }.not_to change(uk_degree, :attributes)
       end
 
-      context "when the stored country label differs from its HESA display name" do
+      context "when the stored country label is the HESA display name" do
+        let(:non_uk_degree) do
+          build(:degree, :non_uk_degree_with_details, country: "Bolivia [Bolivia, Plurinational State of]")
+        end
+
+        it "returns a 409 (conflict) status", openapi: false do
+          put(
+            "/api/v2026.1/trainees/#{trainee.slug}/degrees/#{uk_degree.slug}",
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: {
+              data: degrees_attributes,
+            }.to_json,
+          )
+
+          expect(response).to have_http_status(:conflict)
+        end
+      end
+
+      context "when the stored country label is the service label" do
         let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: "Bolivia") }
+
+        it "returns a 409 (conflict) status", openapi: false do
+          put(
+            "/api/v2026.1/trainees/#{trainee.slug}/degrees/#{uk_degree.slug}",
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: {
+              data: degrees_attributes,
+            }.to_json,
+          )
+
+          expect(response).to have_http_status(:conflict)
+        end
+      end
+
+      context "when the stored subject is a superseded alias" do
+        let(:non_uk_degree) do
+          build(:degree, :non_uk_degree_with_details, subject: "Computing and information technology")
+        end
 
         it "returns a 409 (conflict) status", openapi: false do
           put(


### PR DESCRIPTION
### Context

[9723-duplicate-checks-for-degrees-with-legacy-country-names
](https://trello.com/c/BXjvEWM8/9723-duplicate-checks-for-degrees-with-legacy-country-names)

The same degree subject or country can be stored under more than one name. The UI dropdown offers two names for some subjects like `Computing` and `Computing and information technology` while the API writes `Computing`. Older records written by the `v2025` API stored the long HESA country name `Bolivia [Bolivia, Plurinational State of` instead of `Bolivia` that the UI writes.

### Changes proposed in this pull request

* Refactor `API::V20261::DegreesAttributes#duplicates`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
