### PR TITLE
[9809] Update api csv for employing school in assessment only route

### DIFF
--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -100,6 +100,7 @@ module Api
              nationalisations_attributes: nationality_attributes }],
         ),
         update: true,
+        current_training_route: trainee.training_route,
       )
     end
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -596,6 +596,12 @@ class Trainee < ApplicationRecord
     current_withdrawal&.withdrawal_reasons
   end
 
+  # A GIAS school, or the name and postcode of one that isn't in GIAS.
+  def employing_school_recorded?
+    employing_school_id.present? ||
+      (employing_school_name.present? && employing_school_postcode.present?)
+  end
+
 private
 
   def value_digest

--- a/app/services/api/trainees/award_recommendation_service.rb
+++ b/app/services/api/trainees/award_recommendation_service.rb
@@ -14,7 +14,8 @@ module Api
 
       attr_reader :trainee
 
-      delegate :itt_start_date, :can_recommend_for_award?, :requires_degree?, :requires_placements?, to: :trainee, prefix: true
+      delegate :itt_start_date, :can_recommend_for_award?, :requires_degree?, :requires_placements?,
+               :requires_assessment_only_employing_school?, :employing_school_recorded?, to: :trainee, prefix: true
 
       validates :qts_standards_met_date,
                 presence: true,
@@ -47,6 +48,10 @@ module Api
 
       def trainee_placements_missing?
         placements.size < trainee.minimum_placements
+      end
+
+      def trainee_employing_school_missing?
+        !trainee_employing_school_recorded?
       end
 
     private

--- a/app/services/api/v2026_1/hesa_mapper/attributes.rb
+++ b/app/services/api/v2026_1/hesa_mapper/attributes.rb
@@ -36,9 +36,10 @@ module Api
           params[:data]&.keys&.select { |key| key.to_s.match(DISABILITY_PARAM_REGEX) } || []
         end
 
-        def initialize(params:, update: false)
+        def initialize(params:, update: false, current_training_route: nil)
           @params = params
           @update = update
+          @current_training_route = current_training_route
         end
 
         def call
@@ -47,7 +48,7 @@ module Api
 
       private
 
