### PR TITLE
[xxxx] Check for email address before sending surveys

### DIFF
--- a/app/jobs/survey/send_job.rb
+++ b/app/jobs/survey/send_job.rb
@@ -7,7 +7,7 @@ module Survey
     sidekiq_options retry: 3
 
     def perform(trainee:, event_type:)
-      return unless FeatureService.enabled?(:qualtrics_survey)
+      return unless FeatureService.enabled?(:qualtrics_survey) && trainee.email.present?
 
       case event_type
       when :withdraw

--- a/spec/jobs/survey/send_job_spec.rb
+++ b/spec/jobs/survey/send_job_spec.rb
@@ -35,6 +35,34 @@ module Survey
           described_class.perform_now(trainee:, event_type:)
         end
       end
+
+      context "when trainee email is blank" do
+        let(:event_type) { :withdraw }
+
+        before do
+          trainee.update!(email: "")
+        end
+
+        it "does not call the service" do
+          expect(Withdraw).not_to receive(:call)
+
+          described_class.perform_now(trainee:, event_type:)
+        end
+      end
+
+      context "when trainee email is nil" do
+        let(:event_type) { :award }
+
+        before do
+          trainee.update!(email: nil)
+        end
+
+        it "does not call the service" do
+          expect(Award).not_to receive(:call)
+
+          described_class.perform_now(trainee:, event_type:)
+        end
+      end
     end
 
     context "when the qualtrics_survey feature is disabled", feature_qualtrics_survey: false do


### PR DESCRIPTION
### Context

We have seen some errors from our integration with Qualtrics because trainees didn't have an email address set.

https://dfe-teacher-services.sentry.io/issues/7555447132/

This should only happen with older trainee records before the validations were robust, but we should still put it a guard to prevent these unnecessary errors.

### Changes proposed in this pull request

* Add a guard clause to the job
* Add tests

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
