### PR TITLE
[9787, 9788, 9789] - Changes to ITT census report guidance page

### DIFF
--- a/app/components/census_banner/view.html.erb
+++ b/app/components/census_banner/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_notification_banner(title_text: "Important") do |banner| %>
   <% banner.with_heading(text: banner_heading_text) %>
 
-  <%= govuk_link_to("Sign off your census trainee data", reports_censuses_path) %> by the <%= deadline_date %> deadline.
+  <%= govuk_link_to("Sign off your ITT census trainee data", reports_censuses_path) %> by the <%= deadline_date %> deadline.
 <% end %>

--- a/app/components/performance_profile_banner/view.html.erb
+++ b/app/components/performance_profile_banner/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_notification_banner(title_text: "Important") do |banner| %>
   <% banner.with_heading(text: banner_heading_text) %>
 
-  <%= govuk_link_to("Sign off your performance profile", reports_performance_profiles_path) %> by the <%= deadline_date %> deadline.
+  <%= govuk_link_to("Sign off your ITT performance profile", reports_performance_profiles_path) %> by the <%= deadline_date %> deadline.
 <% end %>

--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -47,7 +47,7 @@ class GuidanceController < ApplicationController
       @previous_academic_cycle_label = previous_academic_cycle.label
       @academic_cycle_for_filter = previous_academic_cycle.start_year
       @sign_off_deadline = performance_profile_sign_off_date.to_fs(:govuk)
-      @fix_mistakes_email_link = "mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in #{@previous_academic_cycle_label} data for performance profiles publication"
+      @fix_mistakes_email_link = "mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in #{@previous_academic_cycle_label} data for ITT performance profiles publication"
       render(layout: "application")
     when :census_period, :outside_period
       render(:performance_profiles_outside, layout: "application")

--- a/app/views/bulk_update/bulk_updates/index.html.erb
+++ b/app/views/bulk_update/bulk_updates/index.html.erb
@@ -60,7 +60,7 @@
       </p>
 
       <p class="govuk-body">
-        You’ll be asked to include placement data as part of performance profile sign off for registered trainees with a course outcome in the previous academic year.
+        You’ll be asked to include placement data as part of ITT performance profile sign off for registered trainees with a course outcome in the previous academic year.
       </p>
     <% end %>
 

--- a/app/views/bulk_update/placements/new.html.erb
+++ b/app/views/bulk_update/placements/new.html.erb
@@ -15,7 +15,7 @@
       </h1>
 
       <p class="govuk-body">
-        You’ll be asked to include placement data as part of performance profile sign off for registered trainees with a course outcome in the previous academic year.
+        You’ll be asked to include placement data as part of ITT performance profile sign off for registered trainees with a course outcome in the previous academic year.
       </p>
 
       <p class="govuk-body">

--- a/app/views/guidance/_census_sign_off_inside.html.erb
+++ b/app/views/guidance/_census_sign_off_inside.html.erb
@@ -11,14 +11,14 @@
 
         <p class="govuk-body">If you’re in a partnership, you’re responsible for ensuring your training partners’ trainee data is accurate and signed off by the deadline.</p>
 
-        <h2 class="govuk-heading-m">Why the census sign-off is important</h2>
+        <h2 class="govuk-heading-m">Why the ITT census sign-off is important</h2>
         <p class="govuk-body">If your teacher trainee data is accurate and signed off by 31 October <%= @current_year_start %>, it will help you:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>receive the correct amount of funding owed to you</li>
             <li>allocate the correct financial support to your trainees when they start their course, if applicable</li>
         </ul>
-        <p class="govuk-body">Your accurate census data also helps the DfE understand new entrants to teacher training in England for the <%= @current_year_label %> academic year, and to inform future policy.</p>
-        <p class="govuk-body">If you do not sign off your data by 31 October, your organisation’s data may not be included in the census publication.</p>
+        <p class="govuk-body">Your accurate ITT census data also helps the DfE understand new entrants to teacher training in England for the <%= @current_year_label %> academic year, and to inform future policy.</p>
+        <p class="govuk-body">If you do not sign off your data by 31 October, your organisation’s data may not be included in the ITT census publication.</p>
 
         <h2 class="govuk-heading-m">Checking your trainee data in the ‘Reports’ section of Register</h2>
         <p class="govuk-body">Register all your new trainees for the <%= @current_year_label %> academic year if you have not done so already. You can find out how to register trainees under the ‘Registering trainees’ section in the guidance.</p>

--- a/app/views/guidance/_census_sign_off_outside.html.erb
+++ b/app/views/guidance/_census_sign_off_outside.html.erb
@@ -8,16 +8,16 @@
 
         <p class="govuk-body">If you’re in a partnership, you’re responsible for ensuring your training partners’ trainee data is accurate and signed off by the deadline.</p>
 