-        attr_reader :params, :update
+        attr_reader :params, :update, :current_training_route
 
         def mapped_params
           mapped_params = params.except(*ATTRIBUTES).merge({
@@ -294,16 +295,26 @@ module Api
               end
             {
               employing_school_id: employing_school_id,
-              employing_school_not_applicable: employing_school_id.nil?,
+              employing_school_not_applicable: employing_school_id.nil? && !assessment_only_route?,
             }
           elsif params.key?(:employing_school_urn) && NOT_APPLICABLE_SCHOOL_URNS.include?(params[:employing_school_urn])
             {
               employing_school_id: nil,
-              employing_school_not_applicable: true,
+              employing_school_not_applicable: !assessment_only_route?,
             }
+          elsif update || assessment_only_route?
+            {}
           else
-            { employing_school_not_applicable: true } unless update
+            { employing_school_not_applicable: true }
           end
+        end
+
+        # An employing school always applies on the assessment only route, so a missing or
+        # placeholder URN leaves the trainee without one rather than marking it not applicable.
+        def assessment_only_route?
+          route = training_route.is_a?(InvalidValue) ? nil : training_route
+
+          (route.presence || current_training_route) == TRAINING_ROUTE_ENUMS[:assessment_only]
         end
 
         def training_initiative_attributes

--- a/app/services/concerns/cacheable.rb
+++ b/app/services/concerns/cacheable.rb
@@ -8,11 +8,18 @@ module Cacheable
   included do
     class << self
       def get(id, key)
-        value = redis.get(cache_key_for(id, key))
+        solid_cache_value = Rails.cache.read(cache_key_for(id, key))
 
-        if value.present?
+        if solid_cache_value.present?
+          track_read(key, :solid_cache_hit)
+          return JSON.parse(solid_cache_value)
+        end
+
+        redis_value = redis.get(cache_key_for(id, key))
+
+        if redis_value.present?
           track_read(key, :redis_hit)
-          JSON.parse(value)
+          JSON.parse(redis_value)
         else
           track_read(key, :miss)
           nil

--- a/app/validators/api/trainees/award_recommendation_validator.rb
+++ b/app/validators/api/trainees/award_recommendation_validator.rb
@@ -8,6 +8,9 @@ module Api
         if record.trainee_requires_placements? && record.trainee_placements_missing?
           record.errors.add(:placements, :invalid, minimum: record.trainee.minimum_placements, training_route: record.trainee.training_route)
         end
+        if record.trainee_requires_assessment_only_employing_school? && record.trainee_employing_school_missing?
+          record.errors.add(:employing_school_urn, :blank)
+        end
         record.errors.add(:state) unless record.trainee_can_recommend_for_award?
       end
     end

--- a/app/views/bulk_update/add_trainees/reference_docs/v2026_1/fields.yaml
+++ b/app/views/bulk_update/add_trainees/reference_docs/v2026_1/fields.yaml
@@ -346,9 +346,12 @@
 - field_name: employing_school_urn
   technical: employing_school_urn
   hesa_alignment: SDEMPLOY
-  description:
-    This field collects the employing school for School Direct salaried
-    trainees.
+  description: |-
+    This field collects the employing school for School Direct salaried and Assessment only trainees.
+
+    Assessment only trainees need an employing school before you can change their QTS status, but you can add it later.
+
+    On the Assessment only training route, the placeholder values below do not record an employing school.
   format: Must be a 6-digit number
   example: |-
     - `115795` - Cheltenham College

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :solid_cache_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :none

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2274,6 +2274,8 @@ en:
           attributes:
             degree_id:
               invalid: must be completed before qts_standards_met_date
+            employing_school_urn:
+              blank: must be completed before qts_standards_met_date
             placements:
               invalid: "must be at least %{minimum} for the %{training_route} training route"
             state:

--- a/spec/requests/api/v2026_1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v2026_1/post_hesa_trainees_spec.rb
@@ -2156,6 +2156,57 @@ describe "`POST /api/v2026.1/trainees` endpoint" do
       expect(response).to have_http_status(:created)
       expect(Trainee.last.study_mode).to be_nil
     end
+
+    it "does not require an employing school" do
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+    end
+
+    it "does not mark the employing school as not applicable" do
+      expect(Trainee.last.employing_school_not_applicable).to be(false)
+    end
+
+    context "when employing_school_urn is a school in GIAS" do
+      let(:employing_school) { create(:school) }
+      let(:data) { super().merge(employing_school_urn: employing_school.urn) }
+
+      it "sets employing_school_urn to employing_school#urn" do
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body[:data][:employing_school_urn]).to eq(employing_school.urn)
+      end
+
+      it "stores the employing school against the trainee" do
+        expect(Trainee.last.employing_school).to eq(employing_school)
+        expect(Trainee.last.employing_school_not_applicable).to be(false)
+      end
+    end
+
+    context "when employing_school_urn is not applicable" do
+      let(:data) { super().merge(employing_school_urn: "900020") }
+
+      it "creates the trainee without an employing school" do
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+      end
+
+      it "does not mark the employing school as not applicable" do
+        trainee = Trainee.last
+
+        expect(trainee.employing_school_id).to be_nil
+        expect(trainee.employing_school_not_applicable).to be(false)
+      end
+    end
+
+    context "when employing_school_urn does not match a school in GIAS" do
+      let(:data) { super().merge(employing_school_urn: "123456") }
+
+      it "returns unprocessible entity HTTP code and a validation error message" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to include(
+          "employing_school_id is invalid. The URN '123456' does not match any known schools",
+        )
+      end
+    end
   end
 
   context "when creating a trainee with early_years_assessment_only route" do

--- a/spec/requests/api/v2026_1/trainees/post_recommend_for_qts_spec.rb
+++ b/spec/requests/api/v2026_1/trainees/post_recommend_for_qts_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "POST /api/v2026.1/trainees/:trainee_id/recommend-for-qts" do
     create(
       :trainee,
       :trn_received,
+      :with_employing_school,
     )
   end
 
@@ -212,6 +213,7 @@ RSpec.describe "POST /api/v2026.1/trainees/:trainee_id/recommend-for-qts" do
           :trainee,
           :without_degrees,
           :trn_received,
+          :with_employing_school,
         )
       end
 
