### PR TITLE
[9726] - remove old param from controller

### DIFF
--- a/app/controllers/api/trainees/withdraw_controller.rb
+++ b/app/controllers/api/trainees/withdraw_controller.rb
@@ -26,7 +26,7 @@ module Api
       end
 
       def withdrawal_params
-        params.expect(data: [:withdraw_date, :withdrawal_date, :trigger, :future_interest, :another_reason, :safeguarding_concern_reasons, { reasons: [] }])
+        params.expect(data: [:withdrawal_date, :trigger, :future_interest, :another_reason, :safeguarding_concern_reasons, { reasons: [] }])
       end
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/zYXkrUbi/9726-issue-with-withdraw-endpoint-v20261-sandox-internal-server-error

`withdraw_date `is not a param on the v2026.1 api but is being allowed through which causes the withdraw endpoint to fail

### Changes proposed in this pull request

Remove `withdraw_date` as an allowed param on the api withdraw controller.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to TRS as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