-        <h2 class="govuk-heading-m">Why the census sign-off is important</h2>
+        <h2 class="govuk-heading-m">Why the ITT census sign-off is important</h2>
 
         <p class="govuk-body">If your teacher trainee data is accurate and signed off by the deadline, it will help you:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>receive the correct amount of funding owed to you</li>
             <li>allocate the correct financial support to your trainees when they start their course, if applicable</li>
         </ul>
-        <p class="govuk-body">Your accurate census data also helps the DfE understand new entrants to teacher training in England for each academic year, and to inform future policy.</p>
+        <p class="govuk-body">Your accurate ITT census data also helps the DfE understand new entrants to teacher training in England for each academic year, and to inform future policy.</p>
 
-        <p class="govuk-body">If you do not sign off your data by the deadline, your organisation’s data may not be included in the census publication.</p>
+        <p class="govuk-body">If you do not sign off your data by the deadline, your organisation’s data may not be included in the ITT census publication.</p>
 
         <h2 class="govuk-heading-m">Checking your trainee data in the ‘Reports’ section of Register</h2>
 

--- a/app/views/guidance/about_register_trainee_teachers.md
+++ b/app/views/guidance/about_register_trainee_teachers.md
@@ -62,9 +62,9 @@ When you sign into Register you will see ‘Draft trainees’ and ‘Registered 
 
 ## How trainee data is used in the initial teacher training (ITT) census publication
 
-The DfE publishes a census each academic year of trainee teachers who are starting their training. This is to get an idea of who could be entering the teaching workforce and to plan teacher recruitment activities.
+The DfE publishes an ITT census each academic year of trainee teachers who are starting their training. This is to get an idea of who could be entering the teaching workforce and to plan teacher recruitment activities.
 
-Once you register your new trainees, your trainee data gets analysed and filtered for the ITT census publication. Not all your new trainees will be included in the ITT census publication. To understand what data will be used read the [Initial Teacher Training Census methodology](https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology).
+Once you register your new trainees, your trainee data gets analysed and filtered for the ITT census publication. Not all of your new trainees will be included in the ITT census publication. To understand what data will be used read the [Initial Teacher Training Census methodology](https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology).
 
 The ITT census happens in September and October every year. We‘ll notify you about the exact dates each year.
 

--- a/app/views/guidance/bulk_upload_placement_data.html.erb
+++ b/app/views/guidance/bulk_upload_placement_data.html.erb
@@ -35,7 +35,7 @@
 
     <h2 class="govuk-heading-m">2. Download a CSV file listing trainees with missing placement data</h2>
 
-    <p class="govuk-body-m">For the purposes of the performance profile sign off deadline in February each academic year, the CSV file will only include data for all trainees who:</p>
+    <p class="govuk-body-m">For the purposes of the ITT performance profile sign off deadline in February each academic year, the CSV file will only include data for all trainees who:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>gained QTS or EYTS in the most recent academic year</li>

--- a/app/views/guidance/census_sign_off.md
+++ b/app/views/guidance/census_sign_off.md
@@ -7,16 +7,16 @@ Each year, as an accredited provider, you need to sign off your teacher trainee 
 
 If you’re in a partnership, you’re responsible for ensuring your training partners’ trainee data is accurate and signed off by the deadline.
 
-## Why the census sign-off is important
+## Why the ITT census sign-off is important
 
 If your teacher trainee data is accurate and signed off by 31 October 2023, it will help you:
 
 * receive the correct amount of funding owed to you
 * allocate the correct financial support to your trainees when they start their course, if applicable
 
-Your accurate census data also helps the DfE understand new entrants to teacher training in England for the 2023 to 2024 academic year, and to inform future policy.
+Your accurate ITT census data also helps the DfE understand new entrants to teacher training in England for the 2023 to 2024 academic year, and to inform future policy.
 
-If you do not sign off your data by 31 October, your organisation’s data may not be included in the census publication.
+If you do not sign off your data by 31 October, your organisation’s data may not be included in the ITT census publication.
 
 ## Checking your trainee data in the ‘Reports’ section of Register
 

--- a/app/views/guidance/dates_and_deadlines.html.erb
+++ b/app/views/guidance/dates_and_deadlines.html.erb
@@ -21,10 +21,10 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <a class="govuk-link" href="/guidance/census-sign-off">Census sign off process</a>
+        <a class="govuk-link" href="/guidance/census-sign-off">ITT census sign off process</a>
       </li>
       <li>