@@ -227,6 +229,32 @@ RSpec.describe "POST /api/v2026.1/trainees/:trainee_id/recommend-for-qts" do
         expect(response.parsed_body[:errors]).to contain_exactly(
           "error" => "UnprocessableEntity",
           "message" => "degree_id must be completed before qts_standards_met_date",
+        )
+      end
+    end
+
+    context "when the trainee is on the assessment_only route without an employing school" do
+      let(:trainee) do
+        create(
+          :trainee,
+          :trn_received,
+          training_route: :assessment_only,
+        )
+      end
+
+      it "does not change status of the trainee for a qts award" do
+        post "/api/v2026.1/trainees/#{trainee.slug}/recommend-for-qts",
+             headers: { authorization: "Bearer #{token}" },
+             params: { data: { qts_standards_met_date: Time.zone.today } }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        trainee.reload
+        expect(trainee.recommended_for_award?).to be(false)
+
+        expect(response.parsed_body[:errors]).to contain_exactly(
+          "error" => "UnprocessableEntity",
+          "message" => "employing_school_urn must be completed before qts_standards_met_date",
         )
       end
     end

--- a/spec/requests/api/v2026_1/trainees/post_update_qts_or_eyts_status_spec.rb
+++ b/spec/requests/api/v2026_1/trainees/post_update_qts_or_eyts_status_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "POST /api/v2026.1/trainees/:trainee_id/update-qts-or-eyts-status
     create(
       :trainee,
       :trn_received,
+      :with_employing_school,
     )
   end
 
@@ -25,5 +26,23 @@ RSpec.describe "POST /api/v2026.1/trainees/:trainee_id/update-qts-or-eyts-status
 
     expect(response).to have_http_status(:accepted)
     expect(response.parsed_body[:data][:recommended_for_award_at]).to eq(current_time.iso8601)
+  end
+
+  context "when the trainee is on the assessment_only route without an employing school" do
+    let(:trainee) { create(:trainee, :trn_received, training_route: :assessment_only) }
+
+    it "does not change the qts status" do
+      post "/api/v2026.1/trainees/#{trainee.slug}/update-qts-or-eyts-status",
+           headers: { authorization: "Bearer #{token}" },
+           params: { data: { qts_standards_met_date: Time.zone.today } }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(trainee.reload.recommended_for_award?).to be(false)
+
+      expect(response.parsed_body[:errors]).to contain_exactly(
+        "error" => "UnprocessableEntity",
+        "message" => "employing_school_urn must be completed before qts_standards_met_date",
+      )
+    end
   end
 end

--- a/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v2026_1/trainee_serializer_spec.rb
@@ -293,6 +293,35 @@ RSpec.describe Api::V20261::TraineeSerializer do
       it "serializes training_route as '16'" do
         expect(json[:training_route]).to eq("16")
       end
+
+      it "serializes employing_school_urn as nil without an employing school" do
+        expect(json[:employing_school_urn]).to be_nil
+      end
+
+      context "with an employing school in GIAS" do
+        let(:employing_school) { create(:school) }
+
+        before { trainee.update!(employing_school:) }
+
+        it "serializes the employing school urn" do
+          expect(json[:employing_school_urn]).to eq(employing_school.urn)
+        end
+      end
+
+      context "with an employing school that is not in GIAS" do
+        before do
+          trainee.update!(
+            employing_school_name: "Oak House School",
+            employing_school_urn: "123456",
+            employing_school_postcode: "SW1A 1AA",
+          )
+        end
+
+        it "does not serialize the employing school" do
+          expect(json[:employing_school_urn]).to be_nil
+          expect(json).not_to include(:employing_school_name, :employing_school_postcode)
+        end
+      end
     end
 
     context "when trainee is on early_years_assessment_only route" do

--- a/spec/services/api/trainees/award_recommendation_service_spec.rb
+++ b/spec/services/api/trainees/award_recommendation_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
 
   describe "::call" do
     describe "success" do
