### PR TITLE
[9772] Move caching to Solid Cache - Part 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -235,3 +235,5 @@ gem "tzinfo-data", platforms: %i[windows jruby]
 
 # Rails console colours
 gem "colorize"
+
+gem "solid_cache", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -757,6 +757,10 @@ GEM
     solargraph-rails (1.3)
       activesupport
       solargraph (>= 0.48.0)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     sorbet-runtime (0.6.13421)
     sord (7.1.0)
       commander (~> 5.0)
@@ -953,6 +957,7 @@ DEPENDENCIES
   skylight
   solargraph
   solargraph-rails
+  solid_cache (~> 1.0)
   spring
   spring-commands-rspec (~> 1.0)
   spring-watcher-listen (~> 2.1.0)
@@ -1237,6 +1242,7 @@ CHECKSUMS
   smart_properties (1.17.0) sha256=f9323f8122e932341756ddec8e0ac9ec6e238408a7661508be99439ca6d6384b
   solargraph (0.60.3) sha256=3f2252faa27cc628a16a4aac1ba0bc0b06b0250194a8713da0ff42adb20bb19d
   solargraph-rails (1.3) sha256=0af6159f4fe2b716857884a9d758d124eae2bd64c27cb43028792027f2973114
+  solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   sorbet-runtime (0.6.13421) sha256=a19fac29c0f9dde55ab203ddc57c0e6f68d644ef951e09f41a092cc64cce5262
   sord (7.1.0) sha256=e02fd59294da520e50cea80a07fb9bc93db709c552d055871379ae8d8e87601f
   spring (4.7.0) sha256=f81bf6d41f05518ed5d0128ce5c75fb6dd9c6153f158129c8b85c4461ca0b72c

--- a/app/services/concerns/cacheable.rb
+++ b/app/services/concerns/cacheable.rb
@@ -9,13 +9,21 @@ module Cacheable
     class << self
       def get(id, key)
         value = redis.get(cache_key_for(id, key))
-        JSON.parse(value) if value.present?
+
+        if value.present?
+          track_read(key, :redis_hit)
+          JSON.parse(value)
+        else
+          track_read(key, :miss)
+          nil
+        end
       end
 
       def set(id, key, values)
         raise(InvalidKeyError) unless self::FORM_SECTION_KEYS.include?(key)
 
         redis.set(cache_key_for(id, key), values.to_json)
+        track_write(key, :redis)
 
         true
       end
@@ -36,6 +44,14 @@ module Cacheable
 
       def redis
         RedisSetup::RedisClient.current
+      end
+
+      def track_read(key, outcome)
+        Yabeda.form_store.reads_total.increment({ key:, outcome: })
+      end
+
+      def track_write(key, backend)
+        Yabeda.form_store.writes_total.increment({ key:, backend: })
       end
     end
   end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -389,6 +389,13 @@ shared:
     - data
     - created_at
     - updated_at
+  solid_cache_entries:
+    - id
+    - key
+    - value
+    - created_at
+    - key_hash
+    - byte_size
   trainee_disabilities:
     - id
     - trainee_id

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,15 @@
+default: &default
+  store_options:
+    # Cap age of oldest cache entry to fulfill retention policies
+    # max_age: <%= 60.days.to_i %>
+    max_size: <%= 256.megabytes %>
+    namespace: <%= Rails.env %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
-    config.cache_store = :redis_cache_store
+    config.cache_store = :solid_cache_store
     config.public_file_server.headers = { "cache-control" => "public, max-age=#{2.days.to_i}" }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :redis_cache_store, { url: RedisSetup::RedisSetting.new.url }
+  config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -23,4 +23,14 @@ Yabeda.configure do
               per: :request,
               tags: %i[method controller action]
   end
+
+  group :form_store do
+    counter :reads_total,
+            comment: "Total number of form store reads, by outcome",
+            tags: %i[key outcome]
+
+    counter :writes_total,
+            comment: "Total number of form store writes, by backend",
+            tags: %i[key backend]
+  end
 end

