### PR TITLE
 [9772] Move caching to solid cache - Part 3 

### DIFF
--- a/app/services/concerns/cacheable.rb
+++ b/app/services/concerns/cacheable.rb
@@ -8,11 +8,18 @@ module Cacheable
   included do
     class << self
       def get(id, key)
-        value = redis.get(cache_key_for(id, key))
+        solid_cache_value = Rails.cache.read(cache_key_for(id, key))
 
-        if value.present?
+        if solid_cache_value.present?
+          track_read(key, :solid_cache_hit)
+          return JSON.parse(solid_cache_value)
+        end
+
+        redis_value = redis.get(cache_key_for(id, key))
+
+        if redis_value.present?
           track_read(key, :redis_hit)
-          JSON.parse(value)
+          JSON.parse(redis_value)
         else
           track_read(key, :miss)
           nil

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :solid_cache_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :none

--- a/spec/services/concerns/cacheable_spec.rb
+++ b/spec/services/concerns/cacheable_spec.rb
@@ -38,12 +38,12 @@ describe Cacheable do
         solid_cache.write(dummy_class.cache_key_for(id, key), solid_cache_values.to_json)
       end
 
-      it "returns the Redis value" do
-        expect(dummy_class.get(id, key)).to eq(redis_values)
+      it "returns the Solid Cache value" do
+        expect(dummy_class.get(id, key)).to eq(solid_cache_values)
       end
 
-      it "counts a redis hit" do
-        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :redis_hit })
+      it "counts a solid cache hit" do
+        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :solid_cache_hit })
 
         dummy_class.get(id, key)
       end
@@ -54,12 +54,28 @@ describe Cacheable do
         solid_cache.write(dummy_class.cache_key_for(id, key), values.to_json)
       end
 
-      it "does not read it, so that a rolling deploy cannot serve stale data" do
-        expect(dummy_class.get(id, key)).to be_nil
+      it "returns the stored value" do
+        expect(dummy_class.get(id, key)).to eq(values)
       end
 
-      it "counts a miss" do
-        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :miss })
+      it "does not read Redis" do
+        expect(dummy_class).not_to receive(:redis)
+
+        dummy_class.get(id, key)
+      end
+    end
+
+    context "when the entry exists in Redis only" do
+      before do
+        dummy_class.redis.set(dummy_class.cache_key_for(id, key), values.to_json)
+      end
+
+      it "falls back to Redis" do
+        expect(dummy_class.get(id, key)).to eq(values)
+      end
+
+      it "counts a redis hit" do
+        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :redis_hit })
 
         dummy_class.get(id, key)
       end


### PR DESCRIPTION
### Context

[9772-move-caching-to-solid-cache
](https://trello.com/c/RYLotvL8/9772-move-caching-to-solid-cache)

### Changes proposed in this pull request

* Read form store entries from Solid Cache
* Use Redis as a fallback
* Switch the test environment to Solid Cache, so specs exercise the read path

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