-        <a class="govuk-link" href="/guidance/performance-profiles">Performance profile sign off process</a>
+        <a class="govuk-link" href="/guidance/performance-profiles">ITT performance profile sign off process</a>
       </li>
     </ul>
 

--- a/app/views/guidance/manage_placements.html.erb
+++ b/app/views/guidance/manage_placements.html.erb
@@ -17,7 +17,7 @@
 
     <p class="govuk-body-m">You do not need to provide duration of time spent at each placement.</p>
 
-    <h2 class="govuk-heading-m">How to include placement data as part of the performance profiles sign off period</h2>
+    <h2 class="govuk-heading-m">How to include placement data as part of the ITT performance profiles sign off period</h2>
 
     <p class="govuk-body-m">A minimum of 2 placements is required for each trainee who has gained QTS or EYTS in each academic year.</p>
 

--- a/app/views/guidance/performance_profiles.html.erb
+++ b/app/views/guidance/performance_profiles.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Sign off your list of trainees from #{@previous_academic_cycle_label} for the performance profiles publication") %>
+<%= render PageTitle::View.new(text: "Sign off your list of trainees from #{@previous_academic_cycle_label} for the ITT performance profiles publication") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">
-      Signing off trainees for the performance profiles publication
+      Signing off trainees for the ITT performance profiles publication
     </h1>
 
     <p class="govuk-body">
@@ -18,7 +18,7 @@
       academic year in Register teacher trainees (Register).
     </p>
     <p class="govuk-body">
-      You’ll be asked to sign off performance profile data for registered trainees
+      You’ll be asked to sign off ITT performance profile data for registered trainees
       with a course outcome in the <%= @previous_academic_cycle_label %> academic year, if you were an
       accredited provider at this time.
     </p>
@@ -27,7 +27,7 @@
       teacher status (QTS) or who have withdrawn.
     </p>
     <p class="govuk-body">
-      This performance profile sign off period’s deadline is <%= @sign_off_deadline %>.
+      This ITT performance profile sign off period’s deadline is <%= @sign_off_deadline %>.
     </p>
 
     <h2 class="govuk-heading-m">Find your trainee data</h2>

--- a/app/views/guidance/performance_profiles_outside.html.erb
+++ b/app/views/guidance/performance_profiles_outside.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Signing off your list of trainees for the performance profiles publication") %>
+<%= render PageTitle::View.new(text: "Signing off your list of trainees for the ITT performance profiles publication") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l" id="signing-off-your-list-of-trainees-for-the-performance-profiles-publication">
-      Signing off your list of trainees for the performance profiles publication
+      Signing off your list of trainees for the ITT performance profiles publication
     </h1>
 
     <p class="govuk-body">

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -109,7 +109,7 @@
       </li>
       <li>
         <%= govuk_link_to(
-              "#{@performance_sign_off} off your list of trainees for the performance profiles publication",
+              "#{@performance_sign_off} off your list of trainees for the ITT performance profiles publication",
               performance_profiles_guidance_path,
             ) %>
       </li>

--- a/app/views/reports/_census_period.html.erb
+++ b/app/views/reports/_census_period.html.erb
@@ -1,11 +1,11 @@
 <h2 class="govuk-heading-m">
-  Census Sign Off
+  ITT census sign off
 </h2>
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
       <%= govuk_link_to "Trainees with their academic start year in #{@current_academic_cycle_label} report", reports_censuses_path, class: "new-trainee-data" %>
-      - census sign off your new trainee data for the <%= @current_academic_cycle_label %> academic year.
+      - ITT census sign off your new trainee data for the <%= @current_academic_cycle_label %> academic year.
     </p>
   </li>
 </ul>

--- a/app/views/reports/_outside_period.html.erb
+++ b/app/views/reports/_outside_period.html.erb
@@ -4,13 +4,13 @@
 <ul class="govuk-list govuk-list--bullet">
   <li>
     <%= govuk_link_to(
-          "#{@census_sign_off} census data",
+          "#{@census_sign_off} ITT census data",
           census_sign_off_guidance_path,
           ) %>
   </li>
   <li>
     <%= govuk_link_to(
-          "#{@performance_sign_off} performance profiles data",
+          "#{@performance_sign_off} ITT performance profiles data",
           performance_profiles_guidance_path,
           ) %>
   </li>

--- a/app/views/reports/_performance_period.html.erb
+++ b/app/views/reports/_performance_period.html.erb
@@ -1,10 +1,10 @@
 <h2 class="govuk-heading-m">
-  Performance Profile
+  ITT performance profiles
 </h2>
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
-      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year report", reports_performance_profiles_path, class: "performance-profiles" %> - for performance profiles sign off with a deadline of <%= @previous_academic_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) %>.
+      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year report", reports_performance_profiles_path, class: "performance-profiles" %> - for ITT performance profiles sign off with a deadline of <%= @previous_academic_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) %>.
     </p>
   </li>
 </ul>

