### PR TITLE
[9728] - reference data corrected to reference 2026_1

### DIFF
--- a/tech_docs/config/tech-docs.yml
+++ b/tech_docs/config/tech-docs.yml
@@ -44,5 +44,4 @@ github_repo: DFE-Digital/register-trainee-teachers
 github_branch: main/tech_docs
 
 # Versions that show a preview warning banner (not yet available in production)
-preview_versions:
-  - v2026.1
+preview_versions: []

--- a/tech_docs/source/reference-data/index.html.md
+++ b/tech_docs/source/reference-data/index.html.md
@@ -32,11 +32,11 @@ Use reference data whenever you need allowed values for trainees, courses, fundi
 
 ## Current version
 
-* Version: v2025.0
+* Version: v2026.1
 
 ## How to view or download reference data 
 
-You can view or download reference data lists and values using the navigation on the left, under the v2025.0 link. 
+You can view or download reference data lists and values using the navigation on the left, under the v2026.1 link. 
 
 1. Choose the dataset you need. 
 2. Open the list to view or select the link to download the CSV file. 


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/Ck2SOWwI/9728-reference-data-page-tells-providers-to-use-last-years-data-shows-20250-should-be-20261)

The reference data section of the documentation still says the current version is **2025.0**. It should say **2026.1** for the 2026 to 2027 academic year.

This is the page providers land on when they need the allowed values for things like training routes, course subjects and funding methods — the codes they put into CSV uploads and API submissions.

There are two problems on the page:

1. Under the heading **"Current version"** it says _"Version: v2025.0"_.
2. The next paragraph tells providers: _"You can view or download reference data lists and values using the navigation on the left, **under the v2025.0 link**."_

### Changes proposed in this pull request

* corrects the version referenced in the index
* removes 2026_1 from the "preview" list so the preview warning stops showing once we go live (see [this comment](https://github.com/DFE-Digital/register-trainee-teachers/pull/6344#discussion_r3665352580))

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