--- a/db/migrate/20260814141525_create_solid_cache_entries.rb
+++ b/db/migrate/20260814141525_create_solid_cache_entries.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateSolidCacheEntries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :solid_cache_entries do |t|
+      t.binary :key, limit: 1024, null: false
+      t.binary :value, limit: 536_870_912, null: false
+      t.datetime :created_at, null: false
+      t.integer :key_hash, limit: 8, null: false
+      t.integer :byte_size, limit: 4, null: false
+
+      t.index :byte_size
+      t.index %i[key_hash byte_size]
+      t.index :key_hash, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_164710) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_141525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -782,6 +782,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_164710) do
     t.index ["provider_id", "academic_cycle_id", "sign_off_type"], name: "idx_on_provider_id_academic_cycle_id_sign_off_type_fc3b6ade67", unique: true
     t.index ["provider_id"], name: "index_sign_offs_on_provider_id"
     t.index ["user_id"], name: "index_sign_offs_on_user_id"
+  end
+
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.integer "byte_size", null: false
+    t.datetime "created_at", null: false
+    t.binary "key", null: false
+    t.bigint "key_hash", null: false
+    t.binary "value", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
   create_table "subject_specialisms", force: :cascade do |t|

--- a/spec/services/concerns/cacheable_spec.rb
+++ b/spec/services/concerns/cacheable_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Cacheable do
+  let(:dummy_class) do
+    Class.new { include Cacheable }.tap do |klass|
+      klass.const_set(:FORM_SECTION_KEYS, %i[contact_details])
+    end
+  end
+
+  let(:id) { 1 }
+  let(:key) { :contact_details }
+  let(:values) { { "email" => "trainee@example.com" } }
+
+  describe "#get" do
+    context "when the entry exists in Redis" do
+      before do
+        dummy_class.set(id, key, values)
+      end
+
+      it "returns the stored value" do
+        expect(dummy_class.get(id, key)).to eq(values)
+      end
+
+      it "counts a redis hit" do
+        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :redis_hit })
+
+        dummy_class.get(id, key)
+      end
+    end
+
+    context "when the entry does not exist" do
+      it "returns nil" do
+        expect(dummy_class.get(id, key)).to be_nil
+      end
+
+      it "counts a miss" do
+        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :miss })
+
+        dummy_class.get(id, key)
+      end
+    end
+  end
+
+  describe "#set" do
+    it "counts a write to redis" do
+      expect(Yabeda.form_store.writes_total).to receive(:increment).with({ key: key, backend: :redis })
+
+      dummy_class.set(id, key, values)
+    end
+
+    context "without a valid form section key" do
+      it "raises an error and counts nothing" do
+        expect(Yabeda.form_store.writes_total).not_to receive(:increment)
+
+        expect { dummy_class.set(id, :not_a_form_section, values) }.to raise_error(described_class::InvalidKeyError)
+      end
+    end
+  end
+end

--- a/terraform/aks/workspace-variables/productiondata.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata.tfvars.json
@@ -36,6 +36,5 @@
   "pg_actiongroup_name": "s189p01-rtt-production-ag",
   "pg_actiongroup_rg": "s189p01-rtt-pd-rg",
   "enable_logit": true,
-  "enable_gcp_wif": true,
-  "enable_prometheus_monitoring": true
+  "enable_gcp_wif": true
 }

--- a/terraform/aks/workspace-variables/productiondata.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata.tfvars.json
@@ -36,5 +36,6 @@
   "pg_actiongroup_name": "s189p01-rtt-production-ag",
   "pg_actiongroup_rg": "s189p01-rtt-pd-rg",
   "enable_logit": true,
-  "enable_gcp_wif": true
+  "enable_gcp_wif": true,
+  "enable_prometheus_monitoring": true
 }


### PR DESCRIPTION
### Context

[9772-move-caching-to-solid-cache
](https://trello.com/c/RYLotvL8/9772-move-caching-to-solid-cache)

### Changes proposed in this pull request

* Add `Yabeda` counters in `Cacheable` to track where form store reads are served from
* Install `Solid Cache`  and point `Rails.cache` at `Postgres`
* Create `solid_cache_entries` and add them to `config/analytics_blocklist.yml`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