-      let(:trainee) { create(:trainee, :trn_received) }
+      let(:trainee) { create(:trainee, :trn_received, :with_employing_school) }
       let(:params) do
         {
           qts_standards_met_date: Time.zone.today.iso8601,
@@ -42,7 +42,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
 
     describe "failure" do
       context "when qts_standards_met_date is nil" do
-        let(:trainee) { create(:trainee, :trn_received) }
+        let(:trainee) { create(:trainee, :trn_received, :with_employing_school) }
         let(:params) do
           {
             qts_standards_met_date: nil,
@@ -59,7 +59,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
       end
 
       context "when qts_standards_met_date is empty" do
-        let(:trainee) { create(:trainee, :trn_received) }
+        let(:trainee) { create(:trainee, :trn_received, :with_employing_school) }
         let(:params) do
           {
             qts_standards_met_date: "",
@@ -76,7 +76,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
       end
 
       context "when qts_standards_met_date is invalid" do
-        let(:trainee) { create(:trainee, :trn_received) }
+        let(:trainee) { create(:trainee, :trn_received, :with_employing_school) }
         let(:params) do
           {
             qts_standards_met_date: "abc",
@@ -93,7 +93,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
       end
 
       context "when qts_standards_met_date is in the future" do
-        let(:trainee) { create(:trainee, :trn_received) }
+        let(:trainee) { create(:trainee, :trn_received, :with_employing_school) }
         let(:params) do
           {
             qts_standards_met_date: Time.zone.tomorrow.iso8601,
@@ -110,7 +110,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
       end
 
       context "when qts_standards_met_date is before trainee's itt_start_date" do
-        let(:trainee) { create(:trainee, :trn_received, :itt_start_date_in_the_future) }
+        let(:trainee) { create(:trainee, :trn_received, :with_employing_school, :itt_start_date_in_the_future) }
         let(:params) do
           {
             qts_standards_met_date: Time.zone.today.iso8601,
@@ -127,7 +127,7 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
       end
 
       context "when trainee's state is not trn_received" do
-        let(:trainee) { create(:trainee, :submitted_for_trn) }
+        let(:trainee) { create(:trainee, :submitted_for_trn, :with_employing_school) }
         let(:params) do
           {
             qts_standards_met_date: Time.zone.today.iso8601,
@@ -260,7 +260,88 @@ RSpec.describe Api::Trainees::AwardRecommendationService do
       end
 
       context "when trainee on assessment_only route has no placements" do
-        let(:trainee) { create(:trainee, :without_placements, :trn_received, training_route: :assessment_only) }
+        let(:trainee) { create(:trainee, :without_placements, :trn_received, :with_employing_school, training_route: :assessment_only) }
+        let(:params) do
+          {
+            qts_standards_met_date: Time.zone.today.iso8601,
+          }
+        end
+
+        it "returns true" do
+          success, _errors = subject.call(params, trainee)
+
+          expect(success).to be(true)
+          expect(trainee.recommended_for_award?).to be(true)
+        end
+      end
+
+      context "when trainee on assessment_only route has no employing school" do
+        let(:trainee) { create(:trainee, :trn_received, training_route: :assessment_only) }
+        let(:params) do
+          {
+            qts_standards_met_date: Time.zone.today.iso8601,
+          }
+        end
+
+        it "returns false" do
+          success, errors = subject.call(params, trainee)
+
+          expect(success).to be(false)
+          expect(errors.full_messages).to contain_exactly("employing_school_urn must be completed before qts_standards_met_date")
+          expect(trainee.recommended_for_award?).to be(false)
+        end
+      end
+
+      context "when trainee on assessment_only route has an employing school that is not applicable" do
+        let(:trainee) do
+          create(
+            :trainee,
+            :trn_received,
+            training_route: :assessment_only,
+            employing_school_not_applicable: true,
+          )
+        end
+        let(:params) do
+          {
+            qts_standards_met_date: Time.zone.today.iso8601,
+          }
+        end
+
+        it "returns false" do
+          success, errors = subject.call(params, trainee)
+
+          expect(success).to be(false)
+          expect(errors.full_messages).to contain_exactly("employing_school_urn must be completed before qts_standards_met_date")
+          expect(trainee.recommended_for_award?).to be(false)
+        end
+      end
+
+      context "when trainee on assessment_only route has an employing school that is not in GIAS" do
+        let(:trainee) do
+          create(
+            :trainee,
+            :trn_received,
+            training_route: :assessment_only,
+            employing_school_name: "Oak House School",
+            employing_school_postcode: "SW1A 1AA",
+          )
+        end
+        let(:params) do
+          {
+            qts_standards_met_date: Time.zone.today.iso8601,
+          }
+        end
+
+        it "returns true" do
+          success, _errors = subject.call(params, trainee)
+
+          expect(success).to be(true)
+          expect(trainee.recommended_for_award?).to be(true)
+        end
+      end
+
+      context "when trainee on early_years_assessment_only route has no employing school" do
+        let(:trainee) { create(:trainee, :trn_received, :early_years_assessment_only) }
         let(:params) do
           {
             qts_standards_met_date: Time.zone.today.iso8601,

--- a/spec/services/concerns/cacheable_spec.rb
+++ b/spec/services/concerns/cacheable_spec.rb
@@ -38,12 +38,12 @@ describe Cacheable do
         solid_cache.write(dummy_class.cache_key_for(id, key), solid_cache_values.to_json)
       end
 
-      it "returns the Redis value" do
-        expect(dummy_class.get(id, key)).to eq(redis_values)
+      it "returns the Solid Cache value" do
+        expect(dummy_class.get(id, key)).to eq(solid_cache_values)
       end
 
-      it "counts a redis hit" do
-        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :redis_hit })
+      it "counts a solid cache hit" do
+        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :solid_cache_hit })
 
         dummy_class.get(id, key)
       end
@@ -54,12 +54,28 @@ describe Cacheable do
         solid_cache.write(dummy_class.cache_key_for(id, key), values.to_json)
       end
 
-      it "does not read it, so that a rolling deploy cannot serve stale data" do
-        expect(dummy_class.get(id, key)).to be_nil
+      it "returns the stored value" do
+        expect(dummy_class.get(id, key)).to eq(values)
       end
 
-      it "counts a miss" do
-        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :miss })
+      it "does not read Redis" do
+        expect(dummy_class).not_to receive(:redis)
+
+        dummy_class.get(id, key)
+      end
+    end
+
+    context "when the entry exists in Redis only" do
+      before do
+        dummy_class.redis.set(dummy_class.cache_key_for(id, key), values.to_json)
+      end
+
+      it "falls back to Redis" do
+        expect(dummy_class.get(id, key)).to eq(values)
+      end
+
+      it "counts a redis hit" do
+        expect(Yabeda.form_store.reads_total).to receive(:increment).with({ key: key, outcome: :redis_hit })
 
         dummy_class.get(id, key)
       end

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-recommend-for-qts.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-recommend-for-qts.html.md.erb
@@ -16,7 +16,7 @@ weight: 13
 
 Change status of a trainee for a QTS Award.
 
-Trainees on the Assessment only training route need an employing school before you can change their status. Set it with `employing_school_urn` on `POST /trainees` or `PUT /trainees/{trainee_id}`. Employing schools that are not in Get information about schools (GIAS) can only be added in Register.
+Trainees on the Assessment only training route need an employing school before you can change their status. Set it with `employing_school_urn` on `POST /trainees` or `PUT /trainees/{trainee_id}`. Employing schools that are not in Get information about schools (GIAS) can only be added via the Register web service (not via the API).
 
 ## Request
 

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-recommend-for-qts.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-recommend-for-qts.html.md.erb
@@ -16,6 +16,8 @@ weight: 13
 
 Change status of a trainee for a QTS Award.
 
+Trainees on the Assessment only training route need an employing school before you can change their status. Set it with `employing_school_urn` on `POST /trainees` or `PUT /trainees/{trainee_id}`. Employing schools that are not in Get information about schools (GIAS) can only be added in Register.
+
 ## Request
 
     POST /api/v2026.1/trainees/{trainee_id}/recommend-for-qts
@@ -219,6 +221,10 @@ Recommendation details
         {
           "error": "UnprocessableEntity",
           "message": "placements must be at least 2 for the provider_led_postgrad training route"
+        },
+        {
+          "error": "UnprocessableEntity",
+          "message": "employing_school_urn must be completed before qts_standards_met_date"
         }
       ]
     }</pre>

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-update-qts-or-eyts-status.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-update-qts-or-eyts-status.html.md.erb
@@ -11,6 +11,8 @@ Update the QTS or EYTS status of a trainee.
 
 This endpoint replaces `POST /trainees/{trainee_id}/recommend-for-qts`, which is still available but deprecated.
 
