### PR TITLE
[9732] - Enable FauAPI for sandbox

### DIFF
--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -30,8 +30,3 @@ features:
 environment:
   name: productiondata
   display_name: Production Data
-
-fauapi:
-  enabled: true
-  base_url: https://pp-apimanagement.education.gov.uk
-

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -38,3 +38,7 @@ api:
 bulk_update:
   add_trainees:
     version: v2026.1
+
+fauapi:
+  enabled: true
+  base_url: https://pp-apimanagement.education.gov.uk


### PR DESCRIPTION
### Context

FauAPI publish jobs are per-environment. productiondata doesnt currently have a worker

### Changes proposed in this pull request

This turns on the FauAPI publish job for the sandbox environment, switches it off for the productiondata environment.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