--- a/app/views/reports/_system_admin_with_no_associated_provider.html.erb
+++ b/app/views/reports/_system_admin_with_no_associated_provider.html.erb
@@ -8,13 +8,13 @@
 <ul class="govuk-list govuk-list--bullet">
   <li>
     <%= govuk_link_to(
-          "#{@census_sign_off} census data",
+          "#{@census_sign_off} ITT census data",
           census_sign_off_guidance_path,
           ) %>
   </li>
   <li>
     <%= govuk_link_to(
-          "#{@performance_sign_off} performance profiles data",
+          "#{@performance_sign_off} ITT performance profiles data",
           performance_profiles_guidance_path,
           ) %>
   </li>

--- a/app/views/reports/censuses/confirmation.html.erb
+++ b/app/views/reports/censuses/confirmation.html.erb
@@ -1,4 +1,4 @@
-<% page_title = "Census sign off submitted" %>
+<% page_title = "ITT census sign off submitted" %>
 <%= render PageTitle::View.new(text: page_title) %>
 
 <%= content_for(:breadcrumbs) do %>
@@ -13,7 +13,7 @@
     <%= govuk_panel(title_text: page_title, classes: "trn-submission-success-panel govuk-!-margin-bottom-6") %>
 
     <h1 class="govuk-body">
-      Census sign off completed.
+      ITT census sign off completed.
     </h1>
 
     <p class="govuk-body">

--- a/app/views/reports/censuses/index.html.erb
+++ b/app/views/reports/censuses/index.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">Export new trainee data for ITT census sign off for the <%= @current_academic_cycle_label %> academic year</h1>
-    <p class="govuk-body">This export will show the new trainee data you’ve provided to the DfE for trainees who’ve started their initial teacher training (ITT) in the <%= @current_academic_cycle_label %> academic year, and have a trainee start date on or before the second Wednesday of October (sometimes called the ITT census date).</p>
+    <p class="govuk-body">This export will show the new trainee data you’ve provided to the DfE for trainees who’ve started their initial teacher training (ITT) in the <%= @current_academic_cycle_label %> academic year, and have a trainee start date on or before the second Wednesday of October (sometimes called the census date).</p>
     <p class="govuk-body">For the <%= @current_academic_cycle_label %> academic year, the ITT census date is Wednesday <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>.
     </p>
     <h2 class="govuk-heading-m">What you must do to sign off your new trainee data</h2>

--- a/app/views/reports/censuses/index.html.erb
+++ b/app/views/reports/censuses/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Export new trainee data for census sign off for the #{@current_academic_cycle_label} academic year") %>
+<%= render PageTitle::View.new(text: "Export new trainee data for ITT census sign off for the #{@current_academic_cycle_label} academic year") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">Export new trainee data for census sign off for the <%= @current_academic_cycle_label %> academic year</h1>
+    <h1 class="govuk-heading-l">Export new trainee data for ITT census sign off for the <%= @current_academic_cycle_label %> academic year</h1>
     <p class="govuk-body">This export will show the new trainee data you’ve provided to the DfE for trainees who’ve started their initial teacher training (ITT) in the <%= @current_academic_cycle_label %> academic year, and have a trainee start date on or before the second Wednesday of October (sometimes called the ITT census date).</p>
     <p class="govuk-body">For the <%= @current_academic_cycle_label %> academic year, the ITT census date is Wednesday <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>.
     </p>
@@ -18,10 +18,10 @@
     <p class="govuk-body">You must sign off your data by <%= @current_academic_cycle.itt_census_end_date.strftime(Date::DATE_FORMATS[:govuk]) %>. Not submitting and signing off new trainee data by this date will mean that we (the DfE) do not have accurate data on your trainees and they may be excluded from the ITT census publication</p>
     <h2 class="govuk-heading-m">How new trainee data relates to the ITT census publication</h2>
     <p class="govuk-body">After signing off your new trainee data, it gets analysed and filtered for the ITT census publication.</p>
-    <p class="govuk-body">Not all your new trainees in this export will be included in the ITT census publication. To understand what data will be used, read the The ITT census is put together using the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">Initial Teacher Training Census methodology (opens in a new tab)</a>.</p>
+    <p class="govuk-body">Not all of your new trainees in this export will be included in the ITT census publication. To understand what data will be used, read how the ITT census is put together using the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">Initial Teacher Training Census methodology (opens in a new tab)</a>.</p>
     <h2 class="govuk-heading-m">New trainees without a start date</h2>
     <p class="govuk-body">Any new trainee who has a course start date on or before <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>, but does not have a trainee start date, will be included in this export.</p>
