### PR TITLE
[9790] Update ITT census sign off email

### DIFF
--- a/app/mailers/census_submitted_email_mailer.rb
+++ b/app/mailers/census_submitted_email_mailer.rb
@@ -6,6 +6,7 @@ class CensusSubmittedEmailMailer < GovukNotifyRails::Mailer
 
     set_personalisation(
       first_name: user.first_name,
+      current_year_label: AcademicCycle.current.label,
       submitted_at: submitted_at.to_fs(:govuk_date_and_time),
     )
 

--- a/spec/mailers/census_submitted_email_mailer_spec.rb
+++ b/spec/mailers/census_submitted_email_mailer_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe CensusSubmittedEmailMailer do
   context "sending an email to a user" do
+    let!(:current_academic_cycle) { create(:academic_cycle, :current) }
     let(:user) { create(:user) }
     let(:submitted_at) { Time.zone.local(2025, 1, 12, 12, 30) }
     let(:mail) { described_class.generate(user:, submitted_at:) }
@@ -24,6 +25,10 @@ describe CensusSubmittedEmailMailer do
 
     it "includes the submitted at time in the personalisation" do
       expect(mail.govuk_notify_personalisation[:submitted_at]).to eq("12 January 2025 at 12:30pm")
+    end
+
+    it "includes the current year label in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:current_year_label]).to eq(current_academic_cycle.label)
     end
   end
 end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/T3d3kZWL/)

### Changes proposed in this pull request

* Pass in the academic year text to the census sign-off email template

### Guidance to review

* Check the corresponding changes to the Notify email template (linked on the [Trello card](https://trello.com/c/T3d3kZWL/)) 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