+Trainees on the Assessment only training route need an employing school before you can update their status. Set it with `employing_school_urn` on `POST /trainees` or `PUT /trainees/{trainee_id}`. Employing schools that are not in Get information about schools (GIAS) can only be added in Register.
+
 ## Request
 
     POST /api/v2026.1/trainees/{trainee_id}/update-qts-or-eyts-status
@@ -199,6 +201,10 @@ Recommendation details
         {
           "error": "UnprocessableEntity",
           "message": "placements must be at least 2 for the provider_led_postgrad training route"
+        },
+        {
+          "error": "UnprocessableEntity",
+          "message": "employing_school_urn must be completed before qts_standards_met_date"
         }
       ]
     }</pre>

--- a/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-update-qts-or-eyts-status.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/endpoints/post-trainees-trainee-id-update-qts-or-eyts-status.html.md.erb
@@ -11,7 +11,7 @@ Update the QTS or EYTS status of a trainee.
 
 This endpoint replaces `POST /trainees/{trainee_id}/recommend-for-qts`, which is still available but deprecated.
 
-Trainees on the Assessment only training route need an employing school before you can update their status. Set it with `employing_school_urn` on `POST /trainees` or `PUT /trainees/{trainee_id}`. Employing schools that are not in Get information about schools (GIAS) can only be added in Register.
+Trainees on the Assessment only training route need an employing school before you can update their status. Set it with `employing_school_urn` on `POST /trainees` or `PUT /trainees/{trainee_id}`. Employing schools that are not in Get information about schools (GIAS) can only be added via the Register web service (not via the API).
 
 ## Request
 