-    <p class="govuk-body">If a new trainee starts their course on or before <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>, you should add their trainee start date as soon as possible (if you’re registering trainees manually in the Register service). Not adding this means we will not know if the trainee has started their course, which could affect funding payments, if the trainee is eligible for funding.</p>
+    <p class="govuk-body">If a new trainee starts their course on or before <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>, you should add their trainee start date as soon as possible. Not adding this means we will not know if the trainee has started their course, which could affect funding payments, if the trainee is eligible for funding.</p>
     <h2 class="govuk-heading-m">About this export</h2>
     <p class="govuk-body">This export includes all trainees:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -47,6 +47,6 @@
     <h2 class="govuk-heading-m">Sign off your new trainee data</h2>
     <p class="govuk-body">If you have checked your data.</p>
 
-    <%= govuk_button_link_to("Continue to census sign off", new_reports_censuse_path)%>
+    <%= govuk_button_link_to("Continue to ITT census sign off", new_reports_censuse_path)%>
   </div>
 </div>

--- a/app/views/reports/censuses/index.html.erb
+++ b/app/views/reports/censuses/index.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">Export new trainee data for ITT census sign off for the <%= @current_academic_cycle_label %> academic year</h1>
     <p class="govuk-body">This export will show the new trainee data you’ve provided to the DfE for trainees who’ve started their initial teacher training (ITT) in the <%= @current_academic_cycle_label %> academic year, and have a trainee start date on or before the second Wednesday of October (sometimes called the census date).</p>
-    <p class="govuk-body">For the <%= @current_academic_cycle_label %> academic year, the ITT census date is Wednesday <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>.
+    <p class="govuk-body">For the <%= @current_academic_cycle_label %> academic year, the census date is Wednesday <%= @census_date.strftime(Date::DATE_FORMATS[:govuk]) %>.
     </p>
     <h2 class="govuk-heading-m">What you must do to sign off your new trainee data</h2>
     <p class="govuk-body">Use this export to check you’ve provided accurate data for all your new trainees. You should check for any errors or missing trainees.</p>

--- a/app/views/reports/censuses/new.html.erb
+++ b/app/views/reports/censuses/new.html.erb
@@ -1,4 +1,4 @@
-<% page_title = "Census sign off your organisation’s new trainee data for the #{@current_academic_cycle_label} academic year" %>
+<% page_title = "ITT census sign off your organisation’s new trainee data for the #{@current_academic_cycle_label} academic year" %>
 <%= render PageTitle::View.new(text: page_title, has_errors: @census_sign_off_form.errors.any?) %>
 
 <%= content_for(:breadcrumbs) do %>
@@ -21,7 +21,7 @@
         Once you’ve checked your data is correct, you can sign off on behalf of your organisation.
       </p>
 