--- a/tech_docs/source/api-docs/v2026.1/objects/trainee.html.md.erb
+++ b/tech_docs/source/api-docs/v2026.1/objects/trainee.html.md.erb
@@ -483,7 +483,10 @@ weight: 1
         string (limited to 6 characters)
       </p>
       <p class="govuk-body">
-        The Unique Reference Number (URN) of the employing school for School Direct salaried trainees.
+        The Unique Reference Number (URN) of the employing school for School Direct salaried and Assessment only trainees.
+      </p>
+      <p class="govuk-body">
+        Assessment only trainees need an employing school before you can change their QTS status, but you can add it later.
       </p>
       <p class="govuk-body">
         Example:
@@ -494,6 +497,12 @@ weight: 1
         <li><code>900020</code> - Other establishment without a URN</li>
         <li><code>900030</code> - Not available</li>
       </ul>
+      <p class="govuk-body">
+        Notes: On the Assessment only training route, the placeholder values above do not record an
+        employing school. A trainee sent one of them still needs a real employing school before you
+        can update their QTS or EYTS status, and an employing school that has already been recorded
+        cannot be removed through the API.
+      </p>
     </dd>
   </div>
   <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/uHHi83SI/9809-update-api-csv-for-employing-school-in-assessment-only-route)

Following on from [9771-add-employing-school-to-assessment-only-route](https://trello.com/c/1wt8XCYe/9771-add-employing-school-to-assessment-only-route)

We want to make sure the API and CSV are consistent with the new UI user journey.

### Changes proposed in this pull request

- AO (hesa "16") API create and csv: employing school still optional. special urns (900000 etc) + blank no longer set `employing_school_not_applicable`
- `PUT` now passes the trainee's current route into the mapper, meaning a special `urn` on an AO trainee can't silently clear a user journey added non-gias school
- award (`/update-qts-or-eyts-status`+ deprecated `/recommend-for-qts`): AO now needs an employing school. new `Trainee#employing_school_recorded?` urn OR name+postcode, (mirrors user journey form logic)
- error: "employing_school_urn must be completed before qts_standards_met_date"
- specs: trainee factory defaults to `assessment_only`, so existing award specs needed `:with_employing_school`

docs:
- api trainee object: `employing_school_urn` now says salaried *and* AO, + a note that placeholder urns don't record a school and can't be removed via api
- both award endpoint pages: line saying AO needs a school first (non-gias is register-only), plus the new `422` in the example
- csv `fields.yaml`: same description update

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to TRS as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