-      <%= govuk_summary_card(title: "Census sign off information") do |card|
+      <%= govuk_summary_card(title: "ITT census sign off information") do |card|
             card.with_summary_list(rows: [
             { key: { text: "Provider name" }, value: { text: current_user.organisation.name } },
             { key: { text: "UKPRN" }, value: { text: @current_user.organisation.ukprn } },
@@ -33,7 +33,7 @@
         <%= f.govuk_check_box(:sign_off, "confirmed", "not_confirmed", multiple: false, link_errors: true, label: { text: "Yes, the trainee data is correct to the best of my knowledge" }) %>
       <% end %>
 
-      <%= f.govuk_submit("Sign off census") %>
+      <%= f.govuk_submit("Sign off ITT census") %>
     </div>
   </div>
 <%- end -%>

--- a/app/views/reports/censuses/new.html.erb
+++ b/app/views/reports/censuses/new.html.erb
@@ -1,4 +1,4 @@
-<% page_title = "ITT census sign off your organisation’s new trainee data for the #{@current_academic_cycle_label} academic year" %>
+<% page_title = "Sign off your organisation’s new trainee data for the #{@current_academic_cycle_label} academic year" %>
 <%= render PageTitle::View.new(text: page_title, has_errors: @census_sign_off_form.errors.any?) %>
 
 <%= content_for(:breadcrumbs) do %>

--- a/app/views/reports/performance_profiles/confirmation.html.erb
+++ b/app/views/reports/performance_profiles/confirmation.html.erb
@@ -1,4 +1,4 @@
-<% page_title = "Performance profile submitted" %>
+<% page_title = "ITT performance profile submitted" %>
 <%= render PageTitle::View.new(text: page_title) %>
 
 <%= content_for(:breadcrumbs) do %>
@@ -13,7 +13,7 @@
     <%= govuk_panel(title_text: page_title, classes: "trn-submission-success-panel govuk-!-margin-bottom-6") %>
 
     <h1 class="govuk-body">
-      Performance profile sign off completed.
+      ITT performance profile sign off completed.
     </h1>
 
     <p class="govuk-body">
@@ -23,7 +23,7 @@
     <h2 class="govuk-heading-m">What happens next</h2>
 
     <p class="govuk-body">
-      We’ll include this trainee data in the next performance profiles publication on GOV.UK.
+      We’ll include this trainee data in the next ITT performance profiles publication on GOV.UK.
     </p>
 
     <p class="govuk-body">

--- a/app/views/reports/performance_profiles/index.html.erb
+++ b/app/views/reports/performance_profiles/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Export trainee data for the #{@previous_academic_cycle_label} performance profile sign off") %>
+<%= render PageTitle::View.new(text: "Export trainee data for the #{@previous_academic_cycle_label} ITT performance profile sign off") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -10,10 +10,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">
-      Export trainee data for the <%= @previous_academic_cycle_label %> performance profile sign off
+      Export trainee data for the <%= @previous_academic_cycle_label %> ITT performance profile sign off
     </h1>
     <p class="govuk-body">
-      Signing off your list of trainees for the performance profiles publication deadline is <%= @previous_academic_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) %>.
+      Signing off your list of trainees for the ITT performance profiles publication deadline is <%= @previous_academic_cycle.end_date_of_performance_profile.strftime(Date::DATE_FORMATS[:govuk]) %>.
     </p>
 
     <p class="govuk-body">
@@ -63,7 +63,7 @@
     </p>
 
     <p class="govuk-body">
-      Find out more on <%= govuk_link_to("Signing off your list of trainees for the performance profiles publication", performance_profiles_guidance_path) %> and <%= govuk_link_to("managing your trainee placement data", manage_placements_guidance_path) %>.
+      Find out more on <%= govuk_link_to("Signing off your list of trainees for the ITT performance profiles publication", performance_profiles_guidance_path) %> and <%= govuk_link_to("managing your trainee placement data", manage_placements_guidance_path) %>.
     </p>
 
     <h2 class="govuk-heading-m">
@@ -72,6 +72,6 @@
     <p class="govuk-body">
       If you have checked your data.
     </p>
-    <%= govuk_button_link_to("Continue to performance profile sign off", new_reports_performance_profile_path)%>
+    <%= govuk_button_link_to("Continue to ITT performance profile sign off", new_reports_performance_profile_path)%>
   </div>
 </div>

--- a/app/views/reports/performance_profiles/new.html.erb
+++ b/app/views/reports/performance_profiles/new.html.erb
@@ -21,7 +21,7 @@
         Once you’ve checked your data is correct, you can sign off on behalf of your organisation.
       </p>
 
-      <%= govuk_summary_card(title: "Performance profile information") do |card|
+      <%= govuk_summary_card(title: "ITT performance profile information") do |card|
             card.with_summary_list(rows: [
             { key: { text: "Provider name" }, value: { text: current_user.organisation.name } },
             { key: { text: "UKPRN" }, value: { text: @current_user.organisation.ukprn } },
@@ -33,7 +33,7 @@
         <%= f.govuk_check_box(:sign_off, "confirmed", "not_confirmed", multiple: false, link_errors: true, label: { text: "Yes, the trainee data is correct to the best of my knowledge" }) %>
       <% end %>
 
-      <%= f.govuk_submit("Sign off performance profile") %>
+      <%= f.govuk_submit("Sign off ITT performance profile") %>
     </div>
   </div>
 <%- end -%>

--- a/spec/components/census_banner/view_spec.rb
+++ b/spec/components/census_banner/view_spec.rb
@@ -54,7 +54,7 @@ describe CensusBanner::View do
     end
 
     it "renders the link correctly" do
-      expect(@result).to have_link("Sign off your census trainee data", href: "/reports/censuses")
+      expect(@result).to have_link("Sign off your ITT census trainee data", href: "/reports/censuses")
     end
   end
 end

--- a/spec/components/performance_profile_banner/view_spec.rb
+++ b/spec/components/performance_profile_banner/view_spec.rb
@@ -54,7 +54,7 @@ describe PerformanceProfileBanner::View do
     end
 
     it "renders the link correctly" do
-      expect(@result).to have_link("Sign off your performance profile", href: "/reports/performance-profiles")
+      expect(@result).to have_link("Sign off your ITT performance profile", href: "/reports/performance-profiles")
     end
   end
 end

--- a/spec/features/performance_profile_banner_spec.rb
+++ b/spec/features/performance_profile_banner_spec.rb
@@ -34,7 +34,7 @@ feature "performance profile banner" do
         given_i_am_authenticated
         when_i_am_on_the_root_page
         then_i_can_see_the_performance_profile_banner
-        and_i_click_on("Sign off your performance profile")
+        and_i_click_on("Sign off your ITT performance profile")
         and_i_am_on_the_sign_off_your_performance_profile_page
       end
     end

--- a/spec/features/reports/census_spec.rb
+++ b/spec/features/reports/census_spec.rb
@@ -149,7 +149,7 @@ private
   end
 
   def and_i_can_see_the_census_information
-    expect(page).to have_css(".govuk-heading-l", text: "ITT census sign off your organisation’s new trainee data for the #{current_academic_cycle_label} academic year")
+    expect(page).to have_css(".govuk-heading-l", text: "Sign off your organisation’s new trainee data for the #{current_academic_cycle_label} academic year")
 
     expect(page).to have_css(".govuk-summary-card__title", text: "ITT census sign off information")
 

--- a/spec/features/reports/census_spec.rb
+++ b/spec/features/reports/census_spec.rb
@@ -41,15 +41,15 @@ feature "census sign off" do
         given_i_am_authenticated
         and_i_am_on_the_root_page
         and_i_can_see_the_census_banner
-        and_i_click_on("Sign off your census")
+        and_i_click_on("Sign off your ITT census")
         and_i_am_on_the_sign_off_your_census_page
 
-        when_i_click_on("Continue to census sign off")
+        when_i_click_on("Continue to ITT census sign off")
         and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
         and_i_can_see_the_census_information
-        and_i_click_on("Sign off census")
+        and_i_click_on("Sign off ITT census")
         and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
-        and_i_click_on("Sign off census")
+        and_i_click_on("Sign off ITT census")
 
         then_i_am_on_the_census_confirmation_page
         and_the_provider_has_census_signed_off
@@ -61,12 +61,12 @@ feature "census sign off" do
         and_i_click_on("Trainees with their academic start year in #{current_academic_cycle_label} report")
         and_i_am_on_the_sign_off_your_census_page
 
-        when_i_click_on("Continue to census sign off")
+        when_i_click_on("Continue to ITT census sign off")
         and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
         and_i_can_see_the_census_information
         and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
         and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
-        and_i_click_on("Sign off census")
+        and_i_click_on("Sign off ITT census")
 
         then_i_am_on_the_census_confirmation_page
         and_the_provider_has_census_signed_off
@@ -79,12 +79,12 @@ feature "census sign off" do
         and_i_click_on("Trainees with their academic start year in #{current_academic_cycle_label} report")
         and_i_am_on_the_sign_off_your_census_page
 
-        when_i_click_on("Continue to census sign off")
+        when_i_click_on("Continue to ITT census sign off")
         and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
         and_i_can_see_the_census_information
         and_i_am_on_the_itt_census_sign_off_for_the_academic_year_page
         and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
-        and_i_click_on("Sign off census")
+        and_i_click_on("Sign off ITT census")
 
         then_i_am_on_the_census_confirmation_page
         and_the_provider_has_census_signed_off
@@ -149,9 +149,9 @@ private
   end
 
   def and_i_can_see_the_census_information
-    expect(page).to have_css(".govuk-heading-l", text: "Census sign off your organisation’s new trainee data for the #{current_academic_cycle_label} academic year")
+    expect(page).to have_css(".govuk-heading-l", text: "ITT census sign off your organisation’s new trainee data for the #{current_academic_cycle_label} academic year")
 
-    expect(page).to have_css(".govuk-summary-card__title", text: "Census sign off information")
+    expect(page).to have_css(".govuk-summary-card__title", text: "ITT census sign off information")
 
     expect(page).to have_css(".govuk-summary-list__key", text: "Provider name")
     expect(page).to have_css(".govuk-summary-list__value", text: current_user.providers.first.name)

--- a/spec/features/reports/index_spec.rb
+++ b/spec/features/reports/index_spec.rb
@@ -76,14 +76,14 @@ private
 
   def then_i_should_see_the_performance_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
-    expect(reports_page).to have_text("Performance Profile")
-    expect(reports_page).to have_text("Trainees who studied in the #{previous_academic_cycle.label} academic year report - for performance profiles sign off with a deadline of #{performance_profile_sign_off_date}")
+    expect(reports_page).to have_text("ITT performance profiles")
+    expect(reports_page).to have_text("Trainees who studied in the #{previous_academic_cycle.label} academic year report - for ITT performance profiles sign off with a deadline of #{performance_profile_sign_off_date}")
   end
 
   def then_i_should_see_the_census_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
-    expect(reports_page).to have_text("Census Sign Off")
-    expect(reports_page).to have_text("Trainees with their academic start year in #{current_academic_cycle.label} report - census sign off your new trainee data for the #{current_academic_cycle.label} academic year.")
+    expect(reports_page).to have_text("ITT census sign off")
+    expect(reports_page).to have_text("Trainees with their academic start year in #{current_academic_cycle.label} report - ITT census sign off your new trainee data for the #{current_academic_cycle.label} academic year.")
   end
 
   def then_i_should_see_the_outside_period_content

--- a/spec/features/reports/performance_profile_spec.rb
+++ b/spec/features/reports/performance_profile_spec.rb
@@ -41,17 +41,17 @@ feature "performance profile sign off" do
         given_i_am_authenticated
         and_i_am_on_the_root_page
         and_i_can_see_the_performance_profile_banner
-        and_i_click_on("Sign off your performance profile")
+        and_i_click_on("Sign off your ITT performance profile")
         and_i_am_on_the_sign_off_your_performance_profile_page
 
-        when_i_click_on("Continue to performance profile sign off")
+        when_i_click_on("Continue to ITT performance profile sign off")
         and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
         and_i_can_see_the_performance_profile_information
-        and_i_click_on("Sign off performance profile")
+        and_i_click_on("Sign off ITT performance profile")
         and_i_see_there_is_a_problem
         and_i_click_on("Confirm sign off")
         and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
-        and_i_click_on("Sign off performance profile")
+        and_i_click_on("Sign off ITT performance profile")
 
         then_i_am_on_the_performance_profile_confirmation_page
         and_the_provider_has_performance_profile_signed_off
@@ -63,12 +63,12 @@ feature "performance profile sign off" do
         and_i_click_on("Trainees who studied in the #{previous_academic_cycle_label} academic year report")
         and_i_am_on_the_sign_off_your_performance_profile_page
 
-        when_i_click_on("Continue to performance profile sign off")
+        when_i_click_on("Continue to ITT performance profile sign off")
         and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
         and_i_can_see_the_performance_profile_information
         and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
         and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
-        and_i_click_on("Sign off performance profile")
+        and_i_click_on("Sign off ITT performance profile")
 
         then_i_am_on_the_performance_profile_confirmation_page
         and_the_provider_has_performance_profile_signed_off
@@ -81,12 +81,12 @@ feature "performance profile sign off" do
         and_i_click_on("Trainees who studied in the #{previous_academic_cycle_label} academic year report")
         and_i_am_on_the_sign_off_your_performance_profile_page
 
-        when_i_click_on("Continue to performance profile sign off")
+        when_i_click_on("Continue to ITT performance profile sign off")
         and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
         and_i_can_see_the_performance_profile_information
         and_i_am_on_the_itt_performance_profile_sign_off_for_the_academic_year_page
         and_i_check_on("Yes, the trainee data is correct to the best of my knowledge")
-        and_i_click_on("Sign off performance profile")
+        and_i_click_on("Sign off ITT performance profile")
 
         then_i_am_on_the_performance_profile_confirmation_page
         and_the_provider_has_performance_profile_signed_off
@@ -153,7 +153,7 @@ private
   def and_i_can_see_the_performance_profile_information
     expect(page).to have_css(".govuk-heading-l", text: "ITT performance profile sign off for the #{previous_academic_cycle_label} academic year")
 
-    expect(page).to have_css(".govuk-summary-card__title", text: "Performance profile information")
+    expect(page).to have_css(".govuk-summary-card__title", text: "ITT performance profile information")
 
     expect(page).to have_css(".govuk-summary-list__key", text: "Provider name")
     expect(page).to have_css(".govuk-summary-list__value", text: current_user.providers.first.name)


### PR DESCRIPTION
### Context

[Trello ticket](https://trello.com/c/i33Vzv2X/9788-changes-to-itt-census-report-guidance-page-reports-censuses)

ITT census report guidance page ahead of 26/27 window opening

### Changes proposed in this pull request

1. Change **Not all your new trainees** to **Not all of your new trainees**
2. change **read the The ITT census is put together** to **read how the ITT census is put together**
3. remove **(if you’re registering trainees manually in the Register service)** this is applicable whichever way the provider is registering the trainee
4. change button text from **Continue to census sign off** to **Continue to ITT census sign off**
5. is the 2nd Wednesday date calculated or manually entered? If not, change this to an auto calculated field
6. check the service for other references to **Census** and change to **ITT census**, apart from where the **Census date** is being discussed
7. check the service for other references to **Performance profiles** and change to **ITT performance profiles**

### Guidance to review

There ended being a lot of instances for both phrasings that needed updating!

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
